### PR TITLE
Fix root repo allocation using worktree-suffixed resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+## [0.5.1] - 2026-03-31
+
+- Fix: root repo setup now uses base port and template database directly instead of treating it as a worktree
+
 ## [0.5.0] - 2026-03-31
 
 - Add `new` command: create worktree + allocate resources + run setup in one step

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -81,10 +81,14 @@ func New(uc *config.UserConfig, pc *config.ProjectConfig, reg *registry.Registry
 
 // Allocate returns an allocation for the given worktree. If an existing
 // allocation is found in the registry, it is reused (idempotent). Otherwise
-// a new allocation is created.
-func (al *Allocator) Allocate(worktreePath, worktreeName string) (*Allocation, error) {
+// a new allocation is created. When mainWorktree is true, base resources
+// (port_base, template DB, no redis prefix) are returned directly.
+func (al *Allocator) Allocate(worktreePath, worktreeName string, mainWorktree bool) (*Allocation, error) {
 	if existing := al.reuseExisting(worktreePath, worktreeName); existing != nil {
 		return existing, nil
+	}
+	if mainWorktree {
+		return al.allocateMain(worktreePath, worktreeName)
 	}
 	return al.allocateNew(worktreePath, worktreeName)
 }
@@ -118,6 +122,24 @@ func (al *Allocator) reuseExisting(worktreePath, worktreeName string) *Allocatio
 	}
 
 	return alloc
+}
+
+func (al *Allocator) allocateMain(worktreePath, worktreeName string) (*Allocation, error) {
+	port := al.UserConfig.PortBase()
+	count := al.ProjectConfig.PortsNeeded()
+	ports := make([]int, count)
+	for i := range count {
+		ports[i] = port + i
+	}
+
+	return &Allocation{
+		Project:      al.ProjectConfig.Project(),
+		Worktree:     worktreePath,
+		WorktreeName: worktreeName,
+		Port:         port,
+		Ports:        ports,
+		Database:     al.ProjectConfig.DatabaseTemplate(),
+	}, nil
 }
 
 func (al *Allocator) allocateNew(worktreePath, worktreeName string) (*Allocation, error) {

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -41,7 +41,7 @@ func itoa(n int) string {
 
 func TestAllocate_SinglePort(t *testing.T) {
 	al, _ := testAllocator(t, 1, "")
-	alloc, err := al.Allocate("/wt/branch-a", "branch-a")
+	alloc, err := al.Allocate("/wt/branch-a", "branch-a", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -58,7 +58,7 @@ func TestAllocate_SinglePort(t *testing.T) {
 
 func TestAllocate_MultiPort(t *testing.T) {
 	al, _ := testAllocator(t, 2, "")
-	alloc, err := al.Allocate("/wt/branch-a", "branch-a")
+	alloc, err := al.Allocate("/wt/branch-a", "branch-a", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,13 +73,13 @@ func TestAllocate_MultiPort(t *testing.T) {
 func TestAllocate_Idempotent(t *testing.T) {
 	al, reg := testAllocator(t, 1, "")
 
-	first, err := al.Allocate("/wt/branch-a", "branch-a")
+	first, err := al.Allocate("/wt/branch-a", "branch-a", false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	_ = reg.Allocate(first.ToRegistryEntry())
 
-	second, err := al.Allocate("/wt/branch-a", "branch-a")
+	second, err := al.Allocate("/wt/branch-a", "branch-a", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -94,10 +94,10 @@ func TestAllocate_Idempotent(t *testing.T) {
 func TestAllocate_IdempotentPreservesAllFields(t *testing.T) {
 	al, reg := testAllocator(t, 2, "")
 
-	first, _ := al.Allocate("/wt/branch-a", "branch-a")
+	first, _ := al.Allocate("/wt/branch-a", "branch-a", false)
 	_ = reg.Allocate(first.ToRegistryEntry())
 
-	second, _ := al.Allocate("/wt/branch-a", "branch-a")
+	second, _ := al.Allocate("/wt/branch-a", "branch-a", false)
 	if second.Database != first.Database {
 		t.Errorf("expected database %s, got %s", first.Database, second.Database)
 	}
@@ -117,7 +117,7 @@ func TestAllocate_SkipsUsedPorts(t *testing.T) {
 		"ports":    []any{float64(3010)},
 	})
 
-	alloc, err := al.Allocate("/wt/new", "new")
+	alloc, err := al.Allocate("/wt/new", "new", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,7 +134,7 @@ func TestAllocate_MultiPort_NonOverlapping(t *testing.T) {
 		"ports":    []any{float64(3010), float64(3011)},
 	})
 
-	alloc, err := al.Allocate("/wt/new", "new")
+	alloc, err := al.Allocate("/wt/new", "new", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestAllocate_PortsNeededExceedsIncrement(t *testing.T) {
 	pc := config.LoadProjectConfig(projDir)
 
 	al := New(uc, pc, reg)
-	_, err := al.Allocate("/wt/x", "x")
+	_, err := al.Allocate("/wt/x", "x", false)
 	if err == nil {
 		t.Fatal("expected error when ports_needed > increment")
 	}
@@ -168,7 +168,7 @@ func TestAllocate_PortsNeededExceedsIncrement(t *testing.T) {
 
 func TestAllocate_DatabaseName(t *testing.T) {
 	al, _ := testAllocator(t, 1, "")
-	alloc, err := al.Allocate("/wt/feature-branch", "feature-branch")
+	alloc, err := al.Allocate("/wt/feature-branch", "feature-branch", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -179,7 +179,7 @@ func TestAllocate_DatabaseName(t *testing.T) {
 
 func TestAllocate_RedisPrefix(t *testing.T) {
 	al, _ := testAllocator(t, 1, "")
-	alloc, err := al.Allocate("/wt/my-branch", "my-branch")
+	alloc, err := al.Allocate("/wt/my-branch", "my-branch", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -203,7 +203,7 @@ func TestAllocate_RedisDatabaseStrategy(t *testing.T) {
 	pc := config.LoadProjectConfig(projDir)
 
 	al := New(uc, pc, reg)
-	alloc, err := al.Allocate("/wt/a", "a")
+	alloc, err := al.Allocate("/wt/a", "a", false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -237,6 +237,32 @@ func TestToRegistryEntry_Format(t *testing.T) {
 		}
 	} else {
 		t.Error("expected ports array")
+	}
+}
+
+func TestAllocate_MainWorktree(t *testing.T) {
+	al, _ := testAllocator(t, 2, "")
+	alloc, err := al.Allocate("/repo/main", "main", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if alloc.Port != 3000 {
+		t.Errorf("expected base port 3000 for main, got %d", alloc.Port)
+	}
+	if len(alloc.Ports) != 2 {
+		t.Errorf("expected 2 ports, got %d", len(alloc.Ports))
+	}
+	if alloc.Ports[0] != 3000 || alloc.Ports[1] != 3001 {
+		t.Errorf("expected ports [3000,3001], got %v", alloc.Ports)
+	}
+	if alloc.Database != "test_dev" {
+		t.Errorf("expected template database 'test_dev', got %s", alloc.Database)
+	}
+	if alloc.RedisDB != 0 {
+		t.Errorf("expected redis db 0 for main, got %d", alloc.RedisDB)
+	}
+	if alloc.RedisPrefix != "" {
+		t.Errorf("expected empty redis prefix for main, got %s", alloc.RedisPrefix)
 	}
 }
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -63,7 +63,8 @@ func New(worktreePath string, mainRepo string, uc *config.UserConfig) *Setup {
 
 func (s *Setup) Run() (*allocator.Allocation, error) {
 	worktreeName := filepath.Base(s.WorktreePath)
-	alloc, err := s.Allocator.Allocate(s.WorktreePath, worktreeName)
+	isMain := s.WorktreePath == s.MainRepo
+	alloc, err := s.Allocator.Allocate(s.WorktreePath, worktreeName, isMain)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- When running `git-treeline setup` on the root repository (not a worktree), the allocator now returns base port and template database directly
- Previously, the root repo got treated like any worktree: offset ports (3010+) and suffixed database names (`salt_development_salt` instead of `salt_development`)
- Adds `mainWorktree` flag to `Allocator.Allocate()` — `setup.Run()` passes `true` when `WorktreePath == MainRepo`

## Test plan

- [x] `make ci` passes
- [x] New `TestAllocate_MainWorktree` test verifies base port, template DB, and no redis prefix
- [ ] Manual: `git-treeline setup .` in root repo should show base port (3000) and template database