### PR TITLE
Harden test coverage across critical paths

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,6 +19,53 @@ Requires Go 1.24+ and optionally `golangci-lint` and `govulncheck` (auto-install
 3. Run `make ci` and ensure all checks pass.
 4. Open a pull request with a clear description of the change and why it's needed.
 
+## Testing conventions
+
+### Making code testable
+
+When production code calls external processes or OS-level APIs, use the lightest
+injection pattern that fits. In order of preference:
+
+1. **Pure extraction** — split decision logic into a standalone function with no
+   side effects. No injection needed. Preferred whenever possible.
+   ```go
+   // Public wrapper
+   func TunnelExists(name string) bool { ... parseTunnelListHasName(output, name) }
+   // Testable pure function
+   func parseTunnelListHasName(data []byte, name string) bool { ... }
+   ```
+
+2. **Func params** — when the helper needs 1–2 injected behaviors, pass them as
+   function arguments. Keep the public function as a thin wrapper.
+   ```go
+   func VerifyDNS(host string, timeout time.Duration) bool {
+       return verifyDNSWith(host, timeout, net.LookupHost, 2*time.Second)
+   }
+   ```
+
+3. **Deps struct** — when a function depends on 3+ external behaviors, group them
+   into a struct with a factory that wires the production defaults.
+   ```go
+   type healthDeps struct { isRunning func() bool; ... }
+   func defaultHealthDeps() healthDeps { return healthDeps{isRunning: IsRunning, ...} }
+   func CheckHealth(...) []HealthCheck { return checkHealthWith(defaultHealthDeps(), ...) }
+   ```
+
+4. **Nil-check struct fields** — use sparingly. Existing code in
+   `database/postgresql.go` and `database/sqlite.go` uses this pattern; avoid
+   proliferating it in new code.
+
+### Known test limitations
+
+- **`run` vs `runSilent` in PostgreSQL**: both route through the same `execRun`
+  mock, so tests cannot detect regressions in stdout/stderr routing. This is
+  acceptable — tests verify argument correctness and error handling; stdout
+  routing is a UI concern.
+- **`os.Chdir` in worktree tests**: several worktree functions rely on
+  process-wide cwd rather than a `dir` parameter, making those tests
+  incompatible with `t.Parallel()`. The long-term fix is to thread `dir`
+  through the production API.
+
 ## Pull request expectations
 
 - One logical change per PR.

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -156,6 +156,20 @@ type dbInfo struct {
 	adapter  database.Adapter
 }
 
+// resolveDBPaths returns the resolved target and template paths for a database
+// adapter. SQLite paths are made absolute; PostgreSQL names pass through as-is.
+func resolveDBPaths(adapterName, absPath, mainRepo, dbName, template string) (target, tmpl string) {
+	target = dbName
+	if adapterName == "sqlite" {
+		target = filepath.Join(absPath, dbName)
+	}
+	tmpl = template
+	if adapterName == "sqlite" && template != "" {
+		tmpl = filepath.Join(mainRepo, template)
+	}
+	return target, tmpl
+}
+
 func resolveDB() (*dbInfo, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -183,19 +197,12 @@ func resolveDB() (*dbInfo, error) {
 		return nil, err
 	}
 
-	target := dbName
-	if adapterName == "sqlite" {
-		target = filepath.Join(absPath, dbName)
-	}
-
 	template := pc.DatabaseTemplate()
-	if adapterName == "sqlite" && template != "" {
-		template = filepath.Join(mainRepo, template)
-	}
+	target, tmpl := resolveDBPaths(adapterName, absPath, mainRepo, dbName, template)
 
 	return &dbInfo{
 		target:   target,
-		template: template,
+		template: tmpl,
 		adapter:  adapter,
 	}, nil
 }

--- a/cmd/db_test.go
+++ b/cmd/db_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestResolveDBPaths_PostgreSQL(t *testing.T) {
+	target, tmpl := resolveDBPaths("postgresql", "/work/myapp-feat", "/work/myapp", "myapp_feat", "myapp_dev")
+	if target != "myapp_feat" {
+		t.Errorf("target = %q, want %q", target, "myapp_feat")
+	}
+	if tmpl != "myapp_dev" {
+		t.Errorf("template = %q, want %q", tmpl, "myapp_dev")
+	}
+}
+
+func TestResolveDBPaths_SQLite(t *testing.T) {
+	target, tmpl := resolveDBPaths("sqlite", "/work/myapp-feat", "/work/myapp", "dev.db", "seed.db")
+	wantTarget := filepath.Join("/work/myapp-feat", "dev.db")
+	wantTmpl := filepath.Join("/work/myapp", "seed.db")
+	if target != wantTarget {
+		t.Errorf("target = %q, want %q", target, wantTarget)
+	}
+	if tmpl != wantTmpl {
+		t.Errorf("template = %q, want %q", tmpl, wantTmpl)
+	}
+}
+
+func TestResolveDBPaths_SQLite_EmptyTemplate(t *testing.T) {
+	target, tmpl := resolveDBPaths("sqlite", "/work/myapp-feat", "/work/myapp", "dev.db", "")
+	wantTarget := filepath.Join("/work/myapp-feat", "dev.db")
+	if target != wantTarget {
+		t.Errorf("target = %q, want %q", target, wantTarget)
+	}
+	if tmpl != "" {
+		t.Errorf("template = %q, want empty", tmpl)
+	}
+}
+
+func TestResolveDBPaths_PostgreSQL_EmptyTemplate(t *testing.T) {
+	target, tmpl := resolveDBPaths("postgresql", "/work/app", "/work/main", "app_branch", "")
+	if target != "app_branch" {
+		t.Errorf("target = %q, want %q", target, "app_branch")
+	}
+	if tmpl != "" {
+		t.Errorf("template = %q, want empty", tmpl)
+	}
+}

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -192,18 +192,32 @@ func doctorConfig(pc *config.ProjectConfig, det *detect.Result, absPath string) 
 	}
 }
 
