### PR TITLE
Suppress usage output for domain errors

### DIFF
--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -45,14 +45,14 @@ The server is NOT auto-started. Review the project, then run 'gtl start'.`,
 		}
 
 		if err := requireServeInstalled(); err != nil {
-			return err
+			return cliErr(cmd, err)
 		}
 
 		if len(args) == 0 {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: "Repository URL is required.",
 				Hint:    "Usage: gtl clone <url> [directory] [git clone flags...]",
-			}
+			})
 		}
 
 		url := args[0]
@@ -78,10 +78,10 @@ The server is NOT auto-started. Review the project, then run 'gtl start'.`,
 			return err
 		}
 		if st, err := os.Stat(absPath); err != nil || !st.IsDir() {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Cloned repository not found at %s", absPath),
 				Hint:    "The git clone succeeded but the expected directory is missing. Check the repo name.",
-			}
+			})
 		}
 
 		uc := config.LoadUserConfig("")
@@ -120,7 +120,7 @@ The server is NOT auto-started. Review the project, then run 'gtl start'.`,
 		s := setup.New(absPath, absPath, uc)
 		alloc, err := s.Run()
 		if err != nil {
-			return errSetupFailed(err)
+			return cliErr(cmd, errSetupFailed(err))
 		}
 
 		printRouterAndTunnel(uc, s.ProjectConfig.Project(), alloc.Branch)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -79,10 +79,10 @@ var configGetCmd = &cobra.Command{
 		uc := config.LoadUserConfig("")
 		val := uc.Get(args[0])
 		if val == nil {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Key %q not found.", args[0]),
 				Hint:    "Use 'gtl config list' to see all keys, or 'gtl config set <key> <value>' to create one.",
-			}
+			})
 		}
 		switch v := val.(type) {
 		case map[string]any:

--- a/cmd/db.go
+++ b/cmd/db.go
@@ -94,10 +94,10 @@ in .treeline.yml. Use --from to clone from a different database instead.`,
 			source = dbResetFrom
 		}
 		if source == "" {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: "No template database configured and no --from specified.",
 				Hint:    "Set 'database.template' in .treeline.yml, or pass --from <db_name>.",
-			}
+			})
 		}
 
 		fmt.Printf("==> Dropping %s\n", info.target)
@@ -124,10 +124,10 @@ pg_dump file. Supports both custom format and plain SQL dumps.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dumpFile := args[0]
 		if _, err := os.Stat(dumpFile); err != nil {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Dump file not found: %s", dumpFile),
 				Hint:    "Check the path — expected a pg_dump output file (custom or plain SQL).",
-			}
+			})
 		}
 
 		info, err := resolveDB()

--- a/cmd/editor.go
+++ b/cmd/editor.go
@@ -32,7 +32,7 @@ var editorRefreshCmd = &cobra.Command{
 		// Load from worktree (not mainRepo) so branch-specific config is respected
 		pc := config.LoadProjectConfig(absPath)
 		if pc.Project() == "" {
-			return errNoProjectConfig()
+			return cliErr(cmd, errNoProjectConfig())
 		}
 
 		uc := config.LoadUserConfig("")

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -68,16 +68,16 @@ var envShowCmd = &cobra.Command{
 		reg := registry.New("")
 		entry := reg.Find(absPath)
 		if entry == nil {
-			return errNoAllocation(absPath)
+			return cliErr(cmd, errNoAllocation(absPath))
 		}
 
 		envPath := filepath.Join(absPath, pc.EnvFileTarget())
 		if _, err := os.Stat(envPath); err != nil {
 			if os.IsNotExist(err) {
-				return &CliError{
+				return cliErr(cmd, &CliError{
 					Message: fmt.Sprintf("Env file does not exist: %s", envPath),
 					Hint:    "Run 'gtl setup' to generate it from .treeline.yml env: template.",
-				}
+				})
 			}
 			return err
 		}

--- a/cmd/env_sync.go
+++ b/cmd/env_sync.go
@@ -36,17 +36,17 @@ Use this when you've edited .treeline.yml and don't use 'gtl start'
 		reg := registry.New("")
 		entry := reg.Find(absPath)
 		if entry == nil {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("No allocation found for %s", absPath),
 				Hint:    "Run 'gtl setup' first to allocate ports and generate the env file.",
-			}
+			})
 		}
 
 		if err := setup.RegenerateEnvFile(absPath, uc); err != nil {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Env sync failed: %s", err),
 				Hint:    "Check your env: block in .treeline.yml. If using {resolve:...} tokens, ensure the linked project is allocated.",
-			}
+			})
 		}
 
 		tmpl := pc.EnvTemplate()

