### PR TITLE
Make gtl review and gtl new worktree-aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **MCP write operations** — the MCP server now supports `setup`, `new`, `link`, `unlink`, `config_set`, and `env_sync` tools. Read tools expanded with `resolve`, `env`, `where`, and `routes`. Tool descriptions improved for AI agent consumption.
 - **Shared `proxy.BuildRouterURL`** — router URL construction extracted from three call sites into a single testable function. Eliminates duplication across `open`, `resolve`, `routes`, and MCP tools.
 - **`internal/envparse` package** — env file parsing extracted from `cmd/env.go` into a shared package with its own test suite. Used by both the CLI and MCP tools.
+- **Worktree-aware `review` and `new`** — `gtl review` from inside a worktree now prompts to switch the current worktree to the PR branch instead of blocking. `gtl new` from a worktree warns about the target path and asks for confirmation; `--force`/`-f` skips the prompt. The old `worktreeGuard` hard error is removed.
 - **Hardened test coverage** — added tests for database adapters (PostgreSQL, SQLite), service health checks, setup orchestration, worktree operations, tunnel cert management, doctor checks, release safety, and framework detection. +3,500 lines of test code.
 
 ## [0.36.0]
@@ -157,7 +158,7 @@
 - **`gtl doctor`** — check project config, allocation, runtime, and diagnostics in one view. Reports on `.treeline.yml` presence, env file status, port allocation, supervisor state, and framework-specific guidance.
 - **Tab completion** — `gtl new`, `gtl review`, and `gtl switch` now provide shell completions for branch names and PR numbers.
 - **`gtl release` confirmation** — single-worktree releases now show what will be released and prompt for confirmation. Use `--force` to skip.
-- **Worktree guard** — `gtl new` and `gtl review` now error if run from inside a worktree (which would create confusing sibling worktrees). Suggests `gtl switch` or navigating to the main repo instead.
+- **Worktree guard** — `gtl new` and `gtl review` now error if run from inside a worktree (which would create confusing sibling worktrees). Suggests `gtl switch` or navigating to the main repo instead. _(Superseded in 0.37.0 — both commands now work from worktrees with interactive prompts.)_
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ gtl review 42 --start
 
 Fetches the PR branch via `gh`, creates a worktree, allocates resources, runs setup, and boots the app. Requires the [gh CLI](https://cli.github.com).
 
-`review` and `new` must be run from the main repo, not from inside a worktree. If you're in a worktree and want to change branches, use `gtl switch`.
+When run from inside a worktree, `review` prompts to switch the current worktree to the PR branch (same as `gtl switch`). `new` warns that the worktree will be created elsewhere and asks for confirmation; pass `--force` / `-f` to skip the prompt. From the main repo, both commands behave as before.
 
 ### 8. Open a worktree in the browser
 
@@ -756,7 +756,7 @@ gtl db name --json         # {"database": "myapp_feature_xyz"}
 | Command | Flags | Description |
 |---|---|---|
 | `gtl init` | `--project` `--template-db` `--skip-agent-config` | Generate `.treeline.yml` (auto-detects framework, writes `AGENTS.md` section) |
-| `gtl new <branch>` | `--base` `--path` `--start` `--open` `--dry-run` | Create worktree + allocate + setup in one step |
+| `gtl new <branch>` | `--base` `--path` `--start` `--open` `--dry-run` `--force`/`-f` | Create worktree + allocate + setup in one step |
 | `gtl review <PR#>` | `--path` `--start` `--open` | Check out a GitHub PR into a worktree with full setup (requires `gh`) |
 | `gtl switch <branch-or-PR#>` | `--setup` `--restart` | Switch worktree to a different branch or PR — fetches, checks out, refreshes env |
 | `gtl setup [PATH]` | `--main-repo` `--dry-run` | Allocate resources and configure a worktree (idempotent) |

--- a/cmd/guard_test.go
+++ b/cmd/guard_test.go
@@ -175,8 +175,21 @@ func TestGuard_CliErrorUsesCliErr(t *testing.T) {
 	}
 }
 
