### PR TITLE
Fix WebSocket forwarding through router and proxy

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -38,7 +38,7 @@ func Run(opts Options) error {
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			pr.SetURL(target)
-			pr.Out.Host = pr.In.Host
+			pr.Out.Header.Set("X-Forwarded-Host", pr.In.Host)
 			if opts.TLS {
 				pr.Out.Header.Set("X-Forwarded-Proto", "https")
 			}

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -55,10 +55,11 @@ func TestProxyPreservesHostHeader(t *testing.T) {
 	targetPort := freePort(t)
 	listenPort := freePort(t)
 
-	var receivedHost string
+	var receivedHost, receivedFwdHost string
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		receivedHost = r.Host
+		receivedFwdHost = r.Header.Get("X-Forwarded-Host")
 		w.WriteHeader(http.StatusOK)
 	})
 	target := &http.Server{Addr: fmt.Sprintf(":%d", targetPort), Handler: mux}
@@ -79,8 +80,12 @@ func TestProxyPreservesHostHeader(t *testing.T) {
 	}
 	_ = resp.Body.Close()
 
-	if receivedHost != "myapp.localhost" {
-		t.Errorf("expected host 'myapp.localhost', got %q", receivedHost)
+	if receivedFwdHost != "myapp.localhost" {
+		t.Errorf("expected X-Forwarded-Host 'myapp.localhost', got %q", receivedFwdHost)
+	}
+	wantHost := fmt.Sprintf("127.0.0.1:%d", targetPort)
+	if receivedHost != wantHost {
+		t.Errorf("expected backend Host %q, got %q", wantHost, receivedHost)
 	}
 }
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -51,7 +51,7 @@ func TestProxyForwardsHTTP(t *testing.T) {
 	}
 }
 