--- a/cmd/error.go
+++ b/cmd/error.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/git-treeline/git-treeline/internal/style"
+	"github.com/spf13/cobra"
 )
 
 // CliError is a user-facing error with optional remediation hint and docs link.
@@ -18,6 +19,17 @@ type CliError struct {
 
 func (e *CliError) Error() string {
 	return e.Message
+}
+
+// cliErr marks the command to suppress usage output and returns the error.
+// Use this for domain/state errors where the user invoked the command correctly
+// but something in the environment prevents success. Cobra's default usage
+// display remains active for invocation errors (wrong args, invalid flags).
+func cliErr(cmd *cobra.Command, err error) error {
+	if err != nil {
+		cmd.SilenceUsage = true
+	}
+	return err
 }
 
 // formatCliError writes a structured error to stderr. Regular errors get a

--- a/cmd/error_test.go
+++ b/cmd/error_test.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCliErr_SuppressesUsageOnError(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Test command",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cliErr(cmd, &CliError{
+				Message: "Something went wrong",
+				Hint:    "Try again",
+			})
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	if !cmd.SilenceUsage {
+		t.Error("expected SilenceUsage to be true after cliErr")
+	}
+}
+
+func TestCliErr_DoesNotSuppressOnNil(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Test command",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return cliErr(cmd, nil)
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cmd.SilenceUsage {
+		t.Error("expected SilenceUsage to remain false when error is nil")
+	}
+}
+
+func TestCliErr_PreservesUsageForCobraErrors(t *testing.T) {
+	cmd := &cobra.Command{
+		Use:   "test",
+		Short: "Test command",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return nil
+		},
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	cmd.SetArgs([]string{}) // wrong number of args
+	_ = cmd.Execute()
+
+	// Cobra's arg validation error should NOT silence usage
+	if cmd.SilenceUsage {
+		t.Error("expected SilenceUsage to remain false for Cobra validation errors")
+	}
+}

--- a/cmd/guard_test.go
+++ b/cmd/guard_test.go
@@ -135,6 +135,71 @@ func TestGuard_NoOsExitInCmdRunE(t *testing.T) {
 	}
 }
 
