### PR TITLE
Add community health files and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,21 @@
+---
+name: Bug report
+about: Report something that isn't working correctly
+labels: bug
+---
+
+**Describe the bug**
+A clear description of what's wrong.
+
+**To reproduce**
+Steps to reproduce the behavior:
+1. ...
+2. ...
+
+**Expected behavior**
+What you expected to happen.
+
+**Environment**
+- OS:
+- `git-treeline version` output:
+- Shell:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,14 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+labels: enhancement
+---
+
+**Problem**
+What's the use case or pain point?
+
+**Proposed solution**
+How you'd like it to work.
+
+**Alternatives considered**
+Other approaches you've thought about.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+## What
+
+Brief description of the change.
+
+## Why
+
+What problem does this solve or what feature does it add?
+
+## Test plan
+
+- [ ] How was this tested?
+
+## Checklist
+
+- [ ] Tests pass (`make ci` / `bundle exec rspec`)
+- [ ] No breaking changes (or documented in description)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,75 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at oss@productmatter.co. All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html](https://www.contributor-covenant.org/version/2/1/code_of_conduct.html).
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing to Git Treeline
+
+Thanks for considering a contribution. Here's what you need to know.
+
+## Setup
+
+```bash
+git clone https://github.com/git-treeline/git-treeline.git
+cd git-treeline
+make ci
+```
+
+Requires Go 1.24+ and optionally `golangci-lint` and `govulncheck` (auto-installed by `make ci` if missing).
+
+## Making changes
+
+1. Fork the repo and create a branch from `main`.
+2. Write tests for new behavior.
+3. Run `make ci` and ensure all checks pass.
+4. Open a pull request with a clear description of the change and why it's needed.
+
+## Pull request expectations
+
+- One logical change per PR.
+- Include a test plan in the PR description.
+- Keep commits focused — squash fixups before requesting review.
+
+## Reporting bugs
+
+Open an issue with steps to reproduce, expected behavior, and actual behavior. Include your OS and `git-treeline version` output.
+
+## Security vulnerabilities
+
+Please report security issues privately — see [SECURITY.md](SECURITY.md).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately. **Do not open a public issue.**
+
+Email: oss@productmatter.co
+
+Include:
+
+- Description of the vulnerability
+- Steps to reproduce
+- Impact assessment (if known)
+
+We will acknowledge receipt within 48 hours and aim to provide a fix or mitigation plan within 7 days.
+
+## Supported Versions
+
+Only the latest release is supported with security updates.


### PR DESCRIPTION
## Summary

- CONTRIBUTING.md with setup instructions and PR guidelines
- CODE_OF_CONDUCT.md (Contributor Covenant v2.1, contact: oss@productmatter.co)
- SECURITY.md for private vulnerability reporting
- Issue templates (bug report, feature request)
- Pull request template with checklist

## Test plan

- [ ] Verify templates render correctly when creating issues/PRs on GitHub