### PR TITLE
Expand TUI dashboard with v0.37.0 features

### DIFF
--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -410,6 +410,15 @@ func BuildRouterURL(port int, project, branch, domain string, routerPort int, sv
 	return fmt.Sprintf("http://localhost:%d", port)
 }
 
+// BuildTunnelURL returns the tunnel URL for a given project/branch when
+// a tunnel domain is configured, or an empty string if not applicable.
+func BuildTunnelURL(project, branch, tunnelDomain string) string {
+	if tunnelDomain == "" || branch == "" {
+		return ""
+	}
+	return "https://" + RouteKey(project, branch) + "." + tunnelDomain
+}
+
 const maxDNSLabel = 63
 
 func truncateDNSLabel(label string) string {

--- a/internal/tui/data.go
+++ b/internal/tui/data.go
@@ -2,10 +2,12 @@ package tui
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/git-treeline/git-treeline/internal/allocator"
 	"github.com/git-treeline/git-treeline/internal/config"
 	"github.com/git-treeline/git-treeline/internal/format"
+	"github.com/git-treeline/git-treeline/internal/proxy"
 	"github.com/git-treeline/git-treeline/internal/registry"
 	"github.com/git-treeline/git-treeline/internal/service"
 	"github.com/git-treeline/git-treeline/internal/supervisor"
@@ -25,6 +27,8 @@ type WorktreeStatus struct {
 	Links        map[string]string
 	Supervisor   string // "running", "stopped", or "not running"
 	Listening    bool
+	RouterURL    string
+	TunnelURL    string
 }
 
 // Snapshot is the full dashboard state captured by a single poll.
@@ -32,12 +36,20 @@ type Snapshot struct {
 	Worktrees    []WorktreeStatus
 	Projects     []string
 	ServeRunning bool
+	TunnelDomain string
 }
 
 // Poll reads the registry and probes each worktree's supervisor and ports.
 func Poll() Snapshot {
 	reg := registry.New("")
 	allocs := reg.Allocations()
+
+	uc := config.LoadUserConfig("")
+	domain := uc.RouterDomain()
+	routerPort := uc.RouterPort()
+	tunnelDomain := uc.TunnelDomain("")
+	svcRunning := service.IsRunning()
+	pfConfigured := service.IsPortForwardConfigured()
 
 	worktrees := make([]WorktreeStatus, 0, len(allocs))
 	projectSet := make(map[string]struct{})
@@ -79,6 +91,18 @@ func Poll() Snapshot {
 			redisDB = int(v)
 		}
 
+		// Only store actual router URLs (https://); localhost fallbacks are
+		// reconstructed on demand in openInBrowser().
+		var routerURL string
+		if len(ports) > 0 {
+			u := proxy.BuildRouterURL(ports[0], project, branch, domain, routerPort, svcRunning, pfConfigured)
+			if strings.HasPrefix(u, "https://") {
+				routerURL = u
+			}
+		}
+
+		tunnelURL := proxy.BuildTunnelURL(project, branch, tunnelDomain)
+
 		worktrees = append(worktrees, WorktreeStatus{
 			Project:      project,
 			Branch:       branch,
@@ -92,6 +116,8 @@ func Poll() Snapshot {
 			Links:        links,
 			Supervisor:   sv,
 			Listening:    listening,
+			RouterURL:    routerURL,
+			TunnelURL:    tunnelURL,
 		})
 	}
 
@@ -104,7 +130,8 @@ func Poll() Snapshot {
 	return Snapshot{
 		Worktrees:    worktrees,
 		Projects:     projects,
-		ServeRunning: service.IsRunning(),
+		ServeRunning: svcRunning,
+		TunnelDomain: tunnelDomain,
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1,12 +1,19 @@
 package tui
 
 import (
+	"fmt"
+	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/bubbles/v2/spinner"
 	"charm.land/lipgloss/v2"
+	"github.com/git-treeline/git-treeline/internal/config"
+	"github.com/git-treeline/git-treeline/internal/setup"
+	"github.com/git-treeline/git-treeline/internal/supervisor"
+	"github.com/git-treeline/git-treeline/internal/worktree"
 )
 
 const pollInterval = 2 * time.Second
@@ -18,6 +25,17 @@ const (
 	paneList focusPane = iota
 	paneDetail
 )
+
+// actionDeps holds injectable functions for side-effectful operations.
+// Production code sets these to real implementations; tests use stubs.
+type actionDeps struct {
+	supervisorSend  func(sockPath, command string) (string, error)
+	supervisorSock  func(worktreePath string) string
+	openURL         func(url string)
+	releaseWorktree func(worktreePath string) error
+	syncEnv         func(worktreePath string) error
+	createWorktree  func(existingWorktreePath, branch string) error
+}
 
 // Model is the root Bubble Tea model for the gtl dashboard.
 type Model struct {
@@ -36,6 +54,10 @@ type Model struct {
 	showHelp     bool
 	confirmKind  string // "release" or ""
 	quitting     bool
+	inputMode    string // "" or "new_worktree"
+	inputText    string
+	statusMsg    string // transient status message
+	deps         actionDeps
 }
 
 // flatEntry is a denormalized row in the worktree list.
@@ -61,13 +83,71 @@ func doPoll() tea.Cmd {
 	}
 }
 
+func defaultDeps() actionDeps {
+	return actionDeps{
+		supervisorSend: supervisor.Send,
+		supervisorSock: supervisor.SocketPath,
+		openURL:        openURLDefault,
+		releaseWorktree: func(wtPath string) error {
+			return exec.Command("git-treeline", "release", "--force", wtPath).Run()
+		},
+		syncEnv: func(wtPath string) error {
+			uc := config.LoadUserConfig("")
+			return setup.RegenerateEnvFile(wtPath, uc)
+		},
+		createWorktree: func(existingWorktreePath, branch string) error {
+			mainRepo := worktree.DetectMainRepo(existingWorktreePath)
+			if mainRepo == "" {
+				return fmt.Errorf("cannot detect main repo from %s", existingWorktreePath)
+			}
+			uc := config.LoadUserConfig("")
+			pc := config.LoadProjectConfig(mainRepo)
+			projectName := pc.Project()
+
+			wtPath := uc.ResolveWorktreePath(mainRepo, projectName, branch)
+			if wtPath == "" {
+				wtPath = mainRepo + "-" + branch
+			}
+
+			if worktree.BranchExists(branch) {
+				_ = worktree.Fetch("origin", branch)
+				if err := worktree.Create(wtPath, branch, false, ""); err != nil {
+					return err
+				}
+			} else {
+				base := worktree.DetectDefaultBranch(mainRepo)
+				if err := worktree.Create(wtPath, branch, true, base); err != nil {
+					return err
+				}
+			}
+
+			s := setup.New(wtPath, mainRepo, uc)
+			_, err := s.Run()
+			return err
+		},
+	}
+}
+
+func openURLDefault(url string) {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "linux":
+		cmd = exec.Command("xdg-open", url)
+	default:
+		return
+	}
+	_ = cmd.Start()
+}
+
 // NewModel creates the initial dashboard model.
 func NewModel() Model {
 	s := spinner.New(
 		spinner.WithSpinner(spinner.MiniDot),
 		spinner.WithStyle(lipgloss.NewStyle().Foreground(highlight)),
 	)
-	return Model{spinner: s, polling: true}
+	return Model{spinner: s, polling: true, deps: defaultDeps()}
 }
 
 func (m Model) Init() tea.Cmd {

--- a/internal/tui/tui_test.go
+++ b/internal/tui/tui_test.go
@@ -1,8 +1,10 @@
 package tui
 
 import (
+	"errors"
 	"testing"
 
+	tea "charm.land/bubbletea/v2"
 	"github.com/git-treeline/git-treeline/internal/registry"
 )
 
@@ -308,6 +310,429 @@ func TestExtractLinks_NonStringValues(t *testing.T) {
 	}
 }
 
+// --- input mode ---
+
+func TestInputMode_EnterClearsMode(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.inputMode = "new_worktree"
+	m.inputText = "feature-x"
+
+	result, _ := m.updateInput(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	rm := result.(Model)
+	if rm.inputMode != "" {
+		t.Errorf("expected inputMode cleared, got %q", rm.inputMode)
+	}
+}
+
+func TestInputMode_EscapeCancels(t *testing.T) {
+	m := buildTestModel()
+	m.inputMode = "new_worktree"
+	m.inputText = "feature-x"
+
+	result, _ := m.updateInput(tea.KeyPressMsg(tea.Key{Code: tea.KeyEscape}))
+	rm := result.(Model)
+	if rm.inputMode != "" {
+		t.Errorf("expected inputMode cleared, got %q", rm.inputMode)
+	}
+	if rm.inputText != "" {
+		t.Errorf("expected inputText cleared, got %q", rm.inputText)
+	}
+}
+
+func TestInputMode_EmptyEnterDoesNothing(t *testing.T) {
+	m := buildTestModel()
+	m.inputMode = "new_worktree"
+	m.inputText = ""
+
+	result, cmd := m.updateInput(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	rm := result.(Model)
+	if rm.inputMode != "" {
+		t.Errorf("expected inputMode cleared, got %q", rm.inputMode)
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd for empty input")
+	}
+}
+
+func TestInputMode_WhitespaceOnlyDoesNothing(t *testing.T) {
+	m := buildTestModel()
+	m.inputMode = "new_worktree"
+	m.inputText = "   "
+
+	_, cmd := m.updateInput(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	if cmd != nil {
+		t.Error("expected nil cmd for whitespace-only input")
+	}
+}
+
+func TestInputMode_RejectsWhitespaceCharacters(t *testing.T) {
+	m := buildTestModel()
+	m.inputMode = "new_worktree"
+	m.inputText = "feat"
+
+	result, _ := m.updateInput(tea.KeyPressMsg(tea.Key{Code: ' ', Text: " "}))
+	rm := result.(Model)
+	if rm.inputText != "feat" {
+		t.Errorf("expected space rejected, got %q", rm.inputText)
+	}
+}
+
+// --- statusMsg ---
+
+func TestStatusMsgClearedOnTick(t *testing.T) {
+	m := buildTestModel()
+	m.statusMsg = "env synced"
+
+	result, _ := m.Update(tickMsg{})
+	rm := result.(Model)
+	if rm.statusMsg != "" {
+		t.Errorf("expected statusMsg cleared on tick, got %q", rm.statusMsg)
+	}
+}
+
+func TestEnvSyncResultMsg_SetsStatusOnSuccess(t *testing.T) {
+	m := buildTestModel()
+	result, _ := m.Update(envSyncResultMsg{})
+	rm := result.(Model)
+	if rm.statusMsg != "env synced" {
+		t.Errorf("expected 'env synced', got %q", rm.statusMsg)
+	}
+}
+
+func TestEnvSyncResultMsg_SetsStatusOnError(t *testing.T) {
+	m := buildTestModel()
+	result, _ := m.Update(envSyncResultMsg{err: errors.New("fail")})
+	rm := result.(Model)
+	if rm.statusMsg != "env sync failed: fail" {
+		t.Errorf("expected error status, got %q", rm.statusMsg)
+	}
+}
+
+func TestNewWorktreeResultMsg_SetsStatus(t *testing.T) {
+	m := buildTestModel()
+	result, _ := m.Update(newWorktreeResultMsg{})
+	rm := result.(Model)
+	if rm.statusMsg != "worktree created" {
+		t.Errorf("expected 'worktree created', got %q", rm.statusMsg)
+	}
+}
+
+func TestNewWorktreeResultMsg_SetsStatusOnError(t *testing.T) {
+	m := buildTestModel()
+	result, _ := m.Update(newWorktreeResultMsg{err: errors.New("exists")})
+	rm := result.(Model)
+	if rm.statusMsg != "create failed: exists" {
+		t.Errorf("expected error status, got %q", rm.statusMsg)
+	}
+}
+
+func TestReleaseResultMsg_SetsStatusOnSuccess(t *testing.T) {
+	m := buildTestModel()
+	result, _ := m.Update(releaseResultMsg{})
+	rm := result.(Model)
+	if rm.statusMsg != "worktree released" {
+		t.Errorf("expected 'worktree released', got %q", rm.statusMsg)
+	}
+}
+
+func TestReleaseResultMsg_SetsStatusOnError(t *testing.T) {
+	m := buildTestModel()
+	result, _ := m.Update(releaseResultMsg{err: errors.New("busy")})
+	rm := result.(Model)
+	if rm.statusMsg != "release failed: busy" {
+		t.Errorf("expected error status, got %q", rm.statusMsg)
+	}
+}
+
+// --- action handoff tests ---
+
+type callRecord struct {
+	action string
+	args   []string
+}
+
+func recordingDeps(calls *[]callRecord) actionDeps {
+	return actionDeps{
+		supervisorSend: func(sockPath, command string) (string, error) {
+			*calls = append(*calls, callRecord{"supervisorSend", []string{sockPath, command}})
+			return "ok", nil
+		},
+		supervisorSock: func(worktreePath string) string {
+			return "/tmp/sock/" + worktreePath
+		},
+		openURL: func(url string) {
+			*calls = append(*calls, callRecord{"openURL", []string{url}})
+		},
+		releaseWorktree: func(wtPath string) error {
+			*calls = append(*calls, callRecord{"releaseWorktree", []string{wtPath}})
+			return nil
+		},
+		syncEnv: func(wtPath string) error {
+			*calls = append(*calls, callRecord{"syncEnv", []string{wtPath}})
+			return nil
+		},
+		createWorktree: func(existingPath, branch string) error {
+			*calls = append(*calls, callRecord{"createWorktree", []string{existingPath, branch}})
+			return nil
+		},
+	}
+}
+
+func buildTestModelWithDeps(calls *[]callRecord) Model {
+	snap := Snapshot{
+		Projects: []string{"api"},
+		Worktrees: []WorktreeStatus{
+			{
+				Project:      "api",
+				Branch:       "main",
+				WorktreeName: "api-main",
+				WorktreePath: "/home/dev/api",
+				Ports:        []int{3000},
+				RouterURL:    "https://api-main.prt.dev",
+				Supervisor:   "running",
+			},
+			{
+				Project:      "api",
+				Branch:       "feature-x",
+				WorktreeName: "api-feature-x",
+				WorktreePath: "/home/dev/api-feature-x",
+				Ports:        []int{3010},
+				RouterURL:    "",
+				Supervisor:   "stopped",
+			},
+		},
+	}
+	m := Model{
+		snapshot: snap,
+		flatList: buildFlatList(snap, ""),
+		height:   40,
+		width:    120,
+		deps:     recordingDeps(calls),
+	}
+	m.clampCursor()
+	return m
+}
+
+func TestOpenInBrowser_UsesRouterURL(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	// cursor is on api/main which has RouterURL set
+	m.openInBrowser()
+
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].action != "openURL" {
+		t.Fatalf("expected openURL, got %s", calls[0].action)
+	}
+	if calls[0].args[0] != "https://api-main.prt.dev" {
+		t.Errorf("expected router URL, got %s", calls[0].args[0])
+	}
+}
+
+func TestOpenInBrowser_FallsBackToLocalhost(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.cursor = 2 // api/feature-x, no RouterURL
+	m.openInBrowser()
+
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].args[0] != "http://localhost:3010" {
+		t.Errorf("expected localhost fallback, got %s", calls[0].args[0])
+	}
+}
+
+func TestEnvSync_PassesSelectedWorktreePath(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	cmd := m.syncEnv()
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd")
+	}
+	msg := cmd()
+	result := msg.(envSyncResultMsg)
+	if result.err != nil {
+		t.Errorf("expected nil error, got %v", result.err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].action != "syncEnv" {
+		t.Fatalf("expected syncEnv, got %s", calls[0].action)
+	}
+	if calls[0].args[0] != "/home/dev/api" {
+		t.Errorf("expected /home/dev/api, got %s", calls[0].args[0])
+	}
+}
+
+func TestEnvSync_NilWhenNoSelection(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.cursor = 0 // header
+	cmd := m.syncEnv()
+	if cmd != nil {
+		t.Error("expected nil cmd when on header")
+	}
+}
+
+func TestEnvSync_PropagatesError(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.deps.syncEnv = func(string) error {
+		return errors.New("permission denied")
+	}
+	cmd := m.syncEnv()
+	msg := cmd()
+	result := msg.(envSyncResultMsg)
+	if result.err == nil || result.err.Error() != "permission denied" {
+		t.Errorf("expected permission denied error, got %v", result.err)
+	}
+}
+
+func TestCreateWorktree_PassesBranchAndExistingPath(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	cmd := m.createWorktree("feature-new")
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd")
+	}
+	msg := cmd()
+	result := msg.(newWorktreeResultMsg)
+	if result.err != nil {
+		t.Errorf("expected nil error, got %v", result.err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].action != "createWorktree" {
+		t.Fatalf("expected createWorktree, got %s", calls[0].action)
+	}
+	if calls[0].args[0] != "/home/dev/api" {
+		t.Errorf("expected existing worktree path, got %s", calls[0].args[0])
+	}
+	if calls[0].args[1] != "feature-new" {
+		t.Errorf("expected branch feature-new, got %s", calls[0].args[1])
+	}
+}
+
+func TestCreateWorktree_NilWhenNoSelection(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.cursor = 0 // header row — selectedWorktree() returns nil
+	cmd := m.createWorktree("feature-new")
+	if cmd != nil {
+		t.Error("expected nil cmd when no worktree selected")
+	}
+}
+
+func TestToggleSupervisor_SendsStop(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	// cursor on api/main, supervisor="running"
+	cmd := m.toggleSupervisor()
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd")
+	}
+	cmd()
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(calls))
+	}
+	if calls[0].action != "supervisorSend" {
+		t.Fatalf("expected supervisorSend, got %s", calls[0].action)
+	}
+	if calls[0].args[1] != "stop" {
+		t.Errorf("expected stop command for running supervisor, got %s", calls[0].args[1])
+	}
+}
+
+func TestToggleSupervisor_SendsStart(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.cursor = 2 // api/feature-x, supervisor="stopped"
+	cmd := m.toggleSupervisor()
+	cmd()
+	if calls[0].args[1] != "start" {
+		t.Errorf("expected start command for stopped supervisor, got %s", calls[0].args[1])
+	}
+}
+
+func TestRestartSupervisor_SendsRestart(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	cmd := m.restartSupervisor()
+	cmd()
+	if calls[0].args[1] != "restart" {
+		t.Errorf("expected restart command, got %s", calls[0].args[1])
+	}
+}
+
+func TestReleaseWorktree_PassesPath(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	cmd := m.releaseWorktree()
+	cmd()
+	if len(calls) != 1 || calls[0].action != "releaseWorktree" {
+		t.Fatalf("expected releaseWorktree call, got %v", calls)
+	}
+	if calls[0].args[0] != "/home/dev/api" {
+		t.Errorf("expected /home/dev/api, got %s", calls[0].args[0])
+	}
+}
+
+func TestKeyE_TriggersEnvSync(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.ready = true
+	_, cmd := m.updateNormal(tea.KeyPressMsg(tea.Key{Code: 'e', Text: "e"}))
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from 'e' key")
+	}
+	cmd()
+	if len(calls) != 1 || calls[0].action != "syncEnv" {
+		t.Fatalf("expected syncEnv call, got %v", calls)
+	}
+	if calls[0].args[0] != "/home/dev/api" {
+		t.Errorf("expected /home/dev/api, got %s", calls[0].args[0])
+	}
+}
+
+func TestKeyN_EntersInputMode(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	result, _ := m.updateNormal(tea.KeyPressMsg(tea.Key{Code: 'n', Text: "n"}))
+	rm := result.(Model)
+	if rm.inputMode != "new_worktree" {
+		t.Errorf("expected inputMode=new_worktree, got %q", rm.inputMode)
+	}
+}
+
+func TestInputMode_EnterTriggersCreate(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.inputMode = "new_worktree"
+	m.inputText = "feature-new"
+
+	result, cmd := m.updateInput(tea.KeyPressMsg(tea.Key{Code: tea.KeyEnter}))
+	rm := result.(Model)
+	if rm.inputMode != "" {
+		t.Errorf("expected inputMode cleared, got %q", rm.inputMode)
+	}
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd")
+	}
+	// Execute the cmd and verify the handoff
+	cmd()
+	if len(calls) != 1 || calls[0].action != "createWorktree" {
+		t.Fatalf("expected createWorktree call, got %v", calls)
+	}
+	if calls[0].args[1] != "feature-new" {
+		t.Errorf("expected branch feature-new, got %s", calls[0].args[1])
+	}
+}
+
 // --- selectedWorktree ---
 
 func TestSelectedWorktree_ValidCursor(t *testing.T) {
@@ -340,5 +765,120 @@ func TestSelectedWorktree_OutOfBounds(t *testing.T) {
 	m.cursor = 999
 	if m.selectedWorktree() != nil {
 		t.Error("expected nil for out-of-bounds cursor")
+	}
+}
+
+// --- confirm flow ---
+
+func TestKeyD_SetsConfirmKind(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	result, _ := m.updateNormal(tea.KeyPressMsg(tea.Key{Code: 'd', Text: "d"}))
+	rm := result.(Model)
+	if rm.confirmKind != "release" {
+		t.Errorf("expected confirmKind=release, got %q", rm.confirmKind)
+	}
+}
+
+func TestKeyD_NoOpWhenNoSelection(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.cursor = 0 // header row
+	result, _ := m.updateNormal(tea.KeyPressMsg(tea.Key{Code: 'd', Text: "d"}))
+	rm := result.(Model)
+	if rm.confirmKind != "" {
+		t.Errorf("expected no confirmKind on header, got %q", rm.confirmKind)
+	}
+}
+
+func TestConfirm_YReleasesWorktree(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.confirmKind = "release"
+
+	result, cmd := m.updateConfirm(tea.KeyPressMsg(tea.Key{Code: 'y', Text: "y"}))
+	rm := result.(Model)
+	if rm.confirmKind != "" {
+		t.Errorf("expected confirmKind cleared, got %q", rm.confirmKind)
+	}
+	if cmd == nil {
+		t.Fatal("expected non-nil cmd from confirm")
+	}
+	cmd()
+	if len(calls) != 1 || calls[0].action != "releaseWorktree" {
+		t.Fatalf("expected releaseWorktree call, got %v", calls)
+	}
+	if calls[0].args[0] != "/home/dev/api" {
+		t.Errorf("expected /home/dev/api, got %s", calls[0].args[0])
+	}
+}
+
+func TestConfirm_OtherKeyCancels(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.confirmKind = "release"
+
+	result, cmd := m.updateConfirm(tea.KeyPressMsg(tea.Key{Code: 'n', Text: "n"}))
+	rm := result.(Model)
+	if rm.confirmKind != "" {
+		t.Errorf("expected confirmKind cleared on cancel, got %q", rm.confirmKind)
+	}
+	if cmd != nil {
+		t.Error("expected nil cmd on cancel")
+	}
+	if len(calls) != 0 {
+		t.Errorf("expected no calls on cancel, got %v", calls)
+	}
+}
+
+// --- nil-guard tests ---
+
+func TestToggleSupervisor_NilWhenNoSelection(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.cursor = 0 // header
+	cmd := m.toggleSupervisor()
+	if cmd != nil {
+		t.Error("expected nil cmd when on header")
+	}
+}
+
+func TestRestartSupervisor_NilWhenNoSelection(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.cursor = 0 // header
+	cmd := m.restartSupervisor()
+	if cmd != nil {
+		t.Error("expected nil cmd when on header")
+	}
+}
+
+func TestReleaseWorktree_NilWhenNoSelection(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.cursor = 0 // header
+	cmd := m.releaseWorktree()
+	if cmd != nil {
+		t.Error("expected nil cmd when on header")
+	}
+}
+
+func TestOpenInBrowser_NoOpWhenNoSelection(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.cursor = 0 // header
+	m.openInBrowser()
+	if len(calls) != 0 {
+		t.Errorf("expected no calls when on header, got %v", calls)
+	}
+}
+
+func TestOpenInBrowser_NoOpWhenNoPorts(t *testing.T) {
+	var calls []callRecord
+	m := buildTestModelWithDeps(&calls)
+	m.flatList[m.cursor].wt.Ports = nil
+	m.openInBrowser()
+	if len(calls) != 0 {
+		t.Errorf("expected no calls when no ports, got %v", calls)
 	}
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -2,13 +2,15 @@ package tui
 
 import (
 	"fmt"
-	"os/exec"
-	"runtime"
+	"strings"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/bubbles/v2/spinner"
-	"github.com/git-treeline/git-treeline/internal/supervisor"
 )
+
+type envSyncResultMsg struct{ err error }
+type newWorktreeResultMsg struct{ err error }
+type releaseResultMsg struct{ err error }
 
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
@@ -27,10 +29,38 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tickMsg:
+		m.statusMsg = ""
 		m.polling = true
 		return m, tea.Batch(doPoll(), doTick())
 
 	case supervisorResultMsg:
+		m.polling = true
+		return m, doPoll()
+
+	case releaseResultMsg:
+		if msg.err != nil {
+			m.statusMsg = "release failed: " + msg.err.Error()
+		} else {
+			m.statusMsg = "worktree released"
+		}
+		m.polling = true
+		return m, doPoll()
+
+	case envSyncResultMsg:
+		if msg.err != nil {
+			m.statusMsg = "env sync failed: " + msg.err.Error()
+		} else {
+			m.statusMsg = "env synced"
+		}
+		m.polling = true
+		return m, doPoll()
+
+	case newWorktreeResultMsg:
+		if msg.err != nil {
+			m.statusMsg = "create failed: " + msg.err.Error()
+		} else {
+			m.statusMsg = "worktree created"
+		}
 		m.polling = true
 		return m, doPoll()
 
@@ -40,6 +70,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, cmd
 
 	case tea.KeyPressMsg:
+		if m.inputMode != "" {
+			return m.updateInput(msg)
+		}
 		if m.filterMode {
 			return m.updateFilter(msg)
 		}
@@ -90,6 +123,14 @@ func (m Model) updateNormal(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 		if m.selectedWorktree() != nil {
 			m.confirmKind = "release"
 		}
+
+	case "e":
+		return m, m.syncEnv()
+
+	case "n":
+		m.inputMode = "new_worktree"
+		m.inputText = ""
+		return m, nil
 
 	case "/":
 		m.filterMode = true
@@ -269,13 +310,14 @@ func (m *Model) toggleSupervisor() tea.Cmd {
 	if wt == nil {
 		return nil
 	}
-	sockPath := supervisor.SocketPath(wt.WorktreePath)
+	sockPath := m.deps.supervisorSock(wt.WorktreePath)
 	command := "start"
 	if wt.Supervisor == "running" {
 		command = "stop"
 	}
+	send := m.deps.supervisorSend
 	return func() tea.Msg {
-		_, _ = supervisor.Send(sockPath, command)
+		_, _ = send(sockPath, command)
 		return supervisorResultMsg{}
 	}
 }
@@ -285,10 +327,62 @@ func (m *Model) restartSupervisor() tea.Cmd {
 	if wt == nil {
 		return nil
 	}
-	sockPath := supervisor.SocketPath(wt.WorktreePath)
+	sockPath := m.deps.supervisorSock(wt.WorktreePath)
+	send := m.deps.supervisorSend
 	return func() tea.Msg {
-		_, _ = supervisor.Send(sockPath, "restart")
+		_, _ = send(sockPath, "restart")
 		return supervisorResultMsg{}
+	}
+}
+
+func (m Model) updateInput(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
+	switch msg.String() {
+	case "enter":
+		branch := strings.TrimSpace(m.inputText)
+		m.inputMode = ""
+		m.inputText = ""
+		if branch == "" {
+			return m, nil
+		}
+		return m, m.createWorktree(branch)
+	case "escape", "esc":
+		m.inputMode = ""
+		m.inputText = ""
+		return m, nil
+	case "backspace":
+		if len(m.inputText) > 0 {
+			m.inputText = m.inputText[:len(m.inputText)-1]
+		}
+	default:
+		ch := msg.Key().Text
+		if ch != "" && !strings.ContainsAny(ch, " \t\n\r") {
+			m.inputText += ch
+		}
+	}
+	return m, nil
+}
+
+func (m *Model) syncEnv() tea.Cmd {
+	wt := m.selectedWorktree()
+	if wt == nil || wt.WorktreePath == "" {
+		return nil
+	}
+	wtPath := wt.WorktreePath
+	fn := m.deps.syncEnv
+	return func() tea.Msg {
+		return envSyncResultMsg{err: fn(wtPath)}
+	}
+}
+
+func (m *Model) createWorktree(branch string) tea.Cmd {
+	wt := m.selectedWorktree()
+	if wt == nil || wt.WorktreePath == "" {
+		return nil
+	}
+	existingPath := wt.WorktreePath
+	fn := m.deps.createWorktree
+	return func() tea.Msg {
+		return newWorktreeResultMsg{err: fn(existingPath, branch)}
 	}
 }
 
@@ -297,21 +391,11 @@ func (m *Model) openInBrowser() {
 	if wt == nil || len(wt.Ports) == 0 {
 		return
 	}
-	url := fmt.Sprintf("http://localhost:%d", wt.Ports[0])
-	openURL(url)
-}
-
-func openURL(url string) {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "darwin":
-		cmd = exec.Command("open", url)
-	case "linux":
-		cmd = exec.Command("xdg-open", url)
-	default:
-		return
+	url := wt.RouterURL
+	if url == "" {
+		url = fmt.Sprintf("http://localhost:%d", wt.Ports[0])
 	}
-	_ = cmd.Start()
+	m.deps.openURL(url)
 }
 
 func (m *Model) releaseWorktree() tea.Cmd {
@@ -320,9 +404,8 @@ func (m *Model) releaseWorktree() tea.Cmd {
 		return nil
 	}
 	wtPath := wt.WorktreePath
+	fn := m.deps.releaseWorktree
 	return func() tea.Msg {
-		cmd := exec.Command("git-treeline", "release", "--force", wtPath)
-		_ = cmd.Run()
-		return supervisorResultMsg{}
+		return releaseResultMsg{err: fn(wtPath)}
 	}
 }

--- a/internal/tui/view.go
+++ b/internal/tui/view.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	tea "charm.land/bubbletea/v2"
@@ -61,10 +62,13 @@ func (m Model) View() tea.View {
 	content := lipgloss.JoinVertical(lipgloss.Left, panels, bar)
 
 	if m.showHelp {
-		content = m.renderHelpOverlay(content)
+		content = m.renderHelpOverlay()
 	}
 	if m.confirmKind != "" {
-		content = m.renderConfirmOverlay(content)
+		content = m.renderConfirmOverlay()
+	}
+	if m.inputMode != "" {
+		content = m.renderInputOverlay()
 	}
 
 	v := tea.NewView(content)
@@ -153,13 +157,20 @@ func (m *Model) renderDetailPanel(width, height int) string {
 
 	rows := []struct{ label, value string }{
 		{"Port", portsString(wt.Ports)},
-		{"Database", valueOrDash(wt.Database)},
-		{"Redis", redisDisplay(wt)},
-		{"Supervisor", supervisorDisplay(wt)},
-		{"Listening", boolDisplay(wt.Listening)},
+	}
+
+	if wt.RouterURL != "" {
+		rows = append(rows, struct{ label, value string }{"URL", truncate(wt.RouterURL, width-16)})
+	}
+	if wt.TunnelURL != "" {
+		rows = append(rows, struct{ label, value string }{"Tunnel", truncate(wt.TunnelURL, width-16)})
 	}
 
 	rows = append(rows,
+		struct{ label, value string }{"Database", valueOrDash(wt.Database)},
+		struct{ label, value string }{"Redis", redisDisplay(wt)},
+		struct{ label, value string }{"Supervisor", supervisorDisplay(wt)},
+		struct{ label, value string }{"Listening", boolDisplay(wt.Listening)},
 		struct{ label, value string }{"Env file", valueOrDash(wt.EnvFile)},
 		struct{ label, value string }{"Worktree", truncate(wt.WorktreePath, width-16)},
 	)
@@ -174,12 +185,17 @@ func (m *Model) renderDetailPanel(width, height int) string {
 	if len(wt.Links) > 0 {
 		b.WriteString("\n")
 		b.WriteString("  ")
-		b.WriteString(detailLabel.Render("Links"))
+		b.WriteString(detailLabel.Render("Overrides"))
 		b.WriteString("\n")
-		for k, v := range wt.Links {
+		linkKeys := make([]string, 0, len(wt.Links))
+		for k := range wt.Links {
+			linkKeys = append(linkKeys, k)
+		}
+		sort.Strings(linkKeys)
+		for _, k := range linkKeys {
 			b.WriteString("    ")
 			b.WriteString(linkIndicatorStyle.Render("⇄ "+k))
-			b.WriteString(detailValue.Render(" → "+v))
+			b.WriteString(detailValue.Render(" → "+wt.Links[k]))
 			b.WriteString("\n")
 		}
 	}
@@ -256,10 +272,20 @@ func (m *Model) renderStatusBar(width int) string {
 	stats := fmt.Sprintf("%s%d projects · %d worktrees · %d running · serve: %s",
 		pollIndicator, len(m.snapshot.Projects), len(m.snapshot.Worktrees), running, serveStr)
 
+	if m.snapshot.TunnelDomain != "" {
+		stats += " · tunnel: " + m.snapshot.TunnelDomain
+	}
+
+	if m.statusMsg != "" {
+		stats += " · " + m.statusMsg
+	}
+
 	keys := []struct{ key, desc string }{
 		{"s", "start/stop"},
 		{"o", "open"},
 		{"r", "restart"},
+		{"e", "env sync"},
+		{"n", "new"},
 		{"d", "release"},
 		{"/", "filter"},
 		{"?", "help"},
@@ -282,7 +308,7 @@ func (m *Model) renderStatusBar(width int) string {
 
 // --- Help overlay ---
 
-func (m *Model) renderHelpOverlay(_ string) string {
+func (m *Model) renderHelpOverlay() string {
 	help := `
   gtl dashboard — Keyboard Shortcuts
 
@@ -292,6 +318,8 @@ func (m *Model) renderHelpOverlay(_ string) string {
   s             Start/stop supervisor
   o             Open in browser
   r             Restart supervisor
+  e             Sync env file
+  n             New worktree
   d             Release worktree (confirm)
   /             Filter worktrees
   Esc           Clear filter
@@ -310,7 +338,7 @@ func (m *Model) renderHelpOverlay(_ string) string {
 
 // --- Confirm overlay ---
 
-func (m *Model) renderConfirmOverlay(_ string) string {
+func (m *Model) renderConfirmOverlay() string {
 	wt := m.selectedWorktree()
 	if wt == nil {
 		return ""
@@ -319,6 +347,18 @@ func (m *Model) renderConfirmOverlay(_ string) string {
 	box := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(danger).
+		Padding(1, 2).
+		Render(prompt)
+
+	return lipgloss.Place(m.width, m.height-statusBarHeight,
+		lipgloss.Center, lipgloss.Center, box)
+}
+
+func (m *Model) renderInputOverlay() string {
+	prompt := fmt.Sprintf("New worktree — branch name:\n\n  %s▌\n\n  Enter = create   Esc = cancel", m.inputText)
+	box := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(highlight).
 		Padding(1, 2).
 		Render(prompt)
 


### PR DESCRIPTION
## Summary

- **Router & tunnel URLs** in detail panel with proper truncation for narrow terminals
- **Link override indicators** (`⇄` badge) in worktree list with sorted rendering in detail panel
- **`e` key** triggers env sync on selected worktree with status feedback
- **`n` key** opens branch name input overlay for new worktree creation with whitespace validation
- **`actionDeps` dependency injection** for testable side effects, consistent with existing `healthDeps` pattern
- **Bug fixes**: `releaseWorktree` now propagates errors (was swallowed), `createWorktree` uses selected worktree (was arbitrary first), `RouterURL` field only stores actual router URLs (not localhost fallbacks)

## Test plan

- [x] 56 tests passing across navigation, handoffs, nil guards, confirm flow, input validation, and result message status
- [x] Full `go test ./...` and `go build ./...` clean
- [x] Rebased on latest main
- [x] Manual smoke test of dashboard with active worktrees

🤖 Generated with [Claude Code](https://claude.com/claude-code)