+// TestGuard_CliErrorUsesCliErr ensures all CliError returns in RunE functions
+// use cliErr() to suppress usage output for domain errors.
+func TestGuard_CliErrorUsesCliErr(t *testing.T) {
+	violations := scanGoFiles(t, ".", func(fset *token.FileSet, f *ast.File, path string) []string {
+		base := filepath.Base(path)
+		if strings.HasSuffix(base, "_test.go") || base == "error.go" {
+			return nil
+		}
+
+		var hits []string
+
+		ast.Inspect(f, func(n ast.Node) bool {
+			// Look for RunE function literals in cobra.Command definitions
+			if kv, ok := n.(*ast.KeyValueExpr); ok {
+				if ident, ok := kv.Key.(*ast.Ident); ok && ident.Name == "RunE" {
+					ast.Inspect(kv.Value, func(inner ast.Node) bool {
+						if ret, ok := inner.(*ast.ReturnStmt); ok {
+							for _, result := range ret.Results {
+								if isBareCLIError(result) {
+									pos := fset.Position(ret.Pos())
+									hits = append(hits, pos.String())
+								}
+							}
+						}
+						return true
+					})
+					return false
+				}
+			}
+			return true
+		})
+		return hits
+	})
+
+	if len(violations) > 0 {
+		t.Errorf("Bare CliError returns found in RunE (use cliErr(cmd, ...) to suppress usage):\n  %s",
+			strings.Join(violations, "\n  "))
+	}
+}
+
+// isBareCLIError returns true if the expression is a direct &CliError{} or
+// errXxx() call that's not wrapped in cliErr().
+func isBareCLIError(expr ast.Expr) bool {
+	// Check for &CliError{...}
+	if unary, ok := expr.(*ast.UnaryExpr); ok {
+		if comp, ok := unary.X.(*ast.CompositeLit); ok {
+			if ident, ok := comp.Type.(*ast.Ident); ok && ident.Name == "CliError" {
+				return true
+			}
+		}
+	}
+
+	// Check for errXxx() calls that aren't wrapped in cliErr()
+	if call, ok := expr.(*ast.CallExpr); ok {
+		if ident, ok := call.Fun.(*ast.Ident); ok {
+			// errXxx constructors should be wrapped
+			if strings.HasPrefix(ident.Name, "err") && ident.Name != "err" {
+				return true
+			}
+		}
+	}
+
+	return false
+}
+
 type inspectFunc func(fset *token.FileSet, f *ast.File, path string) []string
 
 func scanGoFiles(t *testing.T, dir string, fn inspectFunc) []string {

--- a/cmd/init_cmd.go
+++ b/cmd/init_cmd.go
@@ -36,10 +36,10 @@ var initCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path := filepath.Join(".", config.ProjectConfigFile)
 		if _, err := os.Stat(path); err == nil {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: ".treeline.yml already exists.",
 				Hint:    "Edit the existing file, or delete it and re-run 'gtl init'.",
-			}
+			})
 		}
 
 		uc := config.LoadUserConfig("")

--- a/cmd/link.go
+++ b/cmd/link.go
@@ -51,10 +51,10 @@ Examples:
 			return listLinks(reg, absPath)
 		}
 		if len(args) != 2 {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: "Missing arguments.",
 				Hint:    "Usage: gtl link <project> <branch>",
-			}
+			})
 		}
 
 		project := args[0]
@@ -62,15 +62,15 @@ Examples:
 
 		alloc := reg.Find(absPath)
 		if alloc == nil {
-			return errNoAllocation(absPath)
+			return cliErr(cmd, errNoAllocation(absPath))
 		}
 
 		target := reg.FindProjectBranch(project, branch)
 		if target == nil {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("No allocation for project %q on branch %q.", project, branch),
 				Hint:    "Run 'gtl setup' in that worktree first.",
-			}
+			})
 		}
 
 		if err := reg.SetLink(absPath, project, branch); err != nil {

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -46,7 +46,7 @@ Otherwise a new branch is created from --base (or the current branch).`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := worktreeGuard(cmd, args); err != nil {
-			return err
+			return cliErr(cmd, err)
 		}
 
 		branch := args[0]
@@ -83,7 +83,7 @@ Otherwise a new branch is created from --base (or the current branch).`,
 		}
 
 		if err := requireServeInstalled(); err != nil {
-			return err
+			return cliErr(cmd, err)
 		}
 
 		projectName := pc.Project()
@@ -111,7 +111,7 @@ Otherwise a new branch is created from --base (or the current branch).`,
 				fmt.Println(style.Actionf("No allocation found — running setup..."))
 				s := setup.New(existingWT, mainRepo, uc)
 				if _, err := s.Run(); err != nil {
-					return errSetupFailed(err)
+					return cliErr(cmd, errSetupFailed(err))
 				}
 				reg = registry.New("")
 				alloc = reg.Find(existingWT)
@@ -194,7 +194,7 @@ Otherwise a new branch is created from --base (or the current branch).`,
 		s.Options.DryRun = false
 		alloc, err := s.Run()
 		if err != nil {
-			return errSetupFailed(err)
+			return cliErr(cmd, errSetupFailed(err))
 		}
 
 		printRouterAndTunnel(uc, projectName, alloc.Branch)

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -33,13 +33,13 @@ var openCmd = &cobra.Command{
 		reg := registry.New("")
 		entry := reg.Find(absPath)
 		if entry == nil {
-			return errNoAllocation(absPath)
+			return cliErr(cmd, errNoAllocation(absPath))
 		}
 
 		fa := format.Allocation(entry)
 		ports := format.GetPorts(fa)
 		if len(ports) == 0 {
-			return errNoAllocationNoPorts(absPath)
+			return cliErr(cmd, errNoAllocationNoPorts(absPath))
 		}
 
 		pc := config.LoadProjectConfig(absPath)
@@ -51,7 +51,7 @@ var openCmd = &cobra.Command{
 		url := buildOpenURL(ports[0], project, branch, uc.RouterDomain(), uc.RouterPort(), service.IsRunning(), service.IsPortForwardConfigured())
 
 		fmt.Printf("Opening %s\n", url)
-		return openBrowser(url)
+		return cliErr(cmd, openBrowser(url))
 	},
 }
 