-// isBareCLIError returns true if the expression is a direct &CliError{} or
-// errXxx() call that's not wrapped in cliErr().
+// cliErrHelpers are functions that can return *CliError indirectly. Calls to
+// these inside RunE must be wrapped with cliErr(cmd, ...) just like direct
+// &CliError{} literals and errXxx() constructors.
+var cliErrHelpers = map[string]bool{
+	"awaitReady":           true,
+	"resolveTunnelTarget":  true,
+	"resolveStartHooks":    true,
+	"validateTunnelPrereqs": true,
+	"requireServeInstalled": true,
+	"switchWorktreeBranch":  true,
+}
+
+// isBareCLIError returns true if the expression is a direct &CliError{},
+// errXxx() call, or known CliError-producing helper that's not wrapped in
+// cliErr().
 func isBareCLIError(expr ast.Expr) bool {
 	// Check for &CliError{...}
 	if unary, ok := expr.(*ast.UnaryExpr); ok {
@@ -187,11 +200,14 @@ func isBareCLIError(expr ast.Expr) bool {
 		}
 	}
 
-	// Check for errXxx() calls that aren't wrapped in cliErr()
 	if call, ok := expr.(*ast.CallExpr); ok {
 		if ident, ok := call.Fun.(*ast.Ident); ok {
 			// errXxx constructors should be wrapped
 			if strings.HasPrefix(ident.Name, "err") && ident.Name != "err" {
+				return true
+			}
+			// Known helpers that return *CliError
+			if cliErrHelpers[ident.Name] {
 				return true
 			}
 		}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 
 	"github.com/git-treeline/git-treeline/internal/config"
 	"github.com/git-treeline/git-treeline/internal/confirm"
@@ -24,6 +23,7 @@ var newPath string
 var newStart bool
 var newOpen bool
 var newDryRun bool
+var newForce bool
 
 func init() {
 	newCmd.Flags().StringVar(&newBase, "base", "", "Base branch for the new worktree (default: current branch)")
@@ -31,6 +31,7 @@ func init() {
 	newCmd.Flags().BoolVar(&newStart, "start", false, "Run commands.start after setup")
 	newCmd.Flags().BoolVar(&newOpen, "open", false, "Open the worktree in the browser after setup")
 	newCmd.Flags().BoolVar(&newDryRun, "dry-run", false, "Print what would happen without making changes")
+	newCmd.Flags().BoolVarP(&newForce, "force", "f", false, "Skip confirmation when creating from inside a worktree")
 	newCmd.ValidArgsFunction = completeBranches
 	rootCmd.AddCommand(newCmd)
 }
@@ -45,17 +46,30 @@ If the branch already exists locally or on origin, it is checked out.
 Otherwise a new branch is created from --base (or the current branch).`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := worktreeGuard(cmd, args); err != nil {
-			return cliErr(cmd, err)
-		}
-
 		branch := args[0]
 
 		cwd, err := os.Getwd()
 		if err != nil {
 			return fmt.Errorf("getting working directory: %w", err)
 		}
-		mainRepo := worktree.DetectMainRepo(cwd)
+		absPath, _ := filepath.Abs(cwd)
+		mainRepo := worktree.DetectMainRepo(absPath)
+
+		if isInWorktree(absPath, mainRepo) && !newForce && !newDryRun {
+			pc := config.LoadProjectConfig(mainRepo)
+			uc := config.LoadUserConfig("")
+			wtPath := resolveNewWorktreePath(mainRepo, pc.Project(), branch, uc)
+
+			fmt.Println()
+			fmt.Printf("You're in worktree '%s'. The new worktree will be created at:\n", filepath.Base(absPath))
+			fmt.Printf("  %s\n\n", wtPath)
+			fmt.Println("You'll need to open it separately in your editor.")
+			if !confirm.Prompt("Continue?", false, nil) {
+				return nil
+			}
+			fmt.Println()
+		}
+
 		pc := config.LoadProjectConfig(mainRepo)
 		uc := config.LoadUserConfig("")
 
@@ -87,14 +101,7 @@ Otherwise a new branch is created from --base (or the current branch).`,
 		}
 
 		projectName := pc.Project()
-
-		wtPath := newPath
-		if wtPath == "" {
-			wtPath = uc.ResolveWorktreePath(mainRepo, projectName, branch)
-		}
-		if wtPath == "" {
-			wtPath = filepath.Join(filepath.Dir(mainRepo), fmt.Sprintf("%s-%s", projectName, branch))
-		}
+		wtPath := resolveNewWorktreePath(mainRepo, projectName, branch, uc)
 
 		if err := ensureGitignored(mainRepo, wtPath); err != nil {
 			return err
@@ -220,30 +227,6 @@ Otherwise a new branch is created from --base (or the current branch).`,
 	},
 }
 
-
-// worktreeGuard returns an error if the cwd is inside a worktree rather than
-// the main repo. Prevents gtl new / gtl review from creating sibling worktrees.
-func worktreeGuard(cmd *cobra.Command, args []string) error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("getting working directory: %w", err)
-	}
-	absPath, _ := filepath.Abs(cwd)
-	mainRepo := worktree.DetectMainRepo(absPath)
-
-	resolvedAbs, _ := filepath.EvalSymlinks(absPath)
-	resolvedMain, _ := filepath.EvalSymlinks(mainRepo)
-	if resolvedAbs != resolvedMain {
-		return &CliError{
-			Message: fmt.Sprintf("You're inside worktree '%s', not the main repo.", filepath.Base(absPath)),
-			Hint: fmt.Sprintf("To switch this worktree: gtl switch <branch-or-PR#>\n"+
-				"  To create from main repo:  cd %s && gtl %s %s",
-				mainRepo, cmd.Name(), strings.Join(args, " ")),
-		}
-	}
-	return nil
-}
-
 func execInWorktree(dir, command string) error {
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Dir = dir
@@ -263,14 +246,7 @@ func completeBranches(cmd *cobra.Command, args []string, toComplete string) ([]s
 // createWorktreeOnly creates a worktree without any port/database allocation.
 // Used for non-server projects or when user declines full setup.
 func createWorktreeOnly(mainRepo, branch string, uc *config.UserConfig, pc *config.ProjectConfig) error {
-	projectName := pc.Project()
-	wtPath := newPath
-	if wtPath == "" {
-		wtPath = uc.ResolveWorktreePath(mainRepo, projectName, branch)
-	}
-	if wtPath == "" {
-		wtPath = filepath.Join(filepath.Dir(mainRepo), fmt.Sprintf("%s-%s", projectName, branch))
-	}
+	wtPath := resolveNewWorktreePath(mainRepo, pc.Project(), branch, uc)
 
 	if existingWT := worktree.FindWorktreeForBranch(branch); existingWT != "" {
 		fmt.Println(style.Actionf("Branch '%s' already checked out at %s", branch, existingWT))
@@ -324,6 +300,18 @@ func createWorktreeOnly(mainRepo, branch string, uc *config.UserConfig, pc *conf
 	fmt.Println()
 	fmt.Printf("  cd %s\n", wtPath)
 	return nil
+}
+
+// resolveNewWorktreePath returns the target path for a new worktree, applying
+// --path override, user config template, or the default sibling layout.
+func resolveNewWorktreePath(mainRepo, projectName, branch string, uc *config.UserConfig) string {
+	if newPath != "" {
+		return newPath
+	}
+	if p := uc.ResolveWorktreePath(mainRepo, projectName, branch); p != "" {
+		return p
+	}
+	return filepath.Join(filepath.Dir(mainRepo), fmt.Sprintf("%s-%s", projectName, branch))
 }
 
 // runInitInteractive runs the init flow to create .treeline.yml.

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -54,10 +54,10 @@ Otherwise a new branch is created from --base (or the current branch).`,
 		}
 		absPath, _ := filepath.Abs(cwd)
 		mainRepo := worktree.DetectMainRepo(absPath)
+		pc := config.LoadProjectConfig(mainRepo)
+		uc := config.LoadUserConfig("")
 
 		if isInWorktree(absPath, mainRepo) && !newForce && !newDryRun {
-			pc := config.LoadProjectConfig(mainRepo)
-			uc := config.LoadUserConfig("")
 			wtPath := resolveNewWorktreePath(mainRepo, pc.Project(), branch, uc)
 
 			fmt.Println()
@@ -69,9 +69,6 @@ Otherwise a new branch is created from --base (or the current branch).`,
 			}
 			fmt.Println()
 		}
-
-		pc := config.LoadProjectConfig(mainRepo)
-		uc := config.LoadUserConfig("")
 
 		// Zero-config: if no .treeline.yml, check if this is a server project
 		if !pc.Exists() {

--- a/cmd/new_test.go
+++ b/cmd/new_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/git-treeline/git-treeline/internal/config"
+)
+
+func TestResolveNewWorktreePath_FlagOverride(t *testing.T) {
+	oldPath := newPath
+	defer func() { newPath = oldPath }()
+
+	newPath = "/custom/path"
+	uc := config.LoadUserConfig("/nonexistent/config.yml")
+	got := resolveNewWorktreePath("/repo/main", "myapp", "feat", uc)
+	if got != "/custom/path" {
+		t.Errorf("expected /custom/path, got %s", got)
+	}
+}
+
+func TestResolveNewWorktreePath_DefaultSiblingLayout(t *testing.T) {
+	oldPath := newPath
+	defer func() { newPath = oldPath }()
+
+	newPath = ""
+	uc := config.LoadUserConfig("/nonexistent/config.yml")
+	got := resolveNewWorktreePath("/repos/main", "myapp", "feat", uc)
+	want := filepath.Join("/repos", "myapp-feat")
+	if got != want {
+		t.Errorf("expected %s, got %s", want, got)
+	}
+}
+
+func TestResolveNewWorktreePath_UserConfigTemplate(t *testing.T) {
+	oldPath := newPath
+	defer func() { newPath = oldPath }()
+
+	newPath = ""
+
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.json")
+	writeFile(t, cfgPath, `{"worktree":{"path":"/worktrees/{project}/{branch}"}}`)
+
+	uc := config.LoadUserConfig(cfgPath)
+	got := resolveNewWorktreePath("/repos/main", "myapp", "feat", uc)
+	if got != "/worktrees/myapp/feat" {
+		t.Errorf("expected /worktrees/myapp/feat, got %s", got)
+	}
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/git-treeline/git-treeline/internal/config"
 	"github.com/git-treeline/git-treeline/internal/proxy"
@@ -42,6 +43,18 @@ func printRouterAndTunnel(uc *config.UserConfig, project, branch string) {
 	if tunnelDomain := uc.TunnelDomain(""); tunnelDomain != "" {
 		fmt.Println(style.Actionf("Tunnel: run %s → %s", style.Cmd("gtl tunnel"), style.Link("https://"+routeKey+"."+tunnelDomain)))
 	}
+}
+
+// isInWorktree reports whether absPath differs from mainRepo after resolving
+// symlinks. Falls back to filepath.Clean comparison when EvalSymlinks fails,
+// avoiding false equality from two empty-string errors.
+func isInWorktree(absPath, mainRepo string) bool {
+	resolvedAbs, errAbs := filepath.EvalSymlinks(absPath)
+	resolvedMain, errMain := filepath.EvalSymlinks(mainRepo)
+	if errAbs != nil || errMain != nil {
+		return filepath.Clean(absPath) != filepath.Clean(mainRepo)
+	}
+	return resolvedAbs != resolvedMain
 }
 
 // ensureGitignored delegates to worktree.EnsureGitignored and prints

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -57,6 +57,44 @@ func TestSortedRouteKeys_Single(t *testing.T) {
 	}
 }
 
+func TestIsInWorktree_SamePath(t *testing.T) {
+	dir := t.TempDir()
+	if isInWorktree(dir, dir) {
+		t.Error("same path should not be detected as worktree")
+	}
+}
+
+func TestIsInWorktree_DifferentPath(t *testing.T) {
+	a := t.TempDir()
+	b := t.TempDir()
+	if !isInWorktree(a, b) {
+		t.Error("different paths should be detected as worktree")
+	}
+}
+
+func TestIsInWorktree_SymlinkResolution(t *testing.T) {
+	real := t.TempDir()
+	parent := t.TempDir()
+	link := filepath.Join(parent, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Skip("symlinks not supported:", err)
+	}
+	if isInWorktree(link, real) {
+		t.Error("symlinked path pointing to same dir should not be detected as worktree")
+	}
+}
+
+func TestIsInWorktree_NonexistentPathFallback(t *testing.T) {
+	a := "/nonexistent/path/a"
+	b := "/nonexistent/path/b"
+	if !isInWorktree(a, b) {
+		t.Error("different nonexistent paths should fall back to clean comparison")
+	}
+	if isInWorktree(a, a) {
+		t.Error("same nonexistent path should not be detected as worktree")
+	}
+}
+
 func initGitRepo(t *testing.T, dir string) {
 	t.Helper()
 	cmd := exec.Command("git", "init", "--initial-branch=main")

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -13,6 +13,7 @@ import (
 	"github.com/git-treeline/git-treeline/internal/registry"
 	"github.com/git-treeline/git-treeline/internal/service"
 	"github.com/git-treeline/git-treeline/internal/setup"
+	"github.com/git-treeline/git-treeline/internal/style"
 	"github.com/git-treeline/git-treeline/internal/worktree"
 	"github.com/spf13/cobra"
 )
@@ -77,7 +78,7 @@ resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 			}
 			fmt.Println()
 			if err := switchWorktreeBranch(absPath, mainRepo, branch, false); err != nil {
-				return err
+				return cliErr(cmd, err)
 			}
 
 			pc := config.LoadProjectConfig(absPath)
@@ -87,22 +88,23 @@ resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 
 			if reviewOpen {
 				reg := registry.New("")
-				alloc := reg.Find(absPath)
-				ports := format.GetPorts(format.Allocation(alloc))
-				if len(ports) > 0 {
-					url := buildOpenURL(ports[0], projectName, branch, uc.RouterDomain(), uc.RouterPort(), service.IsRunning(), service.IsPortForwardConfigured())
-					fmt.Printf("Opening %s\n", url)
-					_ = openBrowser(url)
+				if alloc := reg.Find(absPath); alloc != nil {
+					ports := format.GetPorts(format.Allocation(alloc))
+					if len(ports) > 0 {
+						url := buildOpenURL(ports[0], projectName, branch, uc.RouterDomain(), uc.RouterPort(), service.IsRunning(), service.IsPortForwardConfigured())
+						fmt.Printf("Opening %s\n", url)
+						_ = openBrowser(url)
+					}
 				}
 			}
 
 			if reviewStart {
 				startCmd := pc.StartCommand()
 				if startCmd == "" {
-					fmt.Println("Warning: --start passed but no commands.start configured in .treeline.yml")
+					fmt.Println(style.Warnf("--start passed but no commands.start configured in .treeline.yml"))
 					return nil
 				}
-				fmt.Printf("==> Starting: %s\n", startCmd)
+				fmt.Println(style.Actionf("Starting: %s", startCmd))
 				return execInWorktree(absPath, startCmd)
 			}
 

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 
 	"github.com/git-treeline/git-treeline/internal/config"
+	"github.com/git-treeline/git-treeline/internal/confirm"
 	"github.com/git-treeline/git-treeline/internal/format"
 	"github.com/git-treeline/git-treeline/internal/github"
 	"github.com/git-treeline/git-treeline/internal/registry"
@@ -35,10 +36,6 @@ var reviewCmd = &cobra.Command{
 resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := worktreeGuard(cmd, args); err != nil {
-			return cliErr(cmd, err)
-		}
-
 		if err := requireServeInstalled(); err != nil {
 			return cliErr(cmd, err)
 		}
@@ -64,7 +61,54 @@ resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 		if err != nil {
 			return fmt.Errorf("getting working directory: %w", err)
 		}
-		mainRepo := worktree.DetectMainRepo(cwd)
+		absPath, _ := filepath.Abs(cwd)
+		mainRepo := worktree.DetectMainRepo(absPath)
+
+		if isInWorktree(absPath, mainRepo) {
+			currentBranch := worktree.CurrentBranch(absPath)
+			branchLabel := currentBranch
+			if branchLabel == "" {
+				branchLabel = "(detached)"
+			}
+			fmt.Println()
+			fmt.Printf("You're in worktree '%s' (branch: %s).\n", filepath.Base(absPath), branchLabel)
+			if !confirm.Prompt(fmt.Sprintf("Switch to PR #%d (branch: %s)?", prNumber, branch), false, nil) {
+				return nil
+			}
+			fmt.Println()
+			if err := switchWorktreeBranch(absPath, mainRepo, branch, false); err != nil {
+				return err
+			}
+
+			pc := config.LoadProjectConfig(absPath)
+			uc := config.LoadUserConfig("")
+			projectName := pc.Project()
+			printRouterAndTunnel(uc, projectName, branch)
+
+			if reviewOpen {
+				reg := registry.New("")
+				alloc := reg.Find(absPath)
+				ports := format.GetPorts(format.Allocation(alloc))
+				if len(ports) > 0 {
+					url := buildOpenURL(ports[0], projectName, branch, uc.RouterDomain(), uc.RouterPort(), service.IsRunning(), service.IsPortForwardConfigured())
+					fmt.Printf("Opening %s\n", url)
+					_ = openBrowser(url)
+				}
+			}
+
+			if reviewStart {
+				startCmd := pc.StartCommand()
+				if startCmd == "" {
+					fmt.Println("Warning: --start passed but no commands.start configured in .treeline.yml")
+					return nil
+				}
+				fmt.Printf("==> Starting: %s\n", startCmd)
+				return execInWorktree(absPath, startCmd)
+			}
+
+			return nil
+		}
+
 		pc := config.LoadProjectConfig(mainRepo)
 		uc := config.LoadUserConfig("")
 		projectName := pc.Project()

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -69,7 +69,7 @@ resumes the server in the original terminal. Ctrl+C exits the supervisor.`,
 
 		activeHooks, err := resolveStartHooks(pc, startWith)
 		if err != nil {
-			return err
+			return cliErr(cmd, err)
 		}
 
 		sockPath := supervisor.SocketPath(absPath)
@@ -85,7 +85,7 @@ resumes the server in the original terminal. Ctrl+C exits the supervisor.`,
 			}
 			if resp == "running" {
 				if startAwait {
-					return awaitReady(sockPath)
+					return cliErr(cmd, awaitReady(sockPath))
 				}
 				return cliErr(cmd, errServerAlreadyRunning())
 			}

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -45,7 +45,7 @@ Related commands:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		port, _, err := resolveTunnelTarget(args)
 		if err != nil {
-			return err
+			return cliErr(cmd, err)
 		}
 
 		if shareTailscale {

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -45,9 +45,7 @@ Must be run from inside a worktree (not the main repo).`,
 		absPath, _ := filepath.Abs(cwd)
 		mainRepo := worktree.DetectMainRepo(absPath)
 
-		resolvedAbs, _ := filepath.EvalSymlinks(absPath)
-		resolvedMain, _ := filepath.EvalSymlinks(mainRepo)
-		if resolvedAbs == resolvedMain {
+		if !isInWorktree(absPath, mainRepo) {
 			return cliErr(cmd, errNotInWorktree())
 		}
 
@@ -62,34 +60,8 @@ Must be run from inside a worktree (not the main repo).`,
 			fmt.Println(style.Actionf("PR #%d → branch '%s'", prNum, branch))
 		}
 
-		fmt.Println(style.Actionf("Fetching origin/%s...", branch))
-		if err := worktree.Fetch("origin", branch); err != nil {
-			fmt.Fprintln(os.Stderr, style.Warnf("fetch failed (%s), trying local checkout", err))
-		}
-
-		fmt.Println(style.Actionf("Checking out '%s'...", branch))
-		if err := worktree.Checkout(branch); err != nil {
+		if err := switchWorktreeBranch(absPath, mainRepo, branch, switchRunSetup); err != nil {
 			return err
-		}
-
-		reg := registry.New("")
-		if err := reg.UpdateField(absPath, "branch", branch); err != nil {
-			fmt.Fprintln(os.Stderr, style.Warnf("could not update branch in registry: %v", err))
-		}
-
-		uc := config.LoadUserConfig("")
-		s := setup.New(absPath, mainRepo, uc)
-		s.Options.RefreshOnly = !switchRunSetup
-		alloc, err := s.Run()
-		if err != nil {
-			return fmt.Errorf("refresh failed: %w", err)
-		}
-
-		fmt.Println()
-		fmt.Printf("Switched to %s\n", branch)
-		fmt.Printf("  Path: %s\n", absPath)
-		if alloc != nil && alloc.Port > 0 {
-			fmt.Printf("  URL:  http://localhost:%d\n", alloc.Port)
 		}
 
 		if switchRestart {
@@ -103,6 +75,43 @@ Must be run from inside a worktree (not the main repo).`,
 
 		return nil
 	},
+}
+
+// switchWorktreeBranch fetches a branch, checks it out in the current worktree,
+// updates the registry, and refreshes the environment. Shared by gtl switch
+// and gtl review (when switching in place).
+func switchWorktreeBranch(absPath, mainRepo, branch string, runSetup bool) error {
+	fmt.Println(style.Actionf("Fetching origin/%s...", branch))
+	if err := worktree.Fetch("origin", branch); err != nil {
+		fmt.Fprintln(os.Stderr, style.Warnf("fetch failed (%s), trying local checkout", err))
+	}
+
+	fmt.Println(style.Actionf("Checking out '%s'...", branch))
+	if err := worktree.Checkout(branch); err != nil {
+		return err
+	}
+
+	reg := registry.New("")
+	if err := reg.UpdateField(absPath, "branch", branch); err != nil {
+		fmt.Fprintln(os.Stderr, style.Warnf("could not update branch in registry: %v", err))
+	}
+
+	uc := config.LoadUserConfig("")
+	s := setup.New(absPath, mainRepo, uc)
+	s.Options.RefreshOnly = !runSetup
+	alloc, err := s.Run()
+	if err != nil {
+		return fmt.Errorf("refresh failed: %w", err)
+	}
+
+	fmt.Println()
+	fmt.Printf("Switched to %s\n", branch)
+	fmt.Printf("  Path: %s\n", absPath)
+	if alloc != nil && alloc.Port > 0 {
+		fmt.Printf("  URL:  http://localhost:%d\n", alloc.Port)
+	}
+
+	return nil
 }
 
 func completeBranchesAndPRs(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {

--- a/cmd/tunnel.go
+++ b/cmd/tunnel.go
@@ -58,7 +58,7 @@ Related commands:
 		uc := config.LoadUserConfig("")
 		port, entry, err := resolveTunnelTarget(args)
 		if err != nil {
-			return err
+			return cliErr(cmd, err)
 		}
 
 		domain := tunnelDomain


### PR DESCRIPTION
## What

Make `gtl review` and `gtl new` worktree-aware so they work from inside existing worktrees instead of blocking with an error. Also suppress cobra usage output for domain/state errors across all commands.

## Why

Previously, running `gtl new` or `gtl review` from inside a worktree produced a hard error telling the user to `cd` back to the main repo. This was frustrating in real workflows where you're already in a worktree and want to create another or review a PR.

Now both commands detect the worktree context and offer interactive prompts:
- `gtl new` confirms the target path and proceeds to create a sibling worktree (`--force` to skip)
- `gtl review` offers to switch the current worktree to the PR branch in-place

The `cliErr()` helper ensures domain errors (bad state, missing config, timeouts) suppress cobra's usage output while preserving it for invocation errors (wrong args, invalid flags).

## Changes

- **`cmd/new.go`**: Replace `worktreeGuard()` with interactive confirmation when inside a worktree. Add `--force` flag. Extract `resolveNewWorktreePath()` to deduplicate path resolution.
- **`cmd/review.go`**: Replace `worktreeGuard()` with branch-switching flow when inside a worktree. Reuses `switchWorktreeBranch()` and handles `--open`/`--start` flags.
- **`cmd/error.go`**: Add `cliErr(cmd, err)` helper that sets `SilenceUsage` for non-nil errors.
- **`cmd/output.go`**: Add `isInWorktree()` with symlink resolution and fallback.
- **`cmd/server.go`**, **`cmd/tunnel.go`**, **`cmd/share.go`**: Wrap bare `*CliError` returns with `cliErr()`.
- **`cmd/guard_test.go`**: Add AST guard ensuring `*CliError` returns in RunE use `cliErr()`. Includes allowlist of known CliError-producing helpers.

## Test plan

- [x] `go test ./...` — all 27 packages pass
- [x] `cliErr()` unit tests: suppresses usage on error, no-op on nil, preserves usage for cobra validation errors
- [x] `isInWorktree()` tests: same path, different path, symlink resolution, nonexistent fallback
- [x] `resolveNewWorktreePath()` tests: `--path` override, user config template, default sibling layout
- [x] AST guard validates no bare `*CliError` returns in RunE functions

## Known issue

When inside a worktree, `gtl new <branch>` shows a confirmation prompt with the target path, but if the branch is already checked out in another worktree, the subsequent `FindWorktreeForBranch` check takes a different code path. The displayed path can be misleading in that case. Tracked for follow-up.