### PR TITLE
Fix main worktree allocation to scan for free ports

### DIFF
--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -125,18 +125,19 @@ func (al *Allocator) reuseExisting(worktreePath, worktreeName string) *Allocatio
 }
 
 func (al *Allocator) allocateMain(worktreePath, worktreeName string) (*Allocation, error) {
-	port := al.UserConfig.PortBase()
 	count := al.ProjectConfig.PortsNeeded()
-	ports := make([]int, count)
-	for i := range count {
-		ports[i] = port + i
+	if count > al.UserConfig.PortIncrement() {
+		return nil, fmt.Errorf("ports_needed (%d) exceeds port.increment (%d); increase port.increment in your config.json to at least %d",
+			count, al.UserConfig.PortIncrement(), count)
 	}
+
+	ports := al.nextAvailablePortsFrom(al.UserConfig.PortBase(), count)
 
 	return &Allocation{
 		Project:      al.ProjectConfig.Project(),
 		Worktree:     worktreePath,
 		WorktreeName: worktreeName,
-		Port:         port,
+		Port:         ports[0],
 		Ports:        ports,
 		Database:     al.ProjectConfig.DatabaseTemplate(),
 	}, nil
@@ -149,7 +150,7 @@ func (al *Allocator) allocateNew(worktreePath, worktreeName string) (*Allocation
 			count, al.UserConfig.PortIncrement(), count)
 	}
 
-	ports := al.nextAvailablePorts(count)
+	ports := al.nextAvailablePortsFrom(al.UserConfig.PortBase()+al.UserConfig.PortIncrement(), count)
 	redisDB, redisPrefix := al.allocateRedis(worktreeName)
 	database := al.buildDatabaseName(worktreeName)
 
@@ -170,13 +171,13 @@ func (al *Allocator) BuildRedisURL(alloc *Allocation) string {
 	return interpolation.BuildRedisURL(al.UserConfig.RedisURL(), m)
 }
 
-func (al *Allocator) nextAvailablePorts(count int) []int {
+func (al *Allocator) nextAvailablePortsFrom(start, count int) []int {
 	usedSet := make(map[int]bool)
 	for _, p := range al.Registry.UsedPorts() {
 		usedSet[p] = true
 	}
 
-	candidate := al.UserConfig.PortBase() + al.UserConfig.PortIncrement()
+	candidate := start
 	for {
 		block := make([]int, count)
 		conflict := false

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -246,14 +246,14 @@ func TestAllocate_MainWorktree(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if alloc.Port != 3000 {
-		t.Errorf("expected base port 3000 for main, got %d", alloc.Port)
-	}
 	if len(alloc.Ports) != 2 {
 		t.Errorf("expected 2 ports, got %d", len(alloc.Ports))
 	}
-	if alloc.Ports[0] != 3000 || alloc.Ports[1] != 3001 {
-		t.Errorf("expected ports [3000,3001], got %v", alloc.Ports)
+	if alloc.Ports[1] != alloc.Ports[0]+1 {
+		t.Errorf("expected contiguous ports, got %v", alloc.Ports)
+	}
+	if alloc.Port != alloc.Ports[0] {
+		t.Errorf("expected Port to match Ports[0], got %d vs %d", alloc.Port, alloc.Ports[0])
 	}
 	if alloc.Database != "test_dev" {
 		t.Errorf("expected template database 'test_dev', got %s", alloc.Database)
@@ -263,6 +263,30 @@ func TestAllocate_MainWorktree(t *testing.T) {
 	}
 	if alloc.RedisPrefix != "" {
 		t.Errorf("expected empty redis prefix for main, got %s", alloc.RedisPrefix)
+	}
+}
+
+func TestAllocate_MainWorktreeSkipsOccupiedPorts(t *testing.T) {
+	al, reg := testAllocator(t, 2, "")
+	// Simulate another allocation holding the base ports
+	other := &Allocation{
+		Project: "other", Worktree: "/wt/other", WorktreeName: "other",
+		Port: 3000, Ports: []int{3000, 3001},
+	}
+	_ = reg.Allocate(other.ToRegistryEntry())
+
+	alloc, err := al.Allocate("/repo/main", "main", true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if alloc.Port == 3000 || alloc.Port == 3001 {
+		t.Errorf("expected main to skip occupied base ports, got %d", alloc.Port)
+	}
+	if alloc.Ports[1] != alloc.Ports[0]+1 {
+		t.Errorf("expected contiguous ports, got %v", alloc.Ports)
+	}
+	if alloc.Database != "test_dev" {
+		t.Errorf("main should still get template database, got %s", alloc.Database)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `allocateMain` now scans for free contiguous port blocks instead of blindly assigning base ports
- Tries base range first (e.g. 3000/3001), skips to next increment if any port is occupied
- Refactors `nextAvailablePorts` → `nextAvailablePortsFrom(start, count)` shared by both paths
- Database and redis behavior unchanged — main still gets template DB directly

Fixes port conflict when an external process (e.g. Next.js dev server) occupies a base port.

## Test plan

- [x] `make ci` passes
- [x] `TestAllocate_MainWorktree` — contiguous ports, template DB, no redis prefix
- [x] `TestAllocate_MainWorktreeSkipsOccupiedPorts` — skips to next block when base ports taken
- [x] Manual: confirmed fix on salt repo with port 3001 occupied by next-server