--- a/cmd/port.go
+++ b/cmd/port.go
@@ -33,12 +33,12 @@ var portCmd = &cobra.Command{
 		reg := registry.New("")
 		entry := reg.Find(absPath)
 		if entry == nil {
-			return errNoAllocation(absPath)
+			return cliErr(cmd, errNoAllocation(absPath))
 		}
 
 		ports := format.GetPorts(format.Allocation(entry))
 		if len(ports) == 0 {
-			return errNoAllocationNoPorts(absPath)
+			return cliErr(cmd, errNoAllocationNoPorts(absPath))
 		}
 
 		if portJSON {

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -41,20 +41,20 @@ Related commands:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		listenPort, err := strconv.Atoi(args[0])
 		if err != nil || listenPort < 1 || listenPort > 65535 {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Invalid listen port: %s", args[0]),
 				Hint:    "Port must be a number between 1 and 65535.",
-			}
+			})
 		}
 
 		var targetPort int
 		if len(args) == 2 {
 			targetPort, err = strconv.Atoi(args[1])
 			if err != nil || targetPort < 1 || targetPort > 65535 {
-				return &CliError{
+				return cliErr(cmd, &CliError{
 					Message: fmt.Sprintf("Invalid target port: %s", args[1]),
 					Hint:    "Port must be a number between 1 and 65535.",
-				}
+				})
 			}
 		} else {
 			targetPort, err = inferTargetPort()
@@ -64,10 +64,10 @@ Related commands:
 		}
 
 		if listenPort == targetPort {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Listen port and target port are the same (%d).", listenPort),
 				Hint:    "The proxy needs different ports for listen and target.",
-			}
+			})
 		}
 
 		return proxy.Run(proxy.Options{

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -51,17 +51,17 @@ var releaseCmd = &cobra.Command{
 			modes++
 		}
 		if modes > 1 {
-			return errMutuallyExclusive("PATH, --project, and --all")
+			return cliErr(cmd, errMutuallyExclusive("PATH, --project, and --all"))
 		}
 
 		if releaseProject != "" {
-			return runReleaseBatch(releaseProject, false)
+			return cliErr(cmd, runReleaseBatch(releaseProject, false))
 		}
 		if releaseAll {
-			return runReleaseBatch("", true)
+			return cliErr(cmd, runReleaseBatch("", true))
 		}
 
-		return runReleaseSingle(args)
+		return cliErr(cmd, runReleaseSingle(args))
 	},
 }
 

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -36,19 +36,19 @@ resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := worktreeGuard(cmd, args); err != nil {
-			return err
+			return cliErr(cmd, err)
 		}
 
 		if err := requireServeInstalled(); err != nil {
-			return err
+			return cliErr(cmd, err)
 		}
 
 		prNumber, err := strconv.Atoi(args[0])
 		if err != nil {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Invalid PR number: %s", args[0]),
 				Hint:    "Pass the numeric PR number, e.g. 'gtl review 42'.",
-			}
+			})
 		}
 
 		fmt.Printf("==> Looking up PR #%d...\n", prNumber)
