### PR TITLE
Add --kill flag to gtl stop

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -27,12 +27,14 @@ import (
 var startAwait bool
 var startAwaitTimeout int
 var startWith string
+var stopKill bool
 
 func init() {
 	startCmd.Flags().BoolVar(&startAwait, "await", false, "Block until the server is accepting connections, then exit 0")
 	startCmd.Flags().IntVar(&startAwaitTimeout, "await-timeout", 60, "Timeout in seconds for --await")
 	startCmd.Flags().StringVar(&startWith, "with", "", "Comma-separated hooks to activate (defined in .treeline.yml hooks:)")
 	rootCmd.AddCommand(startCmd)
+	stopCmd.Flags().BoolVar(&stopKill, "kill", false, "Shut down the supervisor entirely instead of keeping it alive")
 	rootCmd.AddCommand(stopCmd)
 	rootCmd.AddCommand(restartCmd)
 }
@@ -173,14 +175,20 @@ var stopCmd = &cobra.Command{
 	Use:   "stop",
 	Short: "Stop the dev server (supervisor stays alive for resume)",
 	Long: `Stop the running dev server process. The supervisor remains alive so
-the server can be resumed with 'gtl start'. Use Ctrl+C in the original
-terminal to fully exit the supervisor.`,
+the server can be resumed with 'gtl start'. Use --kill to shut down the
+supervisor entirely.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		sockPath, err := resolveSocket()
 		if err != nil {
 			return err
 		}
-		resp, err := supervisor.Send(sockPath, "stop")
+
+		command := "stop"
+		if stopKill {
+			command = "shutdown"
+		}
+
+		resp, err := supervisor.Send(sockPath, command)
 		if err != nil {
 			return err
 		}
@@ -190,7 +198,12 @@ terminal to fully exit the supervisor.`,
 				Hint:    "The supervisor may be in an unexpected state. Check 'gtl start' output.",
 			}
 		}
-		fmt.Println("Server stopped. Supervisor still running — 'gtl start' to resume.")
+
+		if stopKill {
+			fmt.Println("Supervisor shut down.")
+		} else {
+			fmt.Println("Server stopped. Supervisor still running — 'gtl start' to resume.")
+		}
 		return nil
 	},
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -74,9 +74,12 @@ func registerTools(s *mcpserver.MCPServer) {
 	), handleStart)
 
 	s.AddTool(mcplib.NewTool("stop",
-		mcplib.WithDescription("Stop the dev server process but keep the supervisor alive. The server can be quickly resumed with start without re-initializing. Use this to free up resources while keeping the worktree ready."),
+		mcplib.WithDescription("Stop the dev server process but keep the supervisor alive. The server can be quickly resumed with start without re-initializing. Use this to free up resources while keeping the worktree ready. Set kill=true to shut down the supervisor entirely (useful when the supervisor is stuck or needs a full restart)."),
 		mcplib.WithString("path",
 			mcplib.Description("Absolute path to the worktree directory (defaults to cwd if omitted)"),
+		),
+		mcplib.WithBoolean("kill",
+			mcplib.Description("If true, shut down the supervisor entirely instead of keeping it alive for resume. Default: false"),
 		),
 	), handleStop)
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -282,6 +282,20 @@ func TestHandleStop_NotRunning(t *testing.T) {
 	}
 }
 
+func TestHandleStop_KillNotRunning(t *testing.T) {
+	req := mcplib.CallToolRequest{}
+	req.Params.Name = "stop"
+	req.Params.Arguments = map[string]any{"path": "/tmp/nonexistent-wt-for-test", "kill": true}
+
+	result, err := handleStop(context.Background(), req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !result.IsError {
+		t.Error("expected error when supervisor is not running")
+	}
+}
+
 func TestHandleRestart_NotRunning(t *testing.T) {
 	req := mcplib.CallToolRequest{}
 	req.Params.Name = "restart"

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -243,7 +243,15 @@ func handleStop(_ context.Context, req mcplib.CallToolRequest) (*mcplib.CallTool
 	absPath := resolvePath(req)
 	sockPath := supervisor.SocketPath(absPath)
 
-	resp, err := supervisor.Send(sockPath, "stop")
+	args := req.GetArguments()
+	kill, _ := args["kill"].(bool)
+
+	command := "stop"
+	if kill {
+		command = "shutdown"
+	}
+
+	resp, err := supervisor.Send(sockPath, command)
 	if err != nil {
 		return mcplib.NewToolResultError(fmt.Sprintf("Supervisor not running: %v", err)), nil
 	}
@@ -251,6 +259,9 @@ func handleStop(_ context.Context, req mcplib.CallToolRequest) (*mcplib.CallTool
 		return mcplib.NewToolResultError(resp), nil
 	}
 
+	if kill {
+		return mcplib.NewToolResultText("Supervisor shut down."), nil
+	}
 	return mcplib.NewToolResultText("Server stopped. Supervisor still running — use `start` to resume."), nil
 }
 


### PR DESCRIPTION
## Summary
- Adds `--kill` flag to `gtl stop` CLI that sends `shutdown` instead of `stop`, fully terminating the supervisor
- Adds `kill` boolean parameter to the MCP `stop` tool so AI agents can unstick users with zombie supervisors
- No new supervisor protocol changes — leverages the existing `shutdown` command

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — all passing, includes new `TestHandleStop_KillNotRunning`
- [x] Manual: `gtl start` then `gtl stop --kill` — supervisor should exit
- [x] Manual: `gtl stop` (no flag) — supervisor stays alive as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)