### PR TITLE
Fix errcheck violations for golangci-lint-action v9

### DIFF
--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -178,7 +178,7 @@ func IsPortFree(port int) bool {
 	if err != nil {
 		return false
 	}
-	ln.Close()
+	_ = ln.Close()
 	return true
 }
 
@@ -188,7 +188,7 @@ func CheckPortsListening(ports []int) bool {
 	for _, port := range ports {
 		conn, err := net.DialTimeout("tcp", fmt.Sprintf("localhost:%d", port), 200*1e6)
 		if err == nil {
-			conn.Close()
+			_ = conn.Close()
 			return true
 		}
 	}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -181,7 +181,7 @@ func (r *Registry) withLock(fn func(data *RegistryData)) error {
 	if err != nil {
 		return fmt.Errorf("opening lock file: %w", err)
 	}
-	defer lockFile.Close()
+	defer func() { _ = lockFile.Close() }()
 
 	deadline := time.Now().Add(lockTimeout)
 	for {

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -358,10 +358,10 @@ func (s *Setup) configureEditor(alloc *allocator.Allocation) {
 
 func (s *Setup) log(format string, args ...any) {
 	if format == "" {
-		fmt.Fprintln(s.Log)
+		_, _ = fmt.Fprintln(s.Log)
 		return
 	}
-	fmt.Fprintf(s.Log, "==> "+format+"\n", args...)
+	_, _ = fmt.Fprintf(s.Log, "==> "+format+"\n", args...)
 }
 
 func joinInts(ints []int, sep string) string {


### PR DESCRIPTION
## What

Fix 5 unchecked error returns that the newer golangci-lint (via action v9) catches.

## Why

Dependabot PR #5 bumps golangci-lint-action from v6 to v9. The newer linter is stricter. This PR fixes the violations so #5 can merge cleanly after.

## Test plan

- [ ] `make ci` passes
- [ ] Merge this, then merge Dependabot PR #5