@@ -92,7 +92,7 @@ resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 				fmt.Println("==> No allocation found — running setup...")
 				s := setup.New(existing, mainRepo, uc)
 				if _, err := s.Run(); err != nil {
-					return errSetupFailed(err)
+					return cliErr(cmd, errSetupFailed(err))
 				}
 				reg = registry.New("")
 				alloc = reg.Find(existing)
@@ -128,7 +128,7 @@ resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 
 		fmt.Printf("==> Fetching origin/%s...\n", branch)
 		if err := worktree.Fetch("origin", branch); err != nil {
-			return errBranchNotFound(branch)
+			return cliErr(cmd, errBranchNotFound(branch))
 		}
 
 		fmt.Printf("==> Creating worktree at %s\n", wtPath)
@@ -140,7 +140,7 @@ resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 		s := setup.New(wtPath, mainRepo, uc)
 		alloc, err := s.Run()
 		if err != nil {
-			return errSetupFailed(err)
+			return cliErr(cmd, errSetupFailed(err))
 		}
 
 		if alloc != nil {

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -42,13 +42,13 @@ Examples:
 		reg := registry.New("")
 		entry := reg.Find(absPath)
 		if entry == nil {
-			return errNoAllocation(absPath)
+			return cliErr(cmd, errNoAllocation(absPath))
 		}
 
 		fa := format.Allocation(entry)
 		ports := format.GetPorts(fa)
 		if len(ports) == 0 {
-			return errNoAllocationNoPorts(absPath)
+			return cliErr(cmd, errNoAllocationNoPorts(absPath))
 		}
 
 		pc := config.LoadProjectConfig(absPath)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -76,10 +76,10 @@ Requires sudo for two things (explained before each prompt):
 After install, access worktrees at https://{project}-{branch}.{domain}`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("gtl serve requires macOS or Linux (detected %s).", runtime.GOOS),
 				Hint:    "Windows support via WSL2 is planned.",
-			}
+			})
 		}
 
 		gtlPath, err := os.Executable()
@@ -328,10 +328,10 @@ Aliases let you route non-gtl services through the router:
 
 		if len(args) == 0 {
 			if serveAliasRemove {
-				return &CliError{
+				return cliErr(cmd, &CliError{
 					Message: "Missing alias name.",
 					Hint:    "Usage: gtl serve alias --remove <name>",
-				}
+				})
 			}
 			aliases := uc.RouterAliases()
 			if len(aliases) == 0 {
@@ -349,16 +349,16 @@ Aliases let you route non-gtl services through the router:
 		if serveAliasRemove {
 			aliases, _ := config.Dig(uc.Data, "router", "aliases").(map[string]any)
 			if aliases == nil {
-				return &CliError{
+				return cliErr(cmd, &CliError{
 					Message: fmt.Sprintf("Alias %q not found.", name),
 					Hint:    "Run 'gtl serve alias' to list existing aliases.",
-				}
+				})
 			}
 			if _, exists := aliases[name]; !exists {
-				return &CliError{
+				return cliErr(cmd, &CliError{
 					Message: fmt.Sprintf("Alias %q not found.", name),
 					Hint:    "Run 'gtl serve alias' to list existing aliases.",
-				}
+				})
 			}
 			delete(aliases, name)
 			if err := uc.Save(); err != nil {
@@ -369,15 +369,15 @@ Aliases let you route non-gtl services through the router:
 		}
 
 		if len(args) < 2 {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: "Missing port for alias.",
 				Hint:    "Usage: gtl serve alias <name> <port>",
-			}
+			})
 		}
 
 		port, err := strconv.Atoi(args[1])
 		if err != nil || port < 1 || port > 65535 {
-			return errInvalidPort(args[1])
+			return cliErr(cmd, errInvalidPort(args[1]))
 		}
 
 		uc.Set("router.aliases."+name, float64(port))

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -59,7 +59,7 @@ resumes the server in the original terminal. Ctrl+C exits the supervisor.`,
 
 		startCommand := pc.StartCommand()
 		if startCommand == "" {
-			return errNoStartCommand()
+			return cliErr(cmd, errNoStartCommand())
 		}
 
 		warnPortWiring(startCommand, absPath)
@@ -87,28 +87,28 @@ resumes the server in the original terminal. Ctrl+C exits the supervisor.`,
 				if startAwait {
 					return awaitReady(sockPath)
 				}
-				return errServerAlreadyRunning()
+				return cliErr(cmd, errServerAlreadyRunning())
 			}
 			resp, err = supervisor.Send(sockPath, "start")
 			if err != nil {
 				return err
 			}
 			if strings.HasPrefix(resp, "error") {
-				return &CliError{
+				return cliErr(cmd, &CliError{
 					Message: fmt.Sprintf("Server error: %s", resp),
 					Hint:    "Check the server logs, or run 'gtl stop' and try again.",
-				}
+				})
 			}
 			fmt.Println("Server resumed.")
 			if startAwait {
-				return awaitReady(sockPath)
+				return cliErr(cmd, awaitReady(sockPath))
 			}
 			return nil
 		}
 
 		// Fresh start path — run pre_start hooks
 		if err := runPreStartHooks(activeHooks, port, absPath); err != nil {
-			return err
+			return cliErr(cmd, err)
 		}
 		if len(activeHooks) > 0 {
 			writeHooksState(sockPath, activeHooks)
@@ -132,10 +132,10 @@ resumes the server in the original terminal. Ctrl+C exits the supervisor.`,
 			for i := 0; i < 50; i++ {
 				select {
 				case err := <-svErr:
-					return &CliError{
+					return cliErr(cmd, &CliError{
 						Message: fmt.Sprintf("Supervisor exited before ready: %s", err),
 						Hint:    "Check commands.start in .treeline.yml — the process crashed on startup.",
-					}
+					})
 				default:
 				}
 				time.Sleep(100 * time.Millisecond)
@@ -146,15 +146,15 @@ resumes the server in the original terminal. Ctrl+C exits the supervisor.`,
 
 			select {
 			case err := <-svErr:
-				return &CliError{
+				return cliErr(cmd, &CliError{
 					Message: fmt.Sprintf("Supervisor exited before ready: %s", err),
 					Hint:    "Check commands.start in .treeline.yml — the process crashed on startup.",
-				}
+				})
 			default:
 			}
 
 			if err := awaitReady(sockPath); err != nil {
-				return err
+				return cliErr(cmd, err)
 			}
 			return nil
 		}
@@ -193,10 +193,10 @@ supervisor entirely.`,
 			return err
 		}
 		if strings.HasPrefix(resp, "error") {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Server error: %s", resp),
 				Hint:    "The supervisor may be in an unexpected state. Check 'gtl start' output.",
-			}
+			})
 		}
 
 		if stopKill {
@@ -240,16 +240,16 @@ var restartCmd = &cobra.Command{
 
 		resp, err := supervisor.Send(sockPath, "restart")
 		if err != nil {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Could not reach supervisor: %s", err),
 				Hint:    "Is 'gtl start' running? Start the server first, then use 'gtl restart'.",
-			}
+			})
 		}
 		if strings.HasPrefix(resp, "error") {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Server error: %s", resp),
 				Hint:    "The server may have crashed. Check logs and try 'gtl stop' then 'gtl start'.",
-			}
+			})
 		}
 		fmt.Println("Server restarted.")
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -54,7 +54,7 @@ var setupCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if err := requireServeInstalled(); err != nil {
-			return err
+			return cliErr(cmd, err)
 		}
 
 		path := "."

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -48,7 +48,7 @@ Must be run from inside a worktree (not the main repo).`,
 		resolvedAbs, _ := filepath.EvalSymlinks(absPath)
 		resolvedMain, _ := filepath.EvalSymlinks(mainRepo)
 		if resolvedAbs == resolvedMain {
-			return errNotInWorktree()
+			return cliErr(cmd, errNotInWorktree())
 		}
 
 		branch := target

--- a/cmd/tunnel.go
+++ b/cmd/tunnel.go
@@ -69,13 +69,13 @@ Related commands:
 		if domain != "" {
 			tunnelName := uc.TunnelName(tunnelConfigName)
 			if tunnelName == "" {
-				return &CliError{
-				Message: "Tunnel domain is configured but no tunnel name found.",
-				Hint:    "Run 'gtl tunnel setup' to complete configuration.",
-			}
+				return cliErr(cmd, &CliError{
+					Message: "Tunnel domain is configured but no tunnel name found.",
+					Hint:    "Run 'gtl tunnel setup' to complete configuration.",
+				})
 			}
 			if err := validateTunnelPrereqs(tunnelName); err != nil {
-				return err
+				return cliErr(cmd, err)
 			}
 
 			project, branch := resolveProjectAndBranch(entry)
@@ -111,22 +111,22 @@ account that owns that zone. gtl stores per-domain credentials automatically.`,
 
 		if _, err := tunnel.ResolveCloudflared(); err != nil {
 			if !confirm.Prompt("cloudflared not found. Install it?", false, nil) {
-				return &CliError{
+				return cliErr(cmd, &CliError{
 					Message: "cloudflared is required for tunnel setup.",
 					Hint:    "Install it with 'brew install cloudflare/cloudflare/cloudflared' or see https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/",
-				}
+				})
 			}
 			if !tunnel.OfferInstall() {
-				return &CliError{
+				return cliErr(cmd, &CliError{
 					Message: "cloudflared still not found after install attempt.",
 					Hint:    "Install manually: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/",
-				}
+				})
 			}
 			if _, err := tunnel.ResolveCloudflared(); err != nil {
-				return &CliError{
+				return cliErr(cmd, &CliError{
 					Message: "cloudflared still not found after install attempt.",
 					Hint:    "Install manually: https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/",
-				}
+				})
 			}
 		}
 
@@ -149,10 +149,10 @@ account that owns that zone. gtl stores per-domain credentials automatically.`,
 		tunnelName = confirm.Input("Tunnel identifier", tunnelName, nil)
 		tunnelName = strings.TrimSpace(tunnelName)
 		if tunnelName == "" || strings.ContainsAny(tunnelName, " \t\n/\\:.") {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Invalid tunnel name %q.", tunnelName),
 				Hint:    "Use only letters, numbers, and hyphens (this is an identifier, not your domain).",
-			}
+			})
 		}
 
 		if !tunnel.TunnelExists(tunnelName) {
@@ -165,16 +165,16 @@ account that owns that zone. gtl stores per-domain credentials automatically.`,
 		existingDomain := uc.TunnelDomain("")
 		domain := strings.TrimSpace(confirm.Input("Domain (e.g. myteam.dev)", existingDomain, nil))
 		if domain == "" {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: "Domain is required for named tunnel setup.",
 				Hint:    "Enter the domain you manage in Cloudflare, e.g. myteam.dev",
-			}
+			})
 		}
 		if strings.ContainsAny(domain, " \t\n/:") || !strings.Contains(domain, ".") {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Invalid domain %q.", domain),
 				Hint:    "Expected a bare domain like myteam.dev (no protocol, path, or port).",
-			}
+			})
 		}
 
 		certPath := tunnel.CertPathForDomain(domain)
@@ -186,7 +186,7 @@ account that owns that zone. gtl stores per-domain credentials automatically.`,
 		wildcardHost := "*." + domain
 		fmt.Println(style.Actionf("Routing %s → tunnel %q", wildcardHost, tunnelName))
 		if err := tunnel.RouteDNSWithCert(tunnelName, wildcardHost, certPath); err != nil {
-			return printDNSManualInstructions(tunnelName, domain, err)
+			return cliErr(cmd, printDNSManualInstructions(tunnelName, domain, err))
 		}
 
 		// Verify DNS was created in the correct zone
@@ -210,14 +210,14 @@ account that owns that zone. gtl stores per-domain credentials automatically.`,
 			certPath = tunnel.CertPathForDomain(domain)
 				fmt.Println(style.Actionf("Routing %s → tunnel %q", wildcardHost, tunnelName))
 				if err := tunnel.RouteDNSWithCert(tunnelName, wildcardHost, certPath); err != nil {
-					return printDNSManualInstructions(tunnelName, domain, err)
+					return cliErr(cmd, printDNSManualInstructions(tunnelName, domain, err))
 				}
 
 			if !tunnel.VerifyDNS(testHost, 10*time.Second) {
-					return printDNSManualInstructions(tunnelName, domain, nil)
+					return cliErr(cmd, printDNSManualInstructions(tunnelName, domain, nil))
 				}
 			} else {
-				return printDNSManualInstructions(tunnelName, domain, nil)
+				return cliErr(cmd, printDNSManualInstructions(tunnelName, domain, nil))
 			}
 		}
 
@@ -352,10 +352,10 @@ With an argument, sets the default to the named tunnel config.
 		name := args[0]
 		configs := uc.TunnelConfigs()
 		if _, ok := configs[name]; !ok {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Tunnel %q not found in config.", name),
 				Hint:    fmt.Sprintf("Available tunnels: %v", tunnelConfigNames(configs)),
-			}
+			})
 		}
 		uc.Set("tunnel.default", name)
 		if err := uc.Save(); err != nil {
@@ -382,10 +382,10 @@ tunnels (random *.trycloudflare.com URLs).`,
 
 		configs := uc.TunnelConfigs()
 		if _, ok := configs[name]; !ok {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Tunnel %q not found in config.", name),
 				Hint:    fmt.Sprintf("Available tunnels: %v", tunnelConfigNames(configs)),
-			}
+			})
 		}
 
 		wasDefault := uc.TunnelDefault() == name

--- a/cmd/where.go
+++ b/cmd/where.go
@@ -56,10 +56,10 @@ Useful for scripting:
 		}
 
 		if len(matches) == 0 {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("No worktree found for branch %q", query),
 				Hint:    "Run 'gtl status' to see all worktrees.",
-			}
+			})
 		}
 
 		if len(matches) > 1 {
@@ -69,18 +69,18 @@ Useful for scripting:
 					projects = append(projects, p)
 				}
 			}
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Branch %q exists in multiple projects: %s", branch, strings.Join(projects, ", ")),
 				Hint:    fmt.Sprintf("Specify project: gtl where %s/%s", projects[0], branch),
-			}
+			})
 		}
 
 		worktree, _ := matches[0]["worktree"].(string)
 		if worktree == "" {
-			return &CliError{
+			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Allocation for branch %q has no worktree path", query),
 				Hint:    "The registry may be corrupted. Run 'gtl prune --stale' to clean up.",
-			}
+			})
 		}
 		fmt.Println(worktree)
 		return nil

--- a/cmd/worktree.go
+++ b/cmd/worktree.go
@@ -33,7 +33,7 @@ Example:
 		reg := registry.New("")
 		entry := reg.Find(absPath)
 		if entry == nil {
-			return errNoAllocation(absPath)
+			return cliErr(cmd, errNoAllocation(absPath))
 		}
 
 		wt, _ := entry["worktree"].(string)


### PR DESCRIPTION
## Summary

- Domain errors (config exists, no allocation, server running) now show only the error message — no usage block
- Invocation errors (wrong args, unknown flags) still show usage to help users
- Added `cliErr(cmd, err)` helper that sets `SilenceUsage` only when returning an actual error
- Added guard test that fails CI if someone adds a bare `CliError` return in `RunE`

## Before

```
$ gtl init
Usage:
  git-treeline init [flags]

Flags:
  -h, --help                 help for init
      --project string       Project name
      --skip-agent-config    Skip generating agent context files
      --template-db string   Template database name for cloning

Error: .treeline.yml already exists.

  Edit the existing file, or delete it and re-run 'gtl init'.
```

## After

```
$ gtl init
Error: .treeline.yml already exists.

  Edit the existing file, or delete it and re-run 'gtl init'.
```

## Test plan

- [x] `go test ./cmd/...` passes
- [x] `go vet ./cmd/...` clean
- [x] Smoke tested: domain errors suppress usage, invocation errors show usage