+// classifyPortConfig checks whether a port base conflicts with the router port
+// or is a well-known framework default that should stay free.
+// Returns "conflict", "common_dev_port", or "" (ok).
+func classifyPortConfig(base, routerPort int) string {
+	if base == routerPort {
+		return "conflict"
+	}
+	if allocator.IsCommonDevPort(base) {
+		return "common_dev_port"
+	}
+	return ""
+}
+
 func doctorPortConfig() {
 	uc := config.LoadUserConfig("")
 	base := uc.PortBase()
 	routerPort := uc.RouterPort()
 
-	if base == routerPort {
+	switch classifyPortConfig(base, routerPort) {
+	case "conflict":
 		fmt.Println("\nPort config")
 		doctorLine("port.base", fmt.Sprintf("✗ %d conflicts with router.port", base))
 		fmt.Println("  The router listens on this port to proxy traffic to your worktrees.")
 		fmt.Println("  Allocating worktrees here will prevent the router from starting.")
 		fmt.Printf("  Fix: gtl config set port.base %d\n", routerPort+1)
-	} else if allocator.IsCommonDevPort(base) {
+	case "common_dev_port":
 		fmt.Println("\nPort config")
 		doctorLine("port.base", fmt.Sprintf("⚠ %d is a common framework default", base))
 		fmt.Println()

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -1,0 +1,32 @@
+package cmd
+
+import "testing"
+
+func TestClassifyPortConfig_Conflict(t *testing.T) {
+	got := classifyPortConfig(8443, 8443)
+	if got != "conflict" {
+		t.Errorf("classifyPortConfig(8443, 8443) = %q, want %q", got, "conflict")
+	}
+}
+
+func TestClassifyPortConfig_CommonDevPort(t *testing.T) {
+	got := classifyPortConfig(3000, 8443)
+	if got != "common_dev_port" {
+		t.Errorf("classifyPortConfig(3000, 8443) = %q, want %q", got, "common_dev_port")
+	}
+}
+
+func TestClassifyPortConfig_Ok(t *testing.T) {
+	got := classifyPortConfig(3002, 8443)
+	if got != "" {
+		t.Errorf("classifyPortConfig(3002, 8443) = %q, want empty", got)
+	}
+}
+
+func TestClassifyPortConfig_ConflictWhenBaseEqualsRouter(t *testing.T) {
+	// Even when base is also a common dev port, equality with router is the conflict
+	got := classifyPortConfig(3000, 3000)
+	if got != "conflict" {
+		t.Errorf("classifyPortConfig(3000, 3000) = %q, want %q", got, "conflict")
+	}
+}

--- a/cmd/init_cmd.go
+++ b/cmd/init_cmd.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/git-treeline/git-treeline/internal/allocator"
 	"github.com/git-treeline/git-treeline/internal/config"
 	"github.com/git-treeline/git-treeline/internal/confirm"
 	"github.com/git-treeline/git-treeline/internal/detect"
@@ -133,11 +132,12 @@ var initCmd = &cobra.Command{
 
 		base := uc.PortBase()
 		routerPort := uc.RouterPort()
-		if base == routerPort {
+		switch classifyPortConfig(base, routerPort) {
+		case "conflict":
 			fmt.Println()
 			fmt.Println(style.Warnf("port.base (%d) conflicts with router.port (%d).", base, routerPort))
 			fmt.Println(style.Dimf("  The router needs its own port. Fix: gtl config set port.base %d", routerPort+1))
-		} else if allocator.IsCommonDevPort(base) {
+		case "common_dev_port":
 			fmt.Println()
 			fmt.Println(style.Warnf("port.base is %d — a common framework default.", base))
 			fmt.Println(style.Dimf("  Port 3000 should stay free for the proxy so third-party services"))

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -258,6 +258,11 @@ func runReleaseBatch(project string, all bool) error {
 	return nil
 }
 
+// isInsideDir reports whether cwd is equal to or a child of dir.
+func isInsideDir(cwd, dir string) bool {
+	return cwd == dir || strings.HasPrefix(cwd+string(os.PathSeparator), dir+string(os.PathSeparator))
+}
+
 func removeWorktreeDir(absPath string, force bool) {
 	if _, err := os.Stat(absPath); err != nil {
 		return
@@ -265,7 +270,7 @@ func removeWorktreeDir(absPath string, force bool) {
 
 	cwd, _ := os.Getwd()
 	cwdAbs, _ := filepath.Abs(cwd)
-	insideWorktree := cwdAbs == absPath || strings.HasPrefix(cwdAbs+string(os.PathSeparator), absPath+string(os.PathSeparator))
+	insideWorktree := isInsideDir(cwdAbs, absPath)
 
 	if insideWorktree {
 		mainRepo := worktree.DetectMainRepo(absPath)

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsInsideDir_Exact(t *testing.T) {
+	if !isInsideDir("/a/b/c", "/a/b/c") {
+		t.Error("expected true for exact match")
+	}
+}
+
+func TestIsInsideDir_Child(t *testing.T) {
+	if !isInsideDir("/a/b/c/d", "/a/b/c") {
+		t.Error("expected true for child path")
+	}
+}
+
+func TestIsInsideDir_Sibling(t *testing.T) {
+	if isInsideDir("/a/b/cd", "/a/b/c") {
+		t.Error("expected false for sibling with shared prefix")
+	}
+}
+
+func TestIsInsideDir_Parent(t *testing.T) {
+	if isInsideDir("/a/b", "/a/b/c") {
+		t.Error("expected false when cwd is parent of dir")
+	}
+}
+
+func TestIsInsideDir_Unrelated(t *testing.T) {
+	if isInsideDir("/x/y", "/a/b") {
+		t.Error("expected false for unrelated paths")
+	}
+}
+
+func TestIsInsideDir_PlatformSeparator(t *testing.T) {
+	sep := string(os.PathSeparator)
+	dir := sep + "workspace" + sep + "project"
+	cwd := dir + sep + "subdir"
+	if !isInsideDir(cwd, dir) {
+		t.Error("expected true for child using platform separator")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/git-treeline/git-treeline
 
-go 1.26.1
+go 1.26.2
 
 require (
 	charm.land/bubbles/v2 v2.1.0

--- a/internal/database/postgresql.go
+++ b/internal/database/postgresql.go
@@ -22,14 +22,41 @@ var templateLocks sync.Map
 
 // PostgreSQL implements the Adapter interface for PostgreSQL databases.
 // Clone uses createdb --template, Drop uses dropdb --if-exists.
-type PostgreSQL struct{}
+type PostgreSQL struct {
+	execRun    func(name string, args ...string) error
+	execOutput func(name string, args ...string) ([]byte, error)
+}
+
+func (pg *PostgreSQL) run(name string, args ...string) error {
+	if pg.execRun != nil {
+		return pg.execRun(name, args...)
+	}
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func (pg *PostgreSQL) runSilent(name string, args ...string) error {
+	if pg.execRun != nil {
+		return pg.execRun(name, args...)
+	}
+	return exec.Command(name, args...).Run()
+}
+
+func (pg *PostgreSQL) output(name string, args ...string) ([]byte, error) {
+	if pg.execOutput != nil {
+		return pg.execOutput(name, args...)
+	}
+	return exec.Command(name, args...).Output()
+}
 
 func (pg *PostgreSQL) Exists(name string) (bool, error) {
 	if !dbIdentifierRe.MatchString(name) {
 		return false, fmt.Errorf("invalid database identifier: %q", name)
 	}
 
-	out, err := exec.Command("psql", "-lqt").Output()
+	out, err := pg.output("psql", "-lqt")
 	if err != nil {
 		return false, fmt.Errorf("failed to list databases: %w", err)
 	}
@@ -71,12 +98,9 @@ func (pg *PostgreSQL) Clone(template, target string) error {
 		"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s' AND pid <> pg_backend_pid();",
 		template,
 	)
-	_ = exec.Command("psql", "-d", "postgres", "-c", terminateSQL).Run()
+	_ = pg.runSilent("psql", "-d", "postgres", "-c", terminateSQL)
 
-	cmd := exec.Command("createdb", target, "--template", template)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	if err := pg.run("createdb", target, "--template", template); err != nil {
 		return fmt.Errorf("failed to clone database %s -> %s: %w", template, target, err)
 	}
 
@@ -84,7 +108,7 @@ func (pg *PostgreSQL) Clone(template, target string) error {
 }
 
 func (pg *PostgreSQL) Drop(target string) error {
-	return exec.Command("dropdb", "--if-exists", target).Run()
+	return pg.runSilent("dropdb", "--if-exists", target)
 }
 
 func (pg *PostgreSQL) Restore(target, dumpFile string) error {
@@ -92,21 +116,17 @@ func (pg *PostgreSQL) Restore(target, dumpFile string) error {
 		return fmt.Errorf("invalid database identifier: %q", target)
 	}
 
-	cmd := exec.Command("createdb", target)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	if err := pg.run("createdb", target); err != nil {
 		return fmt.Errorf("creating database %s: %w", target, err)
 	}
 
+	var err error
 	if isCustomFormat(dumpFile) {
-		cmd = exec.Command("pg_restore", "--no-owner", "--no-acl", "-d", target, dumpFile)
+		err = pg.run("pg_restore", "--no-owner", "--no-acl", "-d", target, dumpFile)
 	} else {
-		cmd = exec.Command("psql", "-d", target, "-f", dumpFile)
+		err = pg.run("psql", "-d", target, "-f", dumpFile)
 	}
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	if err != nil {
 		return fmt.Errorf("restoring %s into %s: %w", dumpFile, target, err)
 	}
 	return nil

--- a/internal/database/postgresql.go
+++ b/internal/database/postgresql.go
@@ -108,6 +108,9 @@ func (pg *PostgreSQL) Clone(template, target string) error {
 }
 
 func (pg *PostgreSQL) Drop(target string) error {
+	if !dbIdentifierRe.MatchString(target) {
+		return fmt.Errorf("invalid database identifier: %q", target)
+	}
 	return pg.runSilent("dropdb", "--if-exists", target)
 }
 

--- a/internal/database/postgresql_test.go
+++ b/internal/database/postgresql_test.go
@@ -1,8 +1,10 @@
 package database
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -61,6 +63,321 @@ func TestIsCustomFormat_PlainSQL(t *testing.T) {
 func TestIsCustomFormat_Missing(t *testing.T) {
 	if isCustomFormat("/nonexistent/dump.pgdmp") {
 		t.Error("expected false for missing file")
+	}
+}
+
+type cmdCall struct {
+	name string
+	args []string
+}
+
+func (c cmdCall) String() string {
+	return c.name + " " + strings.Join(c.args, " ")
+}
+
+func testPg(t *testing.T, psqlOutput string, failCmd string) (*PostgreSQL, *[]cmdCall) {
+	t.Helper()
+	var calls []cmdCall
+	pg := &PostgreSQL{
+		execRun: func(name string, args ...string) error {
+			calls = append(calls, cmdCall{name, args})
+			if name == failCmd {
+				return fmt.Errorf("mock: %s failed", name)
+			}
+			return nil
+		},
+		execOutput: func(name string, args ...string) ([]byte, error) {
+			calls = append(calls, cmdCall{name, args})
+			if name == failCmd {
+				return nil, fmt.Errorf("mock: %s failed", name)
+			}
+			return []byte(psqlOutput), nil
+		},
+	}
+	return pg, &calls
+}
+
+// --- PostgreSQL.Exists tests ---
+
+func TestPostgreSQL_Exists_Found(t *testing.T) {
+	psqlOutput := " myapp_dev | user | UTF8\n postgres  | user | UTF8\n"
+	pg, calls := testPg(t, psqlOutput, "")
+
+	exists, err := pg.Exists("myapp_dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !exists {
+		t.Error("expected Exists=true for listed database")
+	}
+	if len(*calls) != 1 || (*calls)[0].name != "psql" {
+		t.Errorf("expected psql call, got %v", *calls)
+	}
+}
+
+func TestPostgreSQL_Exists_NotFound(t *testing.T) {
+	psqlOutput := " myapp_dev | user | UTF8\n"
+	pg, _ := testPg(t, psqlOutput, "")
+
+	exists, err := pg.Exists("other_db")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if exists {
+		t.Error("expected Exists=false for unlisted database")
+	}
+}
+
+func TestPostgreSQL_Exists_InvalidIdentifier(t *testing.T) {
+	pg, calls := testPg(t, "", "")
+
+	_, err := pg.Exists("drop table;--")
+	if err == nil {
+		t.Fatal("expected error for invalid identifier")
+	}
+	if !strings.Contains(err.Error(), "invalid database identifier") {
+		t.Errorf("expected 'invalid database identifier' in error, got: %v", err)
+	}
+	if len(*calls) != 0 {
+		t.Error("should not have called psql for invalid identifier")
+	}
+}
+
+func TestPostgreSQL_Exists_PsqlFailure(t *testing.T) {
+	pg, _ := testPg(t, "", "psql")
+
+	_, err := pg.Exists("myapp")
+	if err == nil {
+		t.Fatal("expected error when psql fails")
+	}
+	if !strings.Contains(err.Error(), "failed to list databases") {
+		t.Errorf("expected 'failed to list databases' in error, got: %v", err)
+	}
+}
+
+// --- PostgreSQL.Clone tests ---
+
+func TestPostgreSQL_Clone_Success(t *testing.T) {
+	pg, calls := testPg(t, "", "")
+
+	err := pg.Clone("myapp_dev", "myapp_feat")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(*calls) != 2 {
+		t.Fatalf("expected 2 calls (terminate + createdb), got %d: %v", len(*calls), *calls)
+	}
+	if (*calls)[0].name != "psql" {
+		t.Errorf("first call should be psql (terminate), got %s", (*calls)[0].name)
+	}
+	if (*calls)[1].name != "createdb" {
+		t.Errorf("second call should be createdb, got %s", (*calls)[1].name)
+	}
+	args := (*calls)[1].args
+	if len(args) != 3 || args[0] != "myapp_feat" || args[1] != "--template" || args[2] != "myapp_dev" {
+		t.Errorf("createdb args = %v, want [myapp_feat --template myapp_dev]", args)
+	}
+}
+
+func TestPostgreSQL_Clone_InvalidTarget(t *testing.T) {
+	pg, calls := testPg(t, "", "")
+
+	err := pg.Clone("myapp_dev", "bad;name")
+	if err == nil {
+		t.Fatal("expected error for invalid target")
+	}
+	if len(*calls) != 0 {
+		t.Error("should not execute commands with invalid identifier")
+	}
+}
+
+func TestPostgreSQL_Clone_InvalidTemplate(t *testing.T) {
+	pg, calls := testPg(t, "", "")
+
+	err := pg.Clone("bad;name", "myapp_feat")
+	if err == nil {
+		t.Fatal("expected error for invalid template")
+	}
+	if len(*calls) != 0 {
+		t.Error("should not execute commands with invalid identifier")
+	}
+}
+
+func TestPostgreSQL_Clone_CreatedbFailure(t *testing.T) {
+	pg, _ := testPg(t, "", "createdb")
+
+	err := pg.Clone("myapp_dev", "myapp_feat")
+	if err == nil {
+		t.Fatal("expected error when createdb fails")
+	}
+	if !strings.Contains(err.Error(), "failed to clone database") {
+		t.Errorf("expected 'failed to clone database' in error, got: %v", err)
+	}
+}
+
+func TestPostgreSQL_Clone_TerminateFailureIgnored(t *testing.T) {
+	pg, calls := testPg(t, "", "psql")
+
+	// psql (terminate) will fail, but Clone should still proceed to createdb
+	// Since both psql and createdb go through execRun and we fail "psql",
+	// we need a smarter mock. Let's build one inline.
+	callCount := 0
+	pg.execRun = func(name string, args ...string) error {
+		*calls = append(*calls, cmdCall{name, args})
+		callCount++
+		if name == "psql" {
+			return fmt.Errorf("mock: terminate failed")
+		}
+		return nil
+	}
+
+	err := pg.Clone("myapp_dev", "myapp_feat")
+	if err != nil {
+		t.Fatalf("terminate failure should be ignored, got: %v", err)
+	}
+	if len(*calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(*calls))
+	}
+}
+
+// --- PostgreSQL.Drop tests ---
+
+func TestPostgreSQL_Drop_Success(t *testing.T) {
+	pg, calls := testPg(t, "", "")
+
+	err := pg.Drop("myapp_feat")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(*calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(*calls))
+	}
+	c := (*calls)[0]
+	if c.name != "dropdb" {
+		t.Errorf("expected dropdb, got %s", c.name)
+	}
+	if len(c.args) != 2 || c.args[0] != "--if-exists" || c.args[1] != "myapp_feat" {
+		t.Errorf("dropdb args = %v, want [--if-exists myapp_feat]", c.args)
+	}
+}
+
+func TestPostgreSQL_Drop_Failure(t *testing.T) {
+	pg, _ := testPg(t, "", "dropdb")
+
+	err := pg.Drop("myapp_feat")
+	if err == nil {
+		t.Fatal("expected error when dropdb fails")
+	}
+}
+
+// --- PostgreSQL.Restore tests ---
+
+func TestPostgreSQL_Restore_PlainSQL(t *testing.T) {
+	dir := t.TempDir()
+	dumpFile := filepath.Join(dir, "dump.sql")
+	_ = os.WriteFile(dumpFile, []byte("CREATE TABLE foo;"), 0o644)
+
+	pg, calls := testPg(t, "", "")
+
+	err := pg.Restore("myapp_feat", dumpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(*calls) != 2 {
+		t.Fatalf("expected 2 calls (createdb + psql), got %d: %v", len(*calls), *calls)
+	}
+	if (*calls)[0].name != "createdb" {
+		t.Errorf("first call should be createdb, got %s", (*calls)[0].name)
+	}
+	if (*calls)[1].name != "psql" {
+		t.Errorf("second call should be psql for plain SQL, got %s", (*calls)[1].name)
+	}
+	args := (*calls)[1].args
+	if len(args) != 4 || args[0] != "-d" || args[1] != "myapp_feat" || args[2] != "-f" || args[3] != dumpFile {
+		t.Errorf("psql args = %v, want [-d myapp_feat -f %s]", args, dumpFile)
+	}
+}
+
+func TestPostgreSQL_Restore_CustomFormat(t *testing.T) {
+	dir := t.TempDir()
+	dumpFile := filepath.Join(dir, "dump.pgdmp")
+	_ = os.WriteFile(dumpFile, []byte("PGDMP\x00\x00\x00data"), 0o644)
+
+	pg, calls := testPg(t, "", "")
+
+	err := pg.Restore("myapp_feat", dumpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(*calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(*calls))
+	}
+	if (*calls)[1].name != "pg_restore" {
+		t.Errorf("second call should be pg_restore for custom format, got %s", (*calls)[1].name)
+	}
+	args := (*calls)[1].args
+	if len(args) != 5 || args[0] != "--no-owner" || args[1] != "--no-acl" {
+		t.Errorf("pg_restore args = %v, want [--no-owner --no-acl -d myapp_feat %s]", args, dumpFile)
+	}
+}
+
+func TestPostgreSQL_Restore_InvalidIdentifier(t *testing.T) {
+	pg, calls := testPg(t, "", "")
+
+	err := pg.Restore("bad;name", "/tmp/dump.sql")
+	if err == nil {
+		t.Fatal("expected error for invalid identifier")
+	}
+	if len(*calls) != 0 {
+		t.Error("should not execute commands with invalid identifier")
+	}
+}
+
+func TestPostgreSQL_Restore_CreatedbFailure(t *testing.T) {
+	dir := t.TempDir()
+	dumpFile := filepath.Join(dir, "dump.sql")
+	_ = os.WriteFile(dumpFile, []byte("CREATE TABLE foo;"), 0o644)
+
+	pg, calls := testPg(t, "", "createdb")
+
+	err := pg.Restore("myapp_feat", dumpFile)
+	if err == nil {
+		t.Fatal("expected error when createdb fails")
+	}
+	if !strings.Contains(err.Error(), "creating database") {
+		t.Errorf("expected 'creating database' in error, got: %v", err)
+	}
+	if len(*calls) != 1 {
+		t.Errorf("should stop after createdb failure, got %d calls", len(*calls))
+	}
+}
+
+func TestPostgreSQL_Restore_RestoreCommandFailure(t *testing.T) {
+	dir := t.TempDir()
+	dumpFile := filepath.Join(dir, "dump.sql")
+	_ = os.WriteFile(dumpFile, []byte("CREATE TABLE foo;"), 0o644)
+
+	callCount := 0
+	pg := &PostgreSQL{
+		execRun: func(name string, args ...string) error {
+			callCount++
+			if callCount == 2 {
+				return fmt.Errorf("mock: restore failed")
+			}
+			return nil
+		},
+	}
+
+	err := pg.Restore("myapp_feat", dumpFile)
+	if err == nil {
+		t.Fatal("expected error when restore command fails")
+	}
+	if !strings.Contains(err.Error(), "restoring") {
+		t.Errorf("expected 'restoring' in error, got: %v", err)
 	}
 }
 

--- a/internal/database/postgresql_test.go
+++ b/internal/database/postgresql_test.go
@@ -272,6 +272,18 @@ func TestPostgreSQL_Drop_Failure(t *testing.T) {
 	}
 }
 
+func TestPostgreSQL_Drop_InvalidIdentifier(t *testing.T) {
+	pg, calls := testPg(t, "", "")
+
+	err := pg.Drop("bad;name")
+	if err == nil {
+		t.Fatal("expected error for invalid identifier")
+	}
+	if len(*calls) != 0 {
+		t.Error("should not execute commands with invalid identifier")
+	}
+}
+
 // --- PostgreSQL.Restore tests ---
 
 func TestPostgreSQL_Restore_PlainSQL(t *testing.T) {
@@ -320,7 +332,7 @@ func TestPostgreSQL_Restore_CustomFormat(t *testing.T) {
 		t.Errorf("second call should be pg_restore for custom format, got %s", (*calls)[1].name)
 	}
 	args := (*calls)[1].args
-	if len(args) != 5 || args[0] != "--no-owner" || args[1] != "--no-acl" {
+	if len(args) != 5 || args[0] != "--no-owner" || args[1] != "--no-acl" || args[2] != "-d" || args[3] != "myapp_feat" || args[4] != dumpFile {
 		t.Errorf("pg_restore args = %v, want [--no-owner --no-acl -d myapp_feat %s]", args, dumpFile)
 	}
 }
@@ -361,11 +373,9 @@ func TestPostgreSQL_Restore_RestoreCommandFailure(t *testing.T) {
 	dumpFile := filepath.Join(dir, "dump.sql")
 	_ = os.WriteFile(dumpFile, []byte("CREATE TABLE foo;"), 0o644)
 
-	callCount := 0
 	pg := &PostgreSQL{
 		execRun: func(name string, args ...string) error {
-			callCount++
-			if callCount == 2 {
+			if name == "psql" && len(args) > 0 && args[0] == "-d" {
 				return fmt.Errorf("mock: restore failed")
 			}
 			return nil

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -8,7 +8,16 @@ import (
 	"path/filepath"
 )
 
-type SQLite struct{}
+type SQLite struct {
+	newCommand func(name string, args ...string) *exec.Cmd
+}
+
+func (s *SQLite) command(name string, args ...string) *exec.Cmd {
+	if s.newCommand != nil {
+		return s.newCommand(name, args...)
+	}
+	return exec.Command(name, args...)
+}
 
 func (s *SQLite) Exists(name string) (bool, error) {
 	_, err := os.Stat(name)
@@ -65,7 +74,7 @@ func (s *SQLite) Restore(target, dumpFile string) error {
 	}
 	defer func() { _ = dump.Close() }()
 
-	cmd := exec.Command("sqlite3", target)
+	cmd := s.command("sqlite3", target)
 	cmd.Stdin = dump
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -2,7 +2,9 @@ package database
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -105,5 +107,103 @@ func TestSQLite_Drop_Nonexistent(t *testing.T) {
 	s := &SQLite{}
 	if err := s.Drop(filepath.Join(dir, "nonexistent.db")); err != nil {
 		t.Errorf("dropping nonexistent file should not error: %v", err)
+	}
+}
+
+// --- SQLite.Restore tests ---
+
+func TestSQLite_Restore_Success(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "restored.db")
+	dumpFile := filepath.Join(dir, "dump.sql")
+	_ = os.WriteFile(dumpFile, []byte("CREATE TABLE foo (id INTEGER);"), 0o644)
+
+	var calledName string
+	var calledArgs []string
+	s := &SQLite{
+		newCommand: func(name string, args ...string) *exec.Cmd {
+			calledName = name
+			calledArgs = args
+			return exec.Command("true")
+		},
+	}
+
+	err := s.Restore(target, dumpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if calledName != "sqlite3" {
+		t.Errorf("expected sqlite3 command, got %q", calledName)
+	}
+	if len(calledArgs) != 1 || calledArgs[0] != target {
+		t.Errorf("expected args [%s], got %v", target, calledArgs)
+	}
+}
+
+func TestSQLite_Restore_DropsExisting(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "existing.db")
+	walPath := target + "-wal"
+	dumpFile := filepath.Join(dir, "dump.sql")
+
+	_ = os.WriteFile(target, []byte("old data"), 0o644)
+	_ = os.WriteFile(walPath, []byte("wal"), 0o644)
+	_ = os.WriteFile(dumpFile, []byte("CREATE TABLE foo;"), 0o644)
+
+	s := &SQLite{
+		newCommand: func(name string, args ...string) *exec.Cmd {
+			return exec.Command("true")
+		},
+	}
+
+	err := s.Restore(target, dumpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(target); err == nil {
+		t.Error("expected old database file to be dropped before restore")
+	}
+	if _, err := os.Stat(walPath); err == nil {
+		t.Error("expected WAL file to be dropped before restore")
+	}
+}
+
+func TestSQLite_Restore_MissingDumpFile(t *testing.T) {
+	dir := t.TempDir()
+	s := &SQLite{
+		newCommand: func(name string, args ...string) *exec.Cmd {
+			return exec.Command("true")
+		},
+	}
+
+	err := s.Restore(filepath.Join(dir, "target.db"), filepath.Join(dir, "nonexistent.sql"))
+	if err == nil {
+		t.Fatal("expected error for missing dump file")
+	}
+	if !strings.Contains(err.Error(), "opening dump file") {
+		t.Errorf("expected 'opening dump file' in error, got: %v", err)
+	}
+}
+
+func TestSQLite_Restore_CommandFailure(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "target.db")
+	dumpFile := filepath.Join(dir, "dump.sql")
+	_ = os.WriteFile(dumpFile, []byte("CREATE TABLE foo;"), 0o644)
+
+	s := &SQLite{
+		newCommand: func(name string, args ...string) *exec.Cmd {
+			return exec.Command("false")
+		},
+	}
+
+	err := s.Restore(target, dumpFile)
+	if err == nil {
+		t.Fatal("expected error when sqlite3 fails")
+	}
+	if !strings.Contains(err.Error(), "restoring") {
+		t.Errorf("expected 'restoring' in error, got: %v", err)
 	}
 }

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -1,6 +1,7 @@
 package database
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -116,15 +117,19 @@ func TestSQLite_Restore_Success(t *testing.T) {
 	dir := t.TempDir()
 	target := filepath.Join(dir, "restored.db")
 	dumpFile := filepath.Join(dir, "dump.sql")
-	_ = os.WriteFile(dumpFile, []byte("CREATE TABLE foo (id INTEGER);"), 0o644)
+	dumpContent := "CREATE TABLE foo (id INTEGER);"
+	_ = os.WriteFile(dumpFile, []byte(dumpContent), 0o644)
 
+	// Use "cat" as a fake sqlite3 — it reads stdin and writes to stdout.
+	// We redirect stdout to a capture file to verify stdin was piped.
+	stdinCapture := filepath.Join(dir, "stdin_capture")
 	var calledName string
 	var calledArgs []string
 	s := &SQLite{
 		newCommand: func(name string, args ...string) *exec.Cmd {
 			calledName = name
 			calledArgs = args
-			return exec.Command("true")
+			return exec.Command("sh", "-c", fmt.Sprintf("cat > %s", stdinCapture))
 		},
 	}
 
@@ -138,6 +143,15 @@ func TestSQLite_Restore_Success(t *testing.T) {
 	}
 	if len(calledArgs) != 1 || calledArgs[0] != target {
 		t.Errorf("expected args [%s], got %v", target, calledArgs)
+	}
+
+	// Verify dump file contents were actually piped to the command's stdin
+	captured, err := os.ReadFile(stdinCapture)
+	if err != nil {
+		t.Fatalf("stdin capture file not written: %v", err)
+	}
+	if string(captured) != dumpContent {
+		t.Errorf("stdin received %q, want %q", string(captured), dumpContent)
 	}
 }
 

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -326,3 +326,28 @@ func TestDetect_NoJSBundler(t *testing.T) {
 		t.Error("expected HasJSBundler=false with importmap-rails")
 	}
 }
+
+func TestIsServerFramework(t *testing.T) {
+	cases := []struct {
+		framework string
+		expected  bool
+	}{
+		{"rails", true},
+		{"nextjs", true},
+		{"vite", true},
+		{"node", true},
+		{"django", true},
+		{"python", true},
+		{"go", false},
+		{"rust", false},
+		{"unknown", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.framework, func(t *testing.T) {
+			r := &Result{Framework: tc.framework}
+			if got := r.IsServerFramework(); got != tc.expected {
+				t.Errorf("IsServerFramework()=%v for %s, want %v", got, tc.framework, tc.expected)
+			}
+		})
+	}
+}

--- a/internal/service/health.go
+++ b/internal/service/health.go
@@ -18,21 +18,47 @@ type HealthCheck struct {
 	Fix    string `json:"fix,omitempty"`
 }
 
+type healthDeps struct {
+	isRunning               func() bool
+	installedBinaryPath     func() string
+	runningRouterVersion    func() string
+	isPortForwardConfigured func() bool
+	dialTimeout             func(network, address string, timeout time.Duration) (net.Conn, error)
+	executable              func() (string, error)
+	processOnPort           func(port int) string
+}
+
+func defaultHealthDeps() healthDeps {
+	return healthDeps{
+		isRunning:               IsRunning,
+		installedBinaryPath:     InstalledBinaryPath,
+		runningRouterVersion:    RunningRouterVersion,
+		isPortForwardConfigured: IsPortForwardConfigured,
+		dialTimeout:             net.DialTimeout,
+		executable:              os.Executable,
+		processOnPort:           processOnPort,
+	}
+}
+
 // CheckHealth runs all serve-related health checks and returns the results.
 func CheckHealth(routerPort int, cliVersion string) []HealthCheck {
+	return checkHealthWith(defaultHealthDeps(), routerPort, cliVersion)
+}
+
+func checkHealthWith(d healthDeps, routerPort int, cliVersion string) []HealthCheck {
 	var checks []HealthCheck
 
-	checks = append(checks, checkServiceRegistered())
-	checks = append(checks, checkBinaryMatch())
-	checks = append(checks, checkRouterVersion(cliVersion))
-	checks = append(checks, checkRouterListening(routerPort))
-	checks = append(checks, checkPortForward(routerPort))
+	checks = append(checks, checkServiceRegistered(d))
+	checks = append(checks, checkBinaryMatch(d))
+	checks = append(checks, checkRouterVersion(d, cliVersion))
+	checks = append(checks, checkRouterListening(d, routerPort))
+	checks = append(checks, checkPortForward(d, routerPort))
 
 	return checks
 }
 
-func checkServiceRegistered() HealthCheck {
-	if IsRunning() {
+func checkServiceRegistered(d healthDeps) HealthCheck {
+	if d.isRunning() {
 		return HealthCheck{
 			Name:   "service",
 			Status: "ok",
@@ -47,8 +73,8 @@ func checkServiceRegistered() HealthCheck {
 	}
 }
 
-func checkBinaryMatch() HealthCheck {
-	installed := InstalledBinaryPath()
+func checkBinaryMatch(d healthDeps) HealthCheck {
+	installed := d.installedBinaryPath()
 	if installed == "" {
 		return HealthCheck{
 			Name:   "binary",
@@ -58,7 +84,7 @@ func checkBinaryMatch() HealthCheck {
 		}
 	}
 
-	current, err := os.Executable()
+	current, err := d.executable()
 	if err != nil {
 		return HealthCheck{
 			Name:   "binary",
@@ -83,8 +109,8 @@ func checkBinaryMatch() HealthCheck {
 	}
 }
 
-func checkRouterVersion(cliVersion string) HealthCheck {
-	running := RunningRouterVersion()
+func checkRouterVersion(d healthDeps, cliVersion string) HealthCheck {
+	running := d.runningRouterVersion()
 	if running == "" {
 		return HealthCheck{
 			Name:   "router_version",
@@ -108,10 +134,10 @@ func checkRouterVersion(cliVersion string) HealthCheck {
 	}
 }
 
-func checkRouterListening(port int) HealthCheck {
-	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 2*time.Second)
+func checkRouterListening(d healthDeps, port int) HealthCheck {
+	conn, err := d.dialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 2*time.Second)
 	if err != nil {
-		if IsRunning() {
+		if d.isRunning() {
 			return HealthCheck{
 				Name:   "router_port",
 				Status: "error",
@@ -128,7 +154,7 @@ func checkRouterListening(port int) HealthCheck {
 	}
 	_ = conn.Close()
 
-	proc := processOnPort(port)
+	proc := d.processOnPort(port)
 	if proc != "" && !strings.Contains(proc, "gtl") {
 		return HealthCheck{
 			Name:   "router_port",
@@ -145,8 +171,8 @@ func checkRouterListening(port int) HealthCheck {
 	}
 }
 
-func checkPortForward(routerPort int) HealthCheck {
-	if !IsPortForwardConfigured() {
+func checkPortForward(d healthDeps, routerPort int) HealthCheck {
+	if !d.isPortForwardConfigured() {
 		return HealthCheck{
 			Name:   "port_forwarding",
 			Status: "warn",
@@ -155,7 +181,7 @@ func checkPortForward(routerPort int) HealthCheck {
 		}
 	}
 
-	conn, err := net.DialTimeout("tcp", "127.0.0.1:443", 2*time.Second)
+	conn, err := d.dialTimeout("tcp", "127.0.0.1:443", 2*time.Second)
 	if err != nil {
 		return HealthCheck{
 			Name:   "port_forwarding",

--- a/internal/service/health_test.go
+++ b/internal/service/health_test.go
@@ -1,0 +1,238 @@
+package service
+
+import (
+	"fmt"
+	"net"
+	"testing"
+	"time"
+)
+
+type fakeConn struct{ net.Conn }
+
+func (f fakeConn) Close() error { return nil }
+
+func fakeDial(succeed bool) func(string, string, time.Duration) (net.Conn, error) {
+	return func(_, _ string, _ time.Duration) (net.Conn, error) {
+		if succeed {
+			return fakeConn{}, nil
+		}
+		return nil, fmt.Errorf("connection refused")
+	}
+}
+
+func allHealthy() healthDeps {
+	return healthDeps{
+		isRunning:               func() bool { return true },
+		installedBinaryPath:     func() string { return "/usr/local/bin/gtl" },
+		runningRouterVersion:    func() string { return "1.0.0" },
+		isPortForwardConfigured: func() bool { return true },
+		dialTimeout:             fakeDial(true),
+		executable:              func() (string, error) { return "/usr/local/bin/gtl", nil },
+		processOnPort:           func(int) string { return "gtl (pid 1234)" },
+	}
+}
+
+// --- checkHealthWith integration ---
+
+func TestCheckHealthWith_AllHealthy(t *testing.T) {
+	checks := checkHealthWith(allHealthy(), 8443, "1.0.0")
+
+	if len(checks) != 5 {
+		t.Fatalf("expected 5 checks, got %d", len(checks))
+	}
+	for _, c := range checks {
+		if c.Status != "ok" {
+			t.Errorf("check %q: expected ok, got %s (%s)", c.Name, c.Status, c.Detail)
+		}
+	}
+}
+
+func TestCheckHealthWith_AllBroken(t *testing.T) {
+	d := healthDeps{
+		isRunning:               func() bool { return false },
+		installedBinaryPath:     func() string { return "" },
+		runningRouterVersion:    func() string { return "" },
+		isPortForwardConfigured: func() bool { return false },
+		dialTimeout:             fakeDial(false),
+		executable:              func() (string, error) { return "/usr/local/bin/gtl", nil },
+		processOnPort:           func(int) string { return "" },
+	}
+
+	checks := checkHealthWith(d, 8443, "1.0.0")
+
+	for _, c := range checks {
+		if c.Status == "ok" {
+			t.Errorf("check %q: expected non-ok status, got ok", c.Name)
+		}
+	}
+}
+
+// --- checkServiceRegistered ---
+
+func TestCheckServiceRegistered_Running(t *testing.T) {
+	d := allHealthy()
+	c := checkServiceRegistered(d)
+	if c.Status != "ok" {
+		t.Errorf("expected ok, got %s", c.Status)
+	}
+	if c.Fix != "" {
+		t.Error("expected no fix when running")
+	}
+}
+
+func TestCheckServiceRegistered_NotRunning(t *testing.T) {
+	d := allHealthy()
+	d.isRunning = func() bool { return false }
+	c := checkServiceRegistered(d)
+	if c.Status != "error" {
+		t.Errorf("expected error, got %s", c.Status)
+	}
+	if c.Fix == "" {
+		t.Error("expected fix suggestion")
+	}
+}
+
+// --- checkBinaryMatch ---
+
+func TestCheckBinaryMatch_Match(t *testing.T) {
+	d := allHealthy()
+	c := checkBinaryMatch(d)
+	if c.Status != "ok" {
+		t.Errorf("expected ok, got %s", c.Status)
+	}
+}
+
+func TestCheckBinaryMatch_Mismatch(t *testing.T) {
+	d := allHealthy()
+	d.executable = func() (string, error) { return "/other/path/gtl", nil }
+	c := checkBinaryMatch(d)
+	if c.Status != "warn" {
+		t.Errorf("expected warn, got %s", c.Status)
+	}
+	if c.Fix == "" {
+		t.Error("expected fix for mismatch")
+	}
+}
+
+func TestCheckBinaryMatch_NoServiceDef(t *testing.T) {
+	d := allHealthy()
+	d.installedBinaryPath = func() string { return "" }
+	c := checkBinaryMatch(d)
+	if c.Status != "warn" {
+		t.Errorf("expected warn, got %s", c.Status)
+	}
+}
+
+func TestCheckBinaryMatch_ExecutableError(t *testing.T) {
+	d := allHealthy()
+	d.executable = func() (string, error) { return "", fmt.Errorf("cannot resolve") }
+	c := checkBinaryMatch(d)
+	if c.Status != "warn" {
+		t.Errorf("expected warn, got %s", c.Status)
+	}
+}
+
+// --- checkRouterVersion ---
+
+func TestCheckRouterVersion_Match(t *testing.T) {
+	d := allHealthy()
+	c := checkRouterVersion(d, "1.0.0")
+	if c.Status != "ok" {
+		t.Errorf("expected ok, got %s", c.Status)
+	}
+}
+
+func TestCheckRouterVersion_Mismatch(t *testing.T) {
+	d := allHealthy()
+	d.runningRouterVersion = func() string { return "0.9.0" }
+	c := checkRouterVersion(d, "1.0.0")
+	if c.Status != "warn" {
+		t.Errorf("expected warn, got %s", c.Status)
+	}
+}
+
+func TestCheckRouterVersion_NoVersionFile(t *testing.T) {
+	d := allHealthy()
+	d.runningRouterVersion = func() string { return "" }
+	c := checkRouterVersion(d, "1.0.0")
+	if c.Status != "warn" {
+		t.Errorf("expected warn, got %s", c.Status)
+	}
+}
+
+// --- checkRouterListening ---
+
+func TestCheckRouterListening_Ok(t *testing.T) {
+	d := allHealthy()
+	c := checkRouterListening(d, 8443)
+	if c.Status != "ok" {
+		t.Errorf("expected ok, got %s", c.Status)
+	}
+}
+
+func TestCheckRouterListening_NotListening_ServiceRunning(t *testing.T) {
+	d := allHealthy()
+	d.dialTimeout = fakeDial(false)
+	c := checkRouterListening(d, 8443)
+	if c.Status != "error" {
+		t.Errorf("expected error, got %s", c.Status)
+	}
+	if c.Detail != "service registered but port 8443 not listening" {
+		t.Errorf("unexpected detail: %s", c.Detail)
+	}
+}
+
+func TestCheckRouterListening_NotListening_ServiceStopped(t *testing.T) {
+	d := allHealthy()
+	d.dialTimeout = fakeDial(false)
+	d.isRunning = func() bool { return false }
+	c := checkRouterListening(d, 8443)
+	if c.Status != "error" {
+		t.Errorf("expected error, got %s", c.Status)
+	}
+	if c.Detail != "port 8443 not listening" {
+		t.Errorf("unexpected detail: %s", c.Detail)
+	}
+}
+
+func TestCheckRouterListening_RogueProcess(t *testing.T) {
+	d := allHealthy()
+	d.processOnPort = func(int) string { return "nginx (pid 5678)" }
+	c := checkRouterListening(d, 8443)
+	if c.Status != "warn" {
+		t.Errorf("expected warn for rogue process, got %s", c.Status)
+	}
+}
+
+// --- checkPortForward ---
+
+func TestCheckPortForward_Ok(t *testing.T) {
+	d := allHealthy()
+	c := checkPortForward(d, 8443)
+	if c.Status != "ok" {
+		t.Errorf("expected ok, got %s", c.Status)
+	}
+}
+
+func TestCheckPortForward_NotConfigured(t *testing.T) {
+	d := allHealthy()
+	d.isPortForwardConfigured = func() bool { return false }
+	c := checkPortForward(d, 8443)
+	if c.Status != "warn" {
+		t.Errorf("expected warn, got %s", c.Status)
+	}
+}
+
+func TestCheckPortForward_ConfiguredButUnreachable(t *testing.T) {
+	d := allHealthy()
+	d.dialTimeout = func(_, addr string, _ time.Duration) (net.Conn, error) {
+		if addr == "127.0.0.1:443" {
+			return nil, fmt.Errorf("connection refused")
+		}
+		return fakeConn{}, nil
+	}
+	c := checkPortForward(d, 8443)
+	if c.Status != "error" {
+		t.Errorf("expected error, got %s", c.Status)
+	}
+}

--- a/internal/service/health_test.go
+++ b/internal/service/health_test.go
@@ -60,9 +60,21 @@ func TestCheckHealthWith_AllBroken(t *testing.T) {
 
 	checks := checkHealthWith(d, 8443, "1.0.0")
 
+	expected := map[string]string{
+		"service":         "error",
+		"binary":          "warn",
+		"router_version":  "warn",
+		"router_port":     "error",
+		"port_forwarding": "warn",
+	}
 	for _, c := range checks {
-		if c.Status == "ok" {
-			t.Errorf("check %q: expected non-ok status, got ok", c.Name)
+		want, ok := expected[c.Name]
+		if !ok {
+			t.Errorf("unexpected check %q", c.Name)
+			continue
+		}
+		if c.Status != want {
+			t.Errorf("check %q: got %s, want %s", c.Name, c.Status, want)
 		}
 	}
 }

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -3,6 +3,7 @@ package setup
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -620,5 +621,340 @@ env:
 	}
 	if !strings.Contains(plain, "Port:") || !strings.Contains(plain, "Redis:") {
 		t.Error("expected Port: and Redis: in summary output")
+	}
+}
+
+// --- BuildEnvVars tests ---
+
+func TestBuildEnvVars_BasicTokenInterpolation(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(`
+project: myapp
+env:
+  PORT: "{port}"
+  DATABASE_URL: "postgres://localhost/{database}"
+  REDIS_URL: "{redis_url}"
+`), 0o644)
+	pc := config.LoadProjectConfig(dir)
+
+	alloc := interpolation.Allocation{
+		"port":     float64(3010),
+		"database": "myapp_worktree",
+	}
+
+	result := BuildEnvVars(pc, alloc, "redis://localhost:6379/1")
+
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"PORT", "3010"},
+		{"DATABASE_URL", "postgres://localhost/myapp_worktree"},
+		{"REDIS_URL", "redis://localhost:6379/1"},
+	}
+	for _, tt := range tests {
+		if got := result[tt.key]; got != tt.want {
+			t.Errorf("%s = %q, want %q", tt.key, got, tt.want)
+		}
+	}
+}
+
+func TestBuildEnvVars_MultiPortReferences(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(`
+project: myapp
+env:
+  WEB_PORT: "{port_1}"
+  WORKER_PORT: "{port_2}"
+  PRIMARY_PORT: "{port}"
+`), 0o644)
+	pc := config.LoadProjectConfig(dir)
+
+	alloc := interpolation.Allocation{
+		"port":  float64(3010),
+		"ports": []any{float64(3010), float64(3011)},
+	}
+
+	result := BuildEnvVars(pc, alloc, "redis://localhost:6379")
+
+	tests := []struct {
+		key  string
+		want string
+	}{
+		{"WEB_PORT", "3010"},
+		{"WORKER_PORT", "3011"},
+		{"PRIMARY_PORT", "3010"},
+	}
+	for _, tt := range tests {
+		if got := result[tt.key]; got != tt.want {
+			t.Errorf("%s = %q, want %q", tt.key, got, tt.want)
+		}
+	}
+}
+
+func TestBuildEnvVars_EmptyEnvTemplate(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(`
+project: myapp
+`), 0o644)
+	pc := config.LoadProjectConfig(dir)
+
+	alloc := interpolation.Allocation{"port": float64(3010)}
+	result := BuildEnvVars(pc, alloc, "redis://localhost:6379")
+
+	if len(result) != 0 {
+		t.Errorf("expected empty map for empty env template, got %d entries", len(result))
+	}
+}
+
+func TestBuildEnvVars_MultipleVarsResolved(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(`
+project: myapp
+env:
+  PORT: "{port}"
+  APP_URL: "http://localhost:{port}"
+  DB: "{database}"
+  REDIS: "{redis_url}"
+  PROJECT: "{project}"
+`), 0o644)
+	pc := config.LoadProjectConfig(dir)
+
+	alloc := interpolation.Allocation{
+		"port":     float64(4000),
+		"database": "myapp_test",
+	}
+
+	result := BuildEnvVars(pc, alloc, "redis://localhost:6379/2")
+
+	expected := map[string]string{
+		"PORT":    "4000",
+		"APP_URL": "http://localhost:4000",
+		"DB":      "myapp_test",
+		"REDIS":   "redis://localhost:6379/2",
+		"PROJECT": "myapp",
+	}
+	for k, want := range expected {
+		if got := result[k]; got != want {
+			t.Errorf("%s = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// --- BuildEnvVarsWithResolver tests ---
+
+func TestBuildEnvVarsWithResolver_MockResolver(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(`
+project: myapp
+env:
+  PORT: "{port}"
+  API_URL: "{resolve:api}"
+`), 0o644)
+	pc := config.LoadProjectConfig(dir)
+
+	alloc := interpolation.Allocation{"port": float64(3010)}
+	resolver := func(project string, branch ...string) (string, error) {
+		if project == "api" {
+			return "http://localhost:3020", nil
+		}
+		return "", fmt.Errorf("unknown project: %s", project)
+	}
+
+	result, err := BuildEnvVarsWithResolver(pc, alloc, "redis://localhost:6379", resolver)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := result["PORT"]; got != "3010" {
+		t.Errorf("PORT = %q, want %q", got, "3010")
+	}
+	if got := result["API_URL"]; got != "http://localhost:3020" {
+		t.Errorf("API_URL = %q, want %q", got, "http://localhost:3020")
+	}
+}
+
+func TestBuildEnvVarsWithResolver_ErrorPropagates(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(`
+project: myapp
+env:
+  API_URL: "{resolve:missing}"
+`), 0o644)
+	pc := config.LoadProjectConfig(dir)
+
+	alloc := interpolation.Allocation{"port": float64(3010)}
+	resolver := func(project string, branch ...string) (string, error) {
+		return "", fmt.Errorf("not found: %s", project)
+	}
+
+	_, err := BuildEnvVarsWithResolver(pc, alloc, "redis://localhost:6379", resolver)
+	if err == nil {
+		t.Fatal("expected error from resolver, got nil")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}
+
+func TestBuildEnvVarsWithResolver_NilResolverLeavesTokens(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(`
+project: myapp
+env:
+  PORT: "{port}"
+  API_URL: "{resolve:api}"
+`), 0o644)
+	pc := config.LoadProjectConfig(dir)
+
+	alloc := interpolation.Allocation{"port": float64(3010)}
+
+	result, err := BuildEnvVarsWithResolver(pc, alloc, "redis://localhost:6379", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := result["PORT"]; got != "3010" {
+		t.Errorf("PORT = %q, want %q", got, "3010")
+	}
+	if got := result["API_URL"]; got != "{resolve:api}" {
+		t.Errorf("API_URL = %q, want %q (nil resolver should leave resolve tokens)", got, "{resolve:api}")
+	}
+}
+
+func TestBuildEnvVarsWithResolver_MixedTokens(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(`
+project: myapp
+env:
+  PORT: "{port}"
+  REDIS: "{redis_url}"
+  DB: "{database}"
+  API_URL: "{resolve:api}"
+  AUTH_URL: "{resolve:auth/main}"
+`), 0o644)
+	pc := config.LoadProjectConfig(dir)
+
+	alloc := interpolation.Allocation{
+		"port":     float64(3010),
+		"database": "myapp_wt",
+	}
+	resolver := func(project string, branch ...string) (string, error) {
+		urls := map[string]string{
+			"api":  "http://localhost:4000",
+			"auth": "http://localhost:5000",
+		}
+		if url, ok := urls[project]; ok {
+			return url, nil
+		}
+		return "", fmt.Errorf("unknown: %s", project)
+	}
+
+	result, err := BuildEnvVarsWithResolver(pc, alloc, "redis://localhost:6379/3", resolver)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := map[string]string{
+		"PORT":     "3010",
+		"REDIS":    "redis://localhost:6379/3",
+		"DB":       "myapp_wt",
+		"API_URL":  "http://localhost:4000",
+		"AUTH_URL": "http://localhost:5000",
+	}
+	for k, want := range expected {
+		if got := result[k]; got != want {
+			t.Errorf("%s = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// --- RunHookCommands tests ---
+
+func TestRunHookCommands_MultipleSuccessful(t *testing.T) {
+	dir := t.TempDir()
+	cmds := []string{
+		"touch first",
+		"touch second",
+	}
+
+	err := RunHookCommands("test", cmds, dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"first", "second"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("expected %s to exist after hook commands", name)
+		}
+	}
+}
+
+func TestRunHookCommands_FirstFailureStopsExecution(t *testing.T) {
+	dir := t.TempDir()
+	cmds := []string{
+		"exit 1",
+		"touch should_not_exist",
+	}
+
+	err := RunHookCommands("test", cmds, dir, nil)
+	if err == nil {
+		t.Fatal("expected error from failing command")
+	}
+	if !strings.Contains(err.Error(), "hook test failed") {
+		t.Errorf("expected 'hook test failed' in error, got: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "should_not_exist")); err == nil {
+		t.Error("second command should not have run after first failed")
+	}
+}
+
+func TestRunHookCommands_EmptyCommandList(t *testing.T) {
+	err := RunHookCommands("test", []string{}, t.TempDir(), nil)
+	if err != nil {
+		t.Errorf("expected nil error for empty command list, got: %v", err)
+	}
+}
+
+func TestRunHookCommands_LogReceivesMessages(t *testing.T) {
+	dir := t.TempDir()
+	cmds := []string{"true", "true"}
+
+	var logged []string
+	logFn := func(f string, a ...any) {
+		logged = append(logged, fmt.Sprintf(f, a...))
+	}
+
+	err := RunHookCommands("setup", cmds, dir, logFn)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(logged) != 2 {
+		t.Fatalf("expected 2 log messages, got %d", len(logged))
+	}
+	for i, msg := range logged {
+		if !strings.Contains(msg, "Hook [setup]") {
+			t.Errorf("log[%d] = %q, expected to contain 'Hook [setup]'", i, msg)
+		}
+	}
+}
+
+func TestRunHookCommands_RunsInSpecifiedDirectory(t *testing.T) {
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "proof")
+
+	cmds := []string{
+		fmt.Sprintf("test \"$(pwd)\" = \"%s\" && touch proof", dir),
+	}
+
+	err := RunHookCommands("test", cmds, dir, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Error("expected proof file to exist, command did not run in specified directory")
 	}
 }

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -131,11 +131,11 @@ func filterLineTo(stdout, stderr io.Writer, line string) {
 		strings.Contains(line, "WRN"),
 		strings.Contains(line, "failed"),
 		strings.Contains(line, "error"):
-		fmt.Fprintln(stderr, line)
+		_, _ = fmt.Fprintln(stderr, line)
 	case requestMethodRe.MatchString(line):
-		fmt.Fprintln(stdout, line)
+		_, _ = fmt.Fprintln(stdout, line)
 	case strings.Contains(line, "INF") && strings.Contains(line, "Registered"):
-		fmt.Fprintln(stdout, line)
+		_, _ = fmt.Fprintln(stdout, line)
 	}
 }
 

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -122,17 +122,20 @@ var requestMethodRe = regexp.MustCompile(`\b(GET|POST|PUT|PATCH|DELETE|HEAD|OPTI
 // FilterLine writes a single cloudflared log line to stdout/stderr if it
 // looks like an error, warning, or HTTP request.
 func FilterLine(line string) {
+	filterLineTo(os.Stdout, os.Stderr, line)
+}
+
+func filterLineTo(stdout, stderr io.Writer, line string) {
 	switch {
 	case strings.Contains(line, "ERR"),
 		strings.Contains(line, "WRN"),
 		strings.Contains(line, "failed"),
 		strings.Contains(line, "error"):
-		fmt.Fprintln(os.Stderr, line)
+		fmt.Fprintln(stderr, line)
 	case requestMethodRe.MatchString(line):
-		fmt.Println(line)
+		fmt.Fprintln(stdout, line)
 	case strings.Contains(line, "INF") && strings.Contains(line, "Registered"):
-		// Connection events are useful feedback
-		fmt.Println(line)
+		fmt.Fprintln(stdout, line)
 	}
 }
 

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -244,6 +244,16 @@ func LoginForDomain(domain string) error {
 		return err
 	}
 
+	return loginForDomainWith(domain, func() error {
+		cmd := exec.Command(cfPath, "tunnel", "login")
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
+	})
+}
+
+func loginForDomainWith(domain string, runLogin func() error) error {
 	defaultCertPath := filepath.Join(ConfigDir(), "cert.pem")
 
 	var backupPath string
@@ -254,12 +264,7 @@ func LoginForDomain(domain string) error {
 		}
 	}
 
-	cmd := exec.Command(cfPath, "tunnel", "login")
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		// Restore backup on failure
+	if err := runLogin(); err != nil {
 		if backupPath != "" {
 			_ = os.Rename(backupPath, defaultCertPath)
 		}
@@ -325,10 +330,14 @@ func TunnelExists(name string) bool {
 	if err != nil {
 		return false
 	}
+	return parseTunnelListHasName(out, name)
+}
+
+func parseTunnelListHasName(data []byte, name string) bool {
 	var tunnels []struct {
 		Name string `json:"name"`
 	}
-	if json.Unmarshal(out, &tunnels) != nil {
+	if json.Unmarshal(data, &tunnels) != nil {
 		return false
 	}
 	for _, t := range tunnels {
@@ -378,13 +387,17 @@ func RouteDNSWithCert(tunnelName, hostname, certPath string) error {
 // VerifyDNS checks if a hostname resolves (has DNS records).
 // Returns true if the hostname resolves within the timeout.
 func VerifyDNS(hostname string, timeout time.Duration) bool {
+	return verifyDNSWith(hostname, timeout, net.LookupHost, 2*time.Second)
+}
+
+func verifyDNSWith(hostname string, timeout time.Duration, lookup func(string) ([]string, error), interval time.Duration) bool {
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
-		_, err := net.LookupHost(hostname)
+		_, err := lookup(hostname)
 		if err == nil {
 			return true
 		}
-		time.Sleep(2 * time.Second)
+		time.Sleep(interval)
 	}
 	return false
 }
@@ -441,15 +454,19 @@ func lookupTunnelID(tunnelName string) string {
 	if err != nil {
 		return ""
 	}
+	return parseTunnelListID(out, tunnelName)
+}
+
+func parseTunnelListID(data []byte, name string) string {
 	var tunnels []struct {
 		ID   string `json:"id"`
 		Name string `json:"name"`
 	}
-	if json.Unmarshal(out, &tunnels) != nil {
+	if json.Unmarshal(data, &tunnels) != nil {
 		return ""
 	}
 	for _, t := range tunnels {
-		if strings.EqualFold(t.Name, tunnelName) {
+		if strings.EqualFold(t.Name, name) {
 			return t.ID
 		}
 	}

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -86,23 +86,36 @@ func TestFindCredentialsFile_NoFallbackScan(t *testing.T) {
 	}
 }
 
-func TestFilterLine_Errors(t *testing.T) {
+func TestFilterLine_OutputRouting(t *testing.T) {
 	cases := []struct {
-		line    string
-		printed bool
+		line       string
+		wantStdout bool
+		wantStderr bool
 	}{
-		{"2024 ERR failed to connect", true},
-		{"2024 WRN retrying in 5s", true},
-		{"2024 INF Registered tunnel connection", true},
-		{"2024 INF Starting tunnel", false},
-		{"GET /api/health 200 12ms", true},
-		{"POST /webhook 201 5ms", true},
-		{"some other log line", false},
-		{"connection failed to establish", true},
-		{"error: dial tcp", true},
+		{"2024 ERR failed to connect", false, true},
+		{"2024 WRN retrying in 5s", false, true},
+		{"2024 INF Registered tunnel connection", true, false},
+		{"2024 INF Starting tunnel", false, false},
+		{"GET /api/health 200 12ms", true, false},
+		{"POST /webhook 201 5ms", true, false},
+		{"some other log line", false, false},
+		{"connection failed to establish", false, true},
+		{"error: dial tcp", false, true},
 	}
 	for _, tc := range cases {
-		FilterLine(tc.line)
+		t.Run(tc.line, func(t *testing.T) {
+			var stdout, stderr strings.Builder
+			filterLineTo(&stdout, &stderr, tc.line)
+
+			gotStdout := stdout.Len() > 0
+			gotStderr := stderr.Len() > 0
+			if gotStdout != tc.wantStdout {
+				t.Errorf("stdout: got output=%v, want %v (content: %q)", gotStdout, tc.wantStdout, stdout.String())
+			}
+			if gotStderr != tc.wantStderr {
+				t.Errorf("stderr: got output=%v, want %v (content: %q)", gotStderr, tc.wantStderr, stderr.String())
+			}
+		})
 	}
 }
 
@@ -268,7 +281,10 @@ func TestLoginForDomain_Success_WithPriorCert(t *testing.T) {
 
 	// Domain cert should have the new content
 	domainCert := filepath.Join(cfDir, "cert-example.com.pem")
-	data, _ := os.ReadFile(domainCert)
+	data, err := os.ReadFile(domainCert)
+	if err != nil {
+		t.Fatalf("reading domain cert: %v", err)
+	}
 	if string(data) != "new-domain-cert" {
 		t.Errorf("domain cert = %q, want %q", string(data), "new-domain-cert")
 	}

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -1,11 +1,13 @@
 package tunnel
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestResolveCloudflared_ErrorWhenMissing(t *testing.T) {
@@ -208,5 +210,246 @@ func TestIsLoggedInForDomain(t *testing.T) {
 
 	if !IsLoggedInForDomain("example.com") {
 		t.Error("expected true when domain cert exists")
+	}
+}
+
+// --- loginForDomainWith tests ---
+
+func TestLoginForDomain_Success_NoPriorCert(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	cfDir := filepath.Join(dir, ".cloudflared")
+	_ = os.MkdirAll(cfDir, 0o700)
+
+	certPath := filepath.Join(cfDir, "cert.pem")
+
+	err := loginForDomainWith("example.com", func() error {
+		// Simulate cloudflared writing cert.pem
+		return os.WriteFile(certPath, []byte("new-cert"), 0o600)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// cert.pem should be moved to cert-example.com.pem
+	domainCert := filepath.Join(cfDir, "cert-example.com.pem")
+	data, err := os.ReadFile(domainCert)
+	if err != nil {
+		t.Fatal("expected domain cert to exist")
+	}
+	if string(data) != "new-cert" {
+		t.Errorf("domain cert content = %q, want %q", string(data), "new-cert")
+	}
+
+	// Original cert.pem should not exist (no prior cert to restore)
+	if _, err := os.Stat(certPath); err == nil {
+		t.Error("cert.pem should not exist when there was no prior cert")
+	}
+}
+
+func TestLoginForDomain_Success_WithPriorCert(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	cfDir := filepath.Join(dir, ".cloudflared")
+	_ = os.MkdirAll(cfDir, 0o700)
+
+	certPath := filepath.Join(cfDir, "cert.pem")
+	_ = os.WriteFile(certPath, []byte("original-cert"), 0o600)
+
+	err := loginForDomainWith("example.com", func() error {
+		// Simulate cloudflared writing new cert.pem
+		return os.WriteFile(certPath, []byte("new-domain-cert"), 0o600)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Domain cert should have the new content
+	domainCert := filepath.Join(cfDir, "cert-example.com.pem")
+	data, _ := os.ReadFile(domainCert)
+	if string(data) != "new-domain-cert" {
+		t.Errorf("domain cert = %q, want %q", string(data), "new-domain-cert")
+	}
+
+	// Original cert.pem should be restored from backup
+	data, err = os.ReadFile(certPath)
+	if err != nil {
+		t.Fatal("expected original cert.pem to be restored")
+	}
+	if string(data) != "original-cert" {
+		t.Errorf("restored cert = %q, want %q", string(data), "original-cert")
+	}
+
+	// Backup should be cleaned up
+	if _, err := os.Stat(certPath + ".backup"); err == nil {
+		t.Error("backup file should not exist after successful login")
+	}
+}
+
+func TestLoginForDomain_Failure_RestoresBackup(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	cfDir := filepath.Join(dir, ".cloudflared")
+	_ = os.MkdirAll(cfDir, 0o700)
+
+	certPath := filepath.Join(cfDir, "cert.pem")
+	_ = os.WriteFile(certPath, []byte("original-cert"), 0o600)
+
+	err := loginForDomainWith("example.com", func() error {
+		return fmt.Errorf("login cancelled")
+	})
+	if err == nil {
+		t.Fatal("expected error from failed login")
+	}
+
+	// Original cert.pem should be restored
+	data, err := os.ReadFile(certPath)
+	if err != nil {
+		t.Fatal("expected cert.pem to be restored after failure")
+	}
+	if string(data) != "original-cert" {
+		t.Errorf("restored cert = %q, want %q", string(data), "original-cert")
+	}
+
+	// No domain cert should exist
+	domainCert := filepath.Join(cfDir, "cert-example.com.pem")
+	if _, err := os.Stat(domainCert); err == nil {
+		t.Error("domain cert should not exist after failed login")
+	}
+}
+
+func TestLoginForDomain_Failure_NoPriorCert(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	cfDir := filepath.Join(dir, ".cloudflared")
+	_ = os.MkdirAll(cfDir, 0o700)
+
+	err := loginForDomainWith("example.com", func() error {
+		return fmt.Errorf("login cancelled")
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	// No files should exist
+	if _, err := os.Stat(filepath.Join(cfDir, "cert.pem")); err == nil {
+		t.Error("no cert.pem should exist")
+	}
+	if _, err := os.Stat(filepath.Join(cfDir, "cert-example.com.pem")); err == nil {
+		t.Error("no domain cert should exist")
+	}
+}
+
+// --- verifyDNSWith tests ---
+
+func TestVerifyDNS_ImmediateSuccess(t *testing.T) {
+	ok := verifyDNSWith("example.com", 5*time.Second, func(host string) ([]string, error) {
+		return []string{"1.2.3.4"}, nil
+	}, time.Millisecond)
+	if !ok {
+		t.Error("expected true for immediate DNS resolution")
+	}
+}
+
+func TestVerifyDNS_Timeout(t *testing.T) {
+	ok := verifyDNSWith("example.com", 50*time.Millisecond, func(host string) ([]string, error) {
+		return nil, fmt.Errorf("NXDOMAIN")
+	}, 10*time.Millisecond)
+	if ok {
+		t.Error("expected false when DNS never resolves")
+	}
+}
+
+func TestVerifyDNS_RetryThenSucceed(t *testing.T) {
+	attempts := 0
+	ok := verifyDNSWith("example.com", 500*time.Millisecond, func(host string) ([]string, error) {
+		attempts++
+		if attempts >= 3 {
+			return []string{"1.2.3.4"}, nil
+		}
+		return nil, fmt.Errorf("NXDOMAIN")
+	}, 10*time.Millisecond)
+	if !ok {
+		t.Error("expected true after retries succeed")
+	}
+	if attempts < 3 {
+		t.Errorf("expected at least 3 attempts, got %d", attempts)
+	}
+}
+
+// --- parseTunnelListHasName tests ---
+
+func TestParseTunnelListHasName(t *testing.T) {
+	jsonData := []byte(`[
+		{"name": "gtl", "id": "abc-123"},
+		{"name": "staging", "id": "def-456"}
+	]`)
+
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"gtl", true},
+		{"GTL", true},
+		{"staging", true},
+		{"production", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTunnelListHasName(jsonData, tt.name)
+			if got != tt.want {
+				t.Errorf("parseTunnelListHasName(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTunnelListHasName_InvalidJSON(t *testing.T) {
+	if parseTunnelListHasName([]byte("not json"), "gtl") {
+		t.Error("expected false for invalid JSON")
+	}
+}
+
+func TestParseTunnelListHasName_EmptyList(t *testing.T) {
+	if parseTunnelListHasName([]byte("[]"), "gtl") {
+		t.Error("expected false for empty list")
+	}
+}
+
+// --- parseTunnelListID tests ---
+
+func TestParseTunnelListID(t *testing.T) {
+	jsonData := []byte(`[
+		{"name": "gtl", "id": "abc-123"},
+		{"name": "staging", "id": "def-456"}
+	]`)
+
+	tests := []struct {
+		name string
+		want string
+	}{
+		{"gtl", "abc-123"},
+		{"GTL", "abc-123"},
+		{"staging", "def-456"},
+		{"missing", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseTunnelListID(jsonData, tt.name)
+			if got != tt.want {
+				t.Errorf("parseTunnelListID(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseTunnelListID_InvalidJSON(t *testing.T) {
+	if parseTunnelListID([]byte("garbage"), "gtl") != "" {
+		t.Error("expected empty string for invalid JSON")
 	}
 }

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -488,3 +488,215 @@ func TestUnpushedCommitCount_NoRemote(t *testing.T) {
 		t.Errorf("expected 2 unpushed commits, got %d", count)
 	}
 }
+
+func TestCurrentBranch_OnBranch(t *testing.T) {
+	repo := initTestRepo(t)
+	got := CurrentBranch(repo)
+	if got != "main" {
+		t.Errorf("expected main, got %q", got)
+	}
+}
+
+func TestCurrentBranch_DetachedHEAD(t *testing.T) {
+	repo := initTestRepo(t)
+	run(t, repo, "git", "checkout", "--detach", "HEAD")
+
+	got := CurrentBranch(repo)
+	if got != "" {
+		t.Errorf("expected empty string for detached HEAD, got %q", got)
+	}
+}
+
+func TestCurrentBranch_InWorktree(t *testing.T) {
+	repo := initTestRepo(t)
+	run(t, repo, "git", "branch", "wt-branch")
+
+	wtDir := t.TempDir()
+	wtDir, _ = filepath.EvalSymlinks(wtDir)
+	wtPath := filepath.Join(wtDir, "wt-branch")
+
+	run(t, repo, "git", "worktree", "add", wtPath, "wt-branch")
+	defer func() {
+		cmd := exec.Command("git", "worktree", "remove", "--force", wtPath)
+		cmd.Dir = repo
+		_ = cmd.Run()
+	}()
+
+	got := CurrentBranch(wtPath)
+	if got != "wt-branch" {
+		t.Errorf("expected wt-branch, got %q", got)
+	}
+
+	gotMain := CurrentBranch(repo)
+	if gotMain != "main" {
+		t.Errorf("expected main repo still on main, got %q", gotMain)
+	}
+}
+
+func TestHasUncommittedChanges_Clean(t *testing.T) {
+	repo := initTestRepo(t)
+	if HasUncommittedChanges(repo) {
+		t.Error("expected no uncommitted changes on clean repo")
+	}
+}
+
+func TestHasUncommittedChanges_UnstagedChanges(t *testing.T) {
+	repo := initTestRepo(t)
+	file := filepath.Join(repo, "dirty.txt")
+	if err := os.WriteFile(file, []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(t, repo, "git", "add", "dirty.txt")
+	run(t, repo, "git", "commit", "-m", "add file")
+
+	if err := os.WriteFile(file, []byte("modified"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if !HasUncommittedChanges(repo) {
+		t.Error("expected uncommitted changes with unstaged modification")
+	}
+}
+
+func TestHasUncommittedChanges_StagedChanges(t *testing.T) {
+	repo := initTestRepo(t)
+	file := filepath.Join(repo, "staged.txt")
+	if err := os.WriteFile(file, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(t, repo, "git", "add", "staged.txt")
+
+	if !HasUncommittedChanges(repo) {
+		t.Error("expected uncommitted changes with staged file")
+	}
+}
+
+func TestHasUncommittedChanges_AfterCommit(t *testing.T) {
+	repo := initTestRepo(t)
+	file := filepath.Join(repo, "committed.txt")
+	if err := os.WriteFile(file, []byte("content"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(t, repo, "git", "add", "committed.txt")
+	run(t, repo, "git", "commit", "-m", "commit file")
+
+	if HasUncommittedChanges(repo) {
+		t.Error("expected no uncommitted changes after commit")
+	}
+}
+
+func TestRemove_Worktree(t *testing.T) {
+	repo := initTestRepo(t)
+	run(t, repo, "git", "branch", "remove-test")
+
+	wtDir := t.TempDir()
+	wtDir, _ = filepath.EvalSymlinks(wtDir)
+	wtPath := filepath.Join(wtDir, "remove-test")
+
+	run(t, repo, "git", "worktree", "add", wtPath, "remove-test")
+
+	err := Remove(wtPath, false)
+	if err != nil {
+		t.Fatalf("Remove worktree failed: %v", err)
+	}
+
+	if _, statErr := os.Stat(wtPath); !os.IsNotExist(statErr) {
+		t.Error("expected worktree directory to be removed")
+	}
+}
+
+func TestRemove_MainWorktree(t *testing.T) {
+	repo := initTestRepo(t)
+
+	err := Remove(repo, false)
+	if err == nil {
+		t.Fatal("expected error when removing main worktree")
+	}
+	if !strings.Contains(err.Error(), "cannot remove the main worktree") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRemove_Force_DirtyWorktree(t *testing.T) {
+	repo := initTestRepo(t)
+	run(t, repo, "git", "branch", "dirty-wt")
+
+	wtDir := t.TempDir()
+	wtDir, _ = filepath.EvalSymlinks(wtDir)
+	wtPath := filepath.Join(wtDir, "dirty-wt")
+
+	run(t, repo, "git", "worktree", "add", wtPath, "dirty-wt")
+
+	file := filepath.Join(wtPath, "uncommitted.txt")
+	if err := os.WriteFile(file, []byte("dirty"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	run(t, wtPath, "git", "add", "uncommitted.txt")
+
+	err := Remove(wtPath, false)
+	if err == nil {
+		t.Fatal("expected error removing dirty worktree without force")
+	}
+
+	err = Remove(wtPath, true)
+	if err != nil {
+		t.Fatalf("force remove failed: %v", err)
+	}
+
+	if _, statErr := os.Stat(wtPath); !os.IsNotExist(statErr) {
+		t.Error("expected worktree directory to be removed after force")
+	}
+}
+
+func TestFetch_Success(t *testing.T) {
+	repo := initTestRepo(t)
+
+	remoteDir := t.TempDir()
+	remoteDir, _ = filepath.EvalSymlinks(remoteDir)
+	run(t, remoteDir, "git", "init", "--bare")
+
+	run(t, repo, "git", "remote", "add", "origin", remoteDir)
+	run(t, repo, "git", "push", "origin", "main")
+
+	orig, _ := os.Getwd()
+	_ = os.Chdir(repo)
+	defer func() { _ = os.Chdir(orig) }()
+
+	err := Fetch("origin", "main")
+	if err != nil {
+		t.Fatalf("Fetch failed: %v", err)
+	}
+}
+
+func TestFetch_NonexistentRemote(t *testing.T) {
+	repo := initTestRepo(t)
+
+	orig, _ := os.Getwd()
+	_ = os.Chdir(repo)
+	defer func() { _ = os.Chdir(orig) }()
+
+	err := Fetch("nonexistent-remote", "main")
+	if err == nil {
+		t.Error("expected error for non-existent remote")
+	}
+}
+
+func TestFetch_NonexistentBranch(t *testing.T) {
+	repo := initTestRepo(t)
+
+	remoteDir := t.TempDir()
+	remoteDir, _ = filepath.EvalSymlinks(remoteDir)
+	run(t, remoteDir, "git", "init", "--bare")
+
+	run(t, repo, "git", "remote", "add", "origin", remoteDir)
+	run(t, repo, "git", "push", "origin", "main")
+
+	orig, _ := os.Getwd()
+	_ = os.Chdir(repo)
+	defer func() { _ = os.Chdir(orig) }()
+
+	err := Fetch("origin", "nonexistent-branch-xyz")
+	if err == nil {
+		t.Error("expected error for non-existent branch")
+	}
+}

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -40,6 +40,11 @@ func run(t *testing.T, dir string, name string, args ...string) {
 	}
 }
 
+// TODO: These tests use os.Chdir because several worktree functions rely on
+// process-wide cwd rather than accepting a dir parameter. This makes them
+// incompatible with t.Parallel(). The long-term fix is to thread dir through
+// the production API (Create, BranchExists, Checkout, ListBranches, etc.).
+
 func TestCreateNewBranch(t *testing.T) {
 	repo := initTestRepo(t)
 	wtDir := t.TempDir()


### PR DESCRIPTION
## Summary

- Add ~90 new test functions covering previously untested decision logic across 8 packages
- Introduce lightweight DI seams (extracted helpers, func params, deps structs) to make subprocess-dependent code testable without shelling out
- Fix a real bug: `PostgreSQL.Drop` was missing identifier validation present on every other method
- Refactor `FilterLine` to accept `io.Writer` params, eliminating global stdout/stderr swaps in tests
- Document the project's testing conventions and DI preference order in CONTRIBUTING.md

### Packages covered

| Package | What's tested |
|---------|--------------|
| `setup` | BuildEnvVars, BuildEnvVarsWithResolver, RunHookCommands |
| `worktree` | CurrentBranch, HasUncommittedChanges, Remove, Fetch |
| `detect` | IsServerFramework (all framework classifications) |
| `database` | PostgreSQL Exists/Clone/Drop/Restore, SQLite Restore (with stdin verification) |
| `service` | CheckHealth orchestration via injectable healthDeps |
| `tunnel` | LoginForDomain cert management, VerifyDNS retry, tunnel list parsing, FilterLine output routing |
| `cmd/` | resolveDBPaths, classifyPortConfig, isInsideDir |

### Review process

Two full review passes with subagents identified and fixed:
- FilterLine test was a no-op (called function, never checked output)
- SQLite Restore test didn't verify stdin piping (false coverage)
- PostgreSQL pg_restore assertion only checked 2 of 5 args
- Health AllBroken test only checked "not ok" instead of exact statuses
- Restore failure mock was coupled to call order instead of command name

## Test plan

- [x] `go test ./... -count=1 -race` — 26 packages pass, zero races
- [x] `go build -o /tmp/gtl-smoke .` + smoke test all modified commands
- [x] `gtl doctor`, `gtl doctor --json`, `gtl serve status`, `gtl db name`, `gtl release`, `gtl init --help` all produce expected output