-func TestProxyPreservesHostHeader(t *testing.T) {
+func TestProxyForwardsHostViaXForwardedHost(t *testing.T) {
 	targetPort := freePort(t)
 	listenPort := freePort(t)
 

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -207,7 +207,7 @@ func (r *Router) proxyTo(w http.ResponseWriter, req *http.Request, targetPort in
 	proxy := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
 			pr.SetURL(target)
-			pr.Out.Host = pr.In.Host
+			pr.Out.Header.Set("X-Forwarded-Host", pr.In.Host)
 			pr.Out.Header.Set("X-Gtl-Hops", strconv.Itoa(hops+1))
 			if pr.In.TLS != nil {
 				pr.Out.Header.Set("X-Forwarded-Proto", "https")

--- a/internal/proxy/router_test.go
+++ b/internal/proxy/router_test.go
@@ -563,9 +563,9 @@ func newWSBackend(t *testing.T, path string) int {
 		if err != nil {
 			return
 		}
-		defer conn.Close()
-		fmt.Fprintf(buf, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\n\r\n", accept)
-		buf.Flush()
+		defer func() { _ = conn.Close() }()
+		_, _ = fmt.Fprintf(buf, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\n\r\n", accept)
+		_ = buf.Flush()
 		frame := make([]byte, 256)
 		n, _ := conn.Read(frame)
 		_, _ = conn.Write(frame[:n])
@@ -586,18 +586,13 @@ func dialWebSocket(t *testing.T, tsURL, host, path string) string {
 	if err != nil {
 		t.Fatalf("dial: %v", err)
 	}
-	t.Cleanup(func() { conn.Close() })
+	t.Cleanup(func() { _ = conn.Close() })
 
 	key := base64.StdEncoding.EncodeToString([]byte("test-websocket-key!!"))
-	fmt.Fprintf(conn, "GET %s HTTP/1.1\r\n", path)
-	fmt.Fprintf(conn, "Host: %s\r\n", host)
-	fmt.Fprintf(conn, "Upgrade: websocket\r\n")
-	fmt.Fprintf(conn, "Connection: Upgrade\r\n")
-	fmt.Fprintf(conn, "Sec-WebSocket-Key: %s\r\n", key)
-	fmt.Fprintf(conn, "Sec-WebSocket-Version: 13\r\n")
-	fmt.Fprintf(conn, "\r\n")
+	_, _ = fmt.Fprintf(conn, "GET %s HTTP/1.1\r\nHost: %s\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Key: %s\r\nSec-WebSocket-Version: 13\r\n\r\n",
+		path, host, key)
 
-	conn.SetDeadline(time.Now().Add(3 * time.Second))
+	_ = conn.SetDeadline(time.Now().Add(3 * time.Second))
 	reader := bufio.NewReader(conn)
 	statusLine, err := reader.ReadString('\n')
 	if err != nil {
@@ -627,9 +622,9 @@ func TestRouterWebSocketUpgrade(t *testing.T) {
 		if err != nil {
 			return
 		}
-		defer conn.Close()
-		fmt.Fprintf(buf, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\n\r\n", accept)
-		buf.Flush()
+		defer func() { _ = conn.Close() }()
+		_, _ = fmt.Fprintf(buf, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\n\r\n", accept)
+		_ = buf.Flush()
 		frame := make([]byte, 256)
 		n, _ := conn.Read(frame)
 		_, _ = conn.Write(frame[:n])

--- a/internal/proxy/router_test.go
+++ b/internal/proxy/router_test.go
@@ -602,37 +602,11 @@ func dialWebSocket(t *testing.T, tsURL, host, path string) string {
 }
 
 func TestRouterWebSocketUpgrade(t *testing.T) {
-	targetPort := freePort(t)
-	var gotUpgrade, gotConn string
-	mux := http.NewServeMux()
-	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
-		gotUpgrade = r.Header.Get("Upgrade")
-		gotConn = r.Header.Get("Connection")
-		if !strings.EqualFold(gotUpgrade, "websocket") {
-			w.WriteHeader(http.StatusOK)
-			return
-		}
-		hj, ok := w.(http.Hijacker)
-		if !ok {
-			http.Error(w, "hijack not supported", http.StatusInternalServerError)
-			return
-		}
-		accept := wsAcceptKey(r.Header.Get("Sec-WebSocket-Key"))
-		conn, buf, err := hj.Hijack()
-		if err != nil {
-			return
-		}
-		defer func() { _ = conn.Close() }()
-		_, _ = fmt.Fprintf(buf, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\n\r\n", accept)
-		_ = buf.Flush()
-		frame := make([]byte, 256)
-		n, _ := conn.Read(frame)
-		_, _ = conn.Write(frame[:n])
-	})
-	srv := &http.Server{Addr: fmt.Sprintf(":%d", targetPort), Handler: mux}
-	go func() { _ = srv.ListenAndServe() }()
-	defer func() { _ = srv.Close() }()
-	waitForPort(t, targetPort)
+	// End-to-end: WebSocket upgrade through the router to a host-validating
+	// backend (mimicking Next.js/Vite). Proves the router rewrites Host to
+	// localhost so the backend accepts, while the external hostname travels
+	// via X-Forwarded-Host.
+	targetPort := newWSBackend(t, "/ws")
 
 	reg := testRegistry(t, []registry.Allocation{
 		{"project": "myapp", "branch": "main", "port": float64(targetPort), "ports": []any{float64(targetPort)}, "worktree": "/tmp/myapp"},
@@ -643,17 +617,16 @@ func TestRouterWebSocketUpgrade(t *testing.T) {
 
 	status := dialWebSocket(t, ts.URL, "myapp-main.prt.dev", "/ws")
 	if !strings.Contains(status, "101") {
-		t.Fatalf("expected 101 Switching Protocols, got: %s (Upgrade=%q Connection=%q)", status, gotUpgrade, gotConn)
+		t.Fatalf("expected 101 Switching Protocols, got: %s", status)
 	}
 }
 
 func TestRouterWebSocketBlockedWithoutForwardedHost(t *testing.T) {
-	// Verify that the host-validating backend would reject the request
-	// if the external hostname were passed through as Host (the old behavior).
-	targetPort := newWSBackend(t, "/_next/webpack-hmr")
+	// Proves the host-validating backend rejects the external hostname
+	// directly — this is the failure mode the fix addresses.
+	targetPort := newWSBackend(t, "/ws")
 
-	// Talk directly to the backend with an external Host header.
-	status := dialWebSocket(t, fmt.Sprintf("http://127.0.0.1:%d", targetPort), "myapp-main.prt.dev", "/_next/webpack-hmr")
+	status := dialWebSocket(t, fmt.Sprintf("http://127.0.0.1:%d", targetPort), "myapp-main.prt.dev", "/ws")
 	if !strings.Contains(status, "403") {
 		t.Fatalf("expected backend to reject external Host with 403, got: %s", status)
 	}

--- a/internal/proxy/router_test.go
+++ b/internal/proxy/router_test.go
@@ -1,15 +1,20 @@
 package proxy
 
 import (
+	"bufio"
+	"crypto/sha1"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/git-treeline/git-treeline/internal/registry"
 )
@@ -433,10 +438,10 @@ func TestRouterRegistryOverridesAlias(t *testing.T) {
 
 func TestRouterWildcardFallback(t *testing.T) {
 	targetPort := freePort(t)
-	var receivedHost string
+	var receivedFwdHost string
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		receivedHost = r.Host
+		receivedFwdHost = r.Header.Get("X-Forwarded-Host")
 		_, _ = fmt.Fprint(w, "wildcard ok")
 	})
 	target := &http.Server{Addr: fmt.Sprintf(":%d", targetPort), Handler: mux}
@@ -463,8 +468,8 @@ func TestRouterWildcardFallback(t *testing.T) {
 	if string(body) != "wildcard ok" {
 		t.Errorf("expected wildcard routing to work, got %q (status %d)", string(body), resp.StatusCode)
 	}
-	if !strings.Contains(receivedHost, "tenant1") {
-		t.Errorf("expected original Host header with tenant prefix, got %q", receivedHost)
+	if !strings.Contains(receivedFwdHost, "tenant1") {
+		t.Errorf("expected X-Forwarded-Host with tenant prefix, got %q", receivedFwdHost)
 	}
 }
 
@@ -517,6 +522,145 @@ func TestRouterRefreshPicksUpNewAllocations(t *testing.T) {
 	routes := router.Routes()
 	if routes["salt-main"] != 3001 {
 		t.Errorf("expected salt-main → 3001 after refresh, got %v", routes)
+	}
+}
+
+// wsAcceptKey computes the Sec-WebSocket-Accept value for a given key.
+func wsAcceptKey(key string) string {
+	h := sha1.New()
+	h.Write([]byte(key + "258EAFA5-E914-47DA-95CA-5AB5DF35BC65"))
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+// newWSBackend starts an HTTP server that accepts WebSocket upgrades on path,
+// rejecting requests whose Host header doesn't look like localhost (mimicking
+// Next.js / Vite dev-server host validation). Returns the port.
+func newWSBackend(t *testing.T, path string) int {
+	t.Helper()
+	port := freePort(t)
+	mux := http.NewServeMux()
+	mux.HandleFunc(path, func(w http.ResponseWriter, r *http.Request) {
+		// Reject non-localhost Host — same check Next.js/Vite do.
+		host := r.Host
+		if i := strings.LastIndex(host, ":"); i != -1 {
+			host = host[:i]
+		}
+		if host != "127.0.0.1" && host != "localhost" && host != "::1" {
+			http.Error(w, "forbidden: invalid Host header", http.StatusForbidden)
+			return
+		}
+		if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") {
+			http.Error(w, "expected websocket upgrade", http.StatusBadRequest)
+			return
+		}
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "hijack not supported", http.StatusInternalServerError)
+			return
+		}
+		accept := wsAcceptKey(r.Header.Get("Sec-WebSocket-Key"))
+		conn, buf, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		fmt.Fprintf(buf, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\n\r\n", accept)
+		buf.Flush()
+		frame := make([]byte, 256)
+		n, _ := conn.Read(frame)
+		_, _ = conn.Write(frame[:n])
+	})
+	srv := &http.Server{Addr: fmt.Sprintf(":%d", port), Handler: mux}
+	go func() { _ = srv.ListenAndServe() }()
+	t.Cleanup(func() { _ = srv.Close() })
+	waitForPort(t, port)
+	return port
+}
+
+// dialWebSocket sends a WebSocket upgrade request through the test server and
+// returns the HTTP status line.
+func dialWebSocket(t *testing.T, tsURL, host, path string) string {
+	t.Helper()
+	addr := strings.TrimPrefix(tsURL, "http://")
+	conn, err := net.DialTimeout("tcp", addr, 2*time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+
+	key := base64.StdEncoding.EncodeToString([]byte("test-websocket-key!!"))
+	fmt.Fprintf(conn, "GET %s HTTP/1.1\r\n", path)
+	fmt.Fprintf(conn, "Host: %s\r\n", host)
+	fmt.Fprintf(conn, "Upgrade: websocket\r\n")
+	fmt.Fprintf(conn, "Connection: Upgrade\r\n")
+	fmt.Fprintf(conn, "Sec-WebSocket-Key: %s\r\n", key)
+	fmt.Fprintf(conn, "Sec-WebSocket-Version: 13\r\n")
+	fmt.Fprintf(conn, "\r\n")
+
+	conn.SetDeadline(time.Now().Add(3 * time.Second))
+	reader := bufio.NewReader(conn)
+	statusLine, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	return statusLine
+}
+
+func TestRouterWebSocketUpgrade(t *testing.T) {
+	targetPort := freePort(t)
+	var gotUpgrade, gotConn string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
+		gotUpgrade = r.Header.Get("Upgrade")
+		gotConn = r.Header.Get("Connection")
+		if !strings.EqualFold(gotUpgrade, "websocket") {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "hijack not supported", http.StatusInternalServerError)
+			return
+		}
+		accept := wsAcceptKey(r.Header.Get("Sec-WebSocket-Key"))
+		conn, buf, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		fmt.Fprintf(buf, "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\nSec-WebSocket-Accept: %s\r\n\r\n", accept)
+		buf.Flush()
+		frame := make([]byte, 256)
+		n, _ := conn.Read(frame)
+		_, _ = conn.Write(frame[:n])
+	})
+	srv := &http.Server{Addr: fmt.Sprintf(":%d", targetPort), Handler: mux}
+	go func() { _ = srv.ListenAndServe() }()
+	defer func() { _ = srv.Close() }()
+	waitForPort(t, targetPort)
+
+	reg := testRegistry(t, []registry.Allocation{
+		{"project": "myapp", "branch": "main", "port": float64(targetPort), "ports": []any{float64(targetPort)}, "worktree": "/tmp/myapp"},
+	})
+	router := NewRouter(0, reg).WithBaseDomain("prt.dev")
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	status := dialWebSocket(t, ts.URL, "myapp-main.prt.dev", "/ws")
+	if !strings.Contains(status, "101") {
+		t.Fatalf("expected 101 Switching Protocols, got: %s (Upgrade=%q Connection=%q)", status, gotUpgrade, gotConn)
+	}
+}
+
+func TestRouterWebSocketBlockedWithoutForwardedHost(t *testing.T) {
+	// Verify that the host-validating backend would reject the request
+	// if the external hostname were passed through as Host (the old behavior).
+	targetPort := newWSBackend(t, "/_next/webpack-hmr")
+
+	// Talk directly to the backend with an external Host header.
+	status := dialWebSocket(t, fmt.Sprintf("http://127.0.0.1:%d", targetPort), "myapp-main.prt.dev", "/_next/webpack-hmr")
+	if !strings.Contains(status, "403") {
+		t.Fatalf("expected backend to reject external Host with 403, got: %s", status)
 	}
 }
 

--- a/internal/share/share.go
+++ b/internal/share/share.go
@@ -69,7 +69,7 @@ func NewTokenHandler(token string, appPort int) http.Handler {
 	rp := &httputil.ReverseProxy{
 		Rewrite: func(r *httputil.ProxyRequest) {
 			r.SetURL(target)
-			r.Out.Host = r.In.Host
+			r.Out.Header.Set("X-Forwarded-Host", r.In.Host)
 		},
 	}
 

--- a/internal/share/share_test.go
+++ b/internal/share/share_test.go
@@ -83,7 +83,10 @@ func TestTokenHandler_TokenPath_SetsCookieAndRedirects(t *testing.T) {
 }
 
 func TestTokenHandler_ValidCookie_Proxies(t *testing.T) {
+	var receivedHost, receivedFwdHost string
 	backend := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedHost = r.Host
+		receivedFwdHost = r.Header.Get("X-Forwarded-Host")
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok from backend"))
 	}))
@@ -96,6 +99,7 @@ func TestTokenHandler_ValidCookie_Proxies(t *testing.T) {
 	h := NewTokenHandler(token, port)
 
 	req := httptest.NewRequest(http.MethodGet, "/some/path", nil)
+	req.Host = "myapp.share.example.com"
 	req.AddCookie(&http.Cookie{Name: cookieName, Value: cookieValue(token)})
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, req)
@@ -105,6 +109,12 @@ func TestTokenHandler_ValidCookie_Proxies(t *testing.T) {
 	}
 	if body := rec.Body.String(); body != "ok from backend" {
 		t.Errorf("unexpected body: %q", body)
+	}
+	if receivedFwdHost != "myapp.share.example.com" {
+		t.Errorf("expected X-Forwarded-Host 'myapp.share.example.com', got %q", receivedFwdHost)
+	}
+	if receivedHost == "myapp.share.example.com" {
+		t.Errorf("backend Host should be localhost, not the external hostname; got %q", receivedHost)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Stop overriding `Host` header with the external hostname when proxying — use `X-Forwarded-Host` instead
- Dev servers (Next.js 15+, Vite) validate the `Host` header and reject WebSocket upgrades and static asset requests from unrecognized hostnames, causing `wss://` failures and 403s on `*.prt.dev` URLs
- Applied to all three proxy paths: router (`gtl serve`), simple proxy (`gtl proxy`), and share proxy (`gtl share`)

## Test plan
- [x] `TestRouterWebSocketUpgrade` — WebSocket upgrade through the router with `prt.dev` base domain succeeds (101)
- [x] `TestRouterWebSocketBlockedWithoutForwardedHost` — confirms host-validating backends reject the external hostname directly (the pre-fix failure mode)
- [x] Updated `TestProxyPreservesHostHeader` — backend sees `localhost:PORT` as Host, original in `X-Forwarded-Host`
- [x] Updated `TestRouterWildcardFallback` — asserts `X-Forwarded-Host` carries the original hostname
- [x] Full test suite passes (`go test ./...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)