### PR TITLE
Add Homebrew tap support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,3 +24,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,17 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+brews:
+  - repository:
+      owner: git-treeline
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: https://github.com/git-treeline/git-treeline
+    description: "Worktree environment manager — isolated ports, databases, and services across parallel development environments"
+    license: Apache-2.0
+    install: |
+      bin.install "git-treeline"
+
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
## Summary

- Configure GoReleaser to push a Homebrew formula to `git-treeline/homebrew-tap` on tagged releases
- Update release workflow to pass `HOMEBREW_TAP_TOKEN` to GoReleaser

After merge, the next `git tag v0.x.0 && git push --tags` will publish to Homebrew automatically. Users install with:

```
brew install git-treeline/tap/git-treeline
```

## Test plan

- [ ] Merge, tag a release, verify formula appears in `git-treeline/homebrew-tap`
- [ ] `brew install git-treeline/tap/git-treeline && git-treeline version`