### PR TITLE
Add project name drift detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [0.37.0]
 
+- **Project name drift detection** — `gtl start`, `gtl setup`, and `gtl env sync` now detect when the `project` field in `.treeline.yml` doesn't match the registry allocation. On drift, the user is prompted to revert `.treeline.yml` to the registry name (default: yes). Declining aborts with a hint to release all worktrees first, then re-setup. `gtl doctor` reports drift diagnostically (text and `--json`).
 - **`gtl routes` command** — shows routing URLs for the current worktree. Prints the HTTPS router URL (or localhost fallback) for every allocated port, plus tunnel URL when configured. Supports `--json` for scripting and MCP consumption.
 - **MCP write operations** — the MCP server now supports `setup`, `new`, `link`, `unlink`, `config_set`, and `env_sync` tools. Read tools expanded with `resolve`, `env`, `where`, and `routes`. Tool descriptions improved for AI agent consumption.
 - **Shared `proxy.BuildRouterURL`** — router URL construction extracted from three call sites into a single testable function. Eliminates duplication across `open`, `resolve`, `routes`, and MCP tools.

--- a/README.md
+++ b/README.md
@@ -636,7 +636,7 @@ See [Framework examples](#framework-examples) for complete examples. Available f
 
 | Field | Description |
 |---|---|
-| `project` | Project name (defaults to directory name) |
+| `project` | Project name (defaults to directory name). Once allocated, renaming triggers drift detection — see below |
 | `merge_target` | Branch that `prune --merged` checks against (auto-detected if omitted) |
 | `port_count` | Number of contiguous ports per worktree (default: 1) |
 | `env_file` | Env file path (string shorthand, e.g. `.env.local`) — or map with `path` and `seed_from` when they differ |
@@ -677,6 +677,14 @@ Available in `env` values:
 | `{resolve:project/branch}` | URL of another project's allocation on a specific branch |
 
 > **`{router_url}` vs `localhost:{port}` for your app's host:** Use `localhost:{port}` for your application's canonical host (e.g. `APPLICATION_HOST`, `APP_URL`). It works whether or not `gtl serve` is running and has zero external dependencies. Reserve `{router_url}` for values that specifically need the HTTPS router domain — CORS allowed origins, CSP directives, or cross-service display links.
+
+### Project name drift detection
+
+Once a worktree is allocated, the `project` name is stored in the registry and used for database names, Redis key prefixes, router URLs, and resolve links. If you rename `project:` in `.treeline.yml` without releasing and re-allocating, those persistent identifiers become stale.
+
+`gtl start`, `gtl setup`, and `gtl env sync` detect this mismatch and prompt to revert `.treeline.yml` to the registry name. `gtl doctor` reports drift diagnostically.
+
+To actually rename a project: release all worktrees (`gtl release --all --project <old-name>`), update `.treeline.yml`, then run `gtl setup`.
 
 ## Database cloning (optional)
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -45,6 +45,7 @@ var doctorCmd = &cobra.Command{
 		}
 
 		doctorConfig(pc, det, absPath)
+		doctorProjectDrift(absPath)
 		doctorPortConfig()
 		doctorAllocation(absPath)
 		doctorRuntime(absPath)
@@ -71,6 +72,10 @@ func doctorJSONOutput(pc *config.ProjectConfig, det *detect.Result, absPath stri
 		cfgInfo["treeline_yml"] = "missing"
 	}
 	result["config"] = cfgInfo
+
+	if drift := doctorProjectDriftJSON(absPath); drift != nil {
+		result["project_drift"] = drift
+	}
 
 	reg := registry.New("")
 	alloc := reg.Find(absPath)

--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/git-treeline/git-treeline/internal/config"
+	"github.com/git-treeline/git-treeline/internal/registry"
+	"github.com/git-treeline/git-treeline/internal/style"
+)
+
+// detectProjectDrift compares the project name in .treeline.yml against the
+// registry allocation. Returns the YAML name, registry name, and whether they
+// differ. No drift is reported when no allocation exists yet.
+func detectProjectDrift(absPath string) (yamlName, registryName string, drifted bool) {
+	return detectProjectDriftWith(absPath, registry.New(""))
+}
+
+// detectProjectDriftWith is the testable core — accepts an explicit registry.
+func detectProjectDriftWith(absPath string, reg *registry.Registry) (yamlName, registryName string, drifted bool) {
+	pc := config.LoadProjectConfig(absPath)
+	yamlName = pc.Project()
+
+	alloc := reg.Find(absPath)
+	if alloc == nil {
+		return yamlName, "", false
+	}
+	registryName = registry.GetString(alloc, "project")
+	if registryName == "" {
+		return yamlName, "", false
+	}
+	return yamlName, registryName, yamlName != registryName
+}
+
+// checkDriftOrAbort detects project name drift and prompts the user to revert
+// .treeline.yml. Returns nil if there's no drift or the user accepted the
+// revert. Returns a non-nil error (suitable for cliErr) if the user declined
+// — the caller should not proceed.
+func checkDriftOrAbort(absPath string) error {
+	yamlName, registryName, drifted := detectProjectDrift(absPath)
+	if !drifted {
+		return nil
+	}
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, style.Warnf("Project name mismatch:"))
+	fmt.Fprintf(os.Stderr, "    .treeline.yml says %q, registry says %q.\n\n", yamlName, registryName)
+	fmt.Fprintln(os.Stderr, "  All routing, databases, and resolve links use", fmt.Sprintf("%q.", registryName))
+	fmt.Fprintln(os.Stderr)
+
+	if promptDefaultYes(fmt.Sprintf("  Revert .treeline.yml to %q?", registryName)) {
+		if err := revertProjectInYAML(absPath, registryName); err != nil {
+			return fmt.Errorf("reverting project name: %w", err)
+		}
+		fmt.Fprintf(os.Stderr, "  Reverted project to %q in .treeline.yml.\n\n", registryName)
+		return nil
+	}
+
+	return &CliError{
+		Message: fmt.Sprintf("Project name mismatch: .treeline.yml=%q, registry=%q.", yamlName, registryName),
+		Hint: fmt.Sprintf("To rename the project, release all worktrees first:\n"+
+			"    gtl release --all --project %s\n"+
+			"  Then update .treeline.yml and run gtl setup.", registryName),
+	}
+}
+
+// revertProjectInYAML writes the registry project name back to .treeline.yml.
+func revertProjectInYAML(absPath, registryName string) error {
+	pc := config.LoadProjectConfig(absPath)
+	return pc.SetProject(registryName)
+}
+
+// promptDefaultYes asks a [Y/n] question where Enter defaults to yes.
+func promptDefaultYes(message string) bool {
+	fmt.Printf("%s [Y/n] ", message)
+	scanner := bufio.NewScanner(os.Stdin)
+	if scanner.Scan() {
+		answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
+		if answer == "" || answer == "y" || answer == "yes" {
+			return true
+		}
+	}
+	return false
+}
+
+// doctorProjectDrift reports project name drift as a diagnostic finding.
+// Returns true if drift was detected.
+func doctorProjectDrift(absPath string) bool {
+	return doctorProjectDriftWith(absPath, registry.New(""))
+}
+
+func doctorProjectDriftWith(absPath string, reg *registry.Registry) bool {
+	yamlName, registryName, drifted := detectProjectDriftWith(absPath, reg)
+	if !drifted {
+		return false
+	}
+	fmt.Println("\nProject")
+	doctorLine("Name drift", fmt.Sprintf("⚠ .treeline.yml=%q, registry=%q", yamlName, registryName))
+	fmt.Println("  Routing, databases, and resolve links use", fmt.Sprintf("%q.", registryName))
+	fmt.Printf("  To fix: revert project: in .treeline.yml to %q\n", registryName)
+	return true
+}
+
+// doctorProjectDriftJSON returns drift info for JSON doctor output, or nil.
+func doctorProjectDriftJSON(absPath string) map[string]string {
+	return doctorProjectDriftJSONWith(absPath, registry.New(""))
+}
+
+func doctorProjectDriftJSONWith(absPath string, reg *registry.Registry) map[string]string {
+	yamlName, registryName, drifted := detectProjectDriftWith(absPath, reg)
+	if !drifted {
+		return nil
+	}
+	return map[string]string{
+		"status":        "drift",
+		"yaml_project":  yamlName,
+		"registry_name": registryName,
+	}
+}

--- a/cmd/drift_test.go
+++ b/cmd/drift_test.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/git-treeline/git-treeline/internal/registry"
+)
+
+func TestDetectProjectDrift_NoDrift(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: myapp\n"), 0o644)
+
+	regFile := filepath.Join(t.TempDir(), "registry.json")
+	reg := registry.New(regFile)
+	_ = reg.Allocate(registry.Allocation{
+		"worktree": dir,
+		"project":  "myapp",
+		"port":     3002,
+	})
+
+	yamlName, regName, drifted := detectProjectDriftWith(dir, reg)
+	if drifted {
+		t.Errorf("expected no drift, got yaml=%q reg=%q", yamlName, regName)
+	}
+}
+
+func TestDetectProjectDrift_Drifted(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: new-name\n"), 0o644)
+
+	regFile := filepath.Join(t.TempDir(), "registry.json")
+	reg := registry.New(regFile)
+	_ = reg.Allocate(registry.Allocation{
+		"worktree": dir,
+		"project":  "old-name",
+		"port":     3002,
+	})
+
+	yamlName, regName, drifted := detectProjectDriftWith(dir, reg)
+	if !drifted {
+		t.Fatal("expected drift")
+	}
+	if yamlName != "new-name" {
+		t.Errorf("yaml name: got %q, want %q", yamlName, "new-name")
+	}
+	if regName != "old-name" {
+		t.Errorf("registry name: got %q, want %q", regName, "old-name")
+	}
+}
+
+func TestDetectProjectDrift_NoAllocation(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: myapp\n"), 0o644)
+
+	regFile := filepath.Join(t.TempDir(), "registry.json")
+	reg := registry.New(regFile)
+
+	_, _, drifted := detectProjectDriftWith(dir, reg)
+	if drifted {
+		t.Error("expected no drift when no allocation exists")
+	}
+}
+
+func TestDetectProjectDrift_EmptyRegistryProject(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: myapp\n"), 0o644)
+
+	regFile := filepath.Join(t.TempDir(), "registry.json")
+	reg := registry.New(regFile)
+	_ = reg.Allocate(registry.Allocation{
+		"worktree": dir,
+		"port":     3002,
+	})
+
+	_, _, drifted := detectProjectDriftWith(dir, reg)
+	if drifted {
+		t.Error("expected no drift when registry has no project field")
+	}
+}
+
+func TestDoctorProjectDrift_NoDrift(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: myapp\n"), 0o644)
+
+	regFile := filepath.Join(t.TempDir(), "registry.json")
+	reg := registry.New(regFile)
+	_ = reg.Allocate(registry.Allocation{
+		"worktree": dir,
+		"project":  "myapp",
+		"port":     3002,
+	})
+
+	result := doctorProjectDriftJSONWith(dir, reg)
+	if result != nil {
+		t.Errorf("expected nil for no drift, got %v", result)
+	}
+}
+
+func TestDoctorProjectDrift_Drifted(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: renamed\n"), 0o644)
+
+	regFile := filepath.Join(t.TempDir(), "registry.json")
+	reg := registry.New(regFile)
+	_ = reg.Allocate(registry.Allocation{
+		"worktree": dir,
+		"project":  "original",
+		"port":     3002,
+	})
+
+	result := doctorProjectDriftJSONWith(dir, reg)
+	if result == nil {
+		t.Fatal("expected drift result")
+	}
+	if result["status"] != "drift" {
+		t.Errorf("status: got %q, want %q", result["status"], "drift")
+	}
+	if result["yaml_project"] != "renamed" {
+		t.Errorf("yaml_project: got %q", result["yaml_project"])
+	}
+	if result["registry_name"] != "original" {
+		t.Errorf("registry_name: got %q", result["registry_name"])
+	}
+}
+
+func TestRevertProjectInYAML(t *testing.T) {
+	dir := t.TempDir()
+	ymlPath := filepath.Join(dir, ".treeline.yml")
+	_ = os.WriteFile(ymlPath, []byte("project: wrong-name\nport_count: 2\n"), 0o644)
+
+	if err := revertProjectInYAML(dir, "correct-name"); err != nil {
+		t.Fatalf("revert failed: %v", err)
+	}
+
+	data, _ := os.ReadFile(ymlPath)
+	content := string(data)
+	if !strings.Contains(content, "project: correct-name") {
+		t.Errorf("expected reverted project name, got:\n%s", content)
+	}
+	if !strings.Contains(content, "port_count: 2") {
+		t.Errorf("expected other fields preserved, got:\n%s", content)
+	}
+}
+
+func TestDoctorProjectDriftWith_NoDrift(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: myapp\n"), 0o644)
+
+	regFile := filepath.Join(t.TempDir(), "registry.json")
+	reg := registry.New(regFile)
+	_ = reg.Allocate(registry.Allocation{
+		"worktree": dir,
+		"project":  "myapp",
+		"port":     3002,
+	})
+
+	if doctorProjectDriftWith(dir, reg) {
+		t.Error("expected no drift reported")
+	}
+}
+
+func TestDoctorProjectDriftWith_Drifted(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: new\n"), 0o644)
+
+	regFile := filepath.Join(t.TempDir(), "registry.json")
+	reg := registry.New(regFile)
+	_ = reg.Allocate(registry.Allocation{
+		"worktree": dir,
+		"project":  "old",
+		"port":     3002,
+	})
+
+	if !doctorProjectDriftWith(dir, reg) {
+		t.Error("expected drift reported")
+	}
+}

--- a/cmd/env_sync.go
+++ b/cmd/env_sync.go
@@ -30,6 +30,10 @@ Use this when you've edited .treeline.yml and don't use 'gtl start'
 		}
 		absPath, _ := filepath.Abs(cwd)
 
+		if err := checkDriftOrAbort(absPath); err != nil {
+			return cliErr(cmd, err)
+		}
+
 		pc := config.LoadProjectConfig(absPath)
 		uc := config.LoadUserConfig("")
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -106,7 +106,11 @@ resumes the server in the original terminal. Ctrl+C exits the supervisor.`,
 			return nil
 		}
 
-		// Fresh start path — run pre_start hooks
+		// Fresh start — check for project name drift before proceeding
+		if err := checkDriftOrAbort(absPath); err != nil {
+			return cliErr(cmd, err)
+		}
+
 		if err := runPreStartHooks(activeHooks, port, absPath); err != nil {
 			return cliErr(cmd, err)
 		}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -62,6 +62,11 @@ var setupCmd = &cobra.Command{
 			path = args[0]
 		}
 
+		setupAbs, _ := filepath.Abs(path)
+		if err := checkDriftOrAbort(setupAbs); err != nil {
+			return cliErr(cmd, err)
+		}
+
 		uc := config.LoadUserConfig("")
 		s := setup.New(path, setupMainRepo, uc)
 		s.Options.DryRun = setupDryRun

--- a/docs/CONFIG_LIFECYCLE.md
+++ b/docs/CONFIG_LIFECYCLE.md
@@ -21,7 +21,7 @@ Edit `.treeline.yml` in your worktree, then use `gtl start`, `gtl env sync`, or 
 | `copy_files` | No — provisioning only | `gtl setup` |
 | `database.*` | No — destructive | `gtl db reset` |
 | `port_count` | No — registry conflict risk | `gtl setup` |
-| `project` | Yes (read on demand) | Next command that uses it |
+| `project` | Yes — **drift detection** (see below) | Revert `.treeline.yml` when prompted |
 | `hooks` | N/A | Fires when the hook event occurs |
 
 **Note on `commands.start`:** `gtl start` reads the new command only when no supervisor is running. If the supervisor is already alive (even if the server was stopped via `gtl stop`), `gtl start` resumes with the original command — `gtl stop` stops the child process but the supervisor stays alive. To pick up a new `commands.start`, Ctrl+C the supervisor terminal and run `gtl start` fresh. (`gtl restart` will warn you if it detects a mismatch.)
@@ -77,6 +77,16 @@ You updated setup commands — for example, added `yarn install`.
 - **`gtl setup`** runs the new commands.
 - **`gtl switch --setup`** runs setup after switching branches.
 - Not automatic on `gtl start` — setup commands can be slow (bundle install, migrations).
+
+### "I changed `project`"
+
+You renamed the `project:` field in `.treeline.yml`.
+
+- **`gtl start`, `gtl setup`, `gtl env sync`** detect the mismatch between the YAML name and the registry name and prompt you to revert.
+- **Default behavior:** accept the revert (Enter / Y). The `.treeline.yml` is rewritten to the registry name and the command proceeds.
+- **Decline:** the command aborts. Routing, databases, Redis keys, and resolve links are all keyed to the original name — changing it without migrating those resources would cause silent breakage.
+- **To actually rename:** release all worktrees for the project (`gtl release --all --project <name>`), update `.treeline.yml`, then run `gtl setup` to allocate under the new name.
+- **`gtl doctor`** reports drift diagnostically without prompting.
 
 ### "I changed `port_count`"
 

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -324,6 +324,36 @@ func (pc *ProjectConfig) Exists() bool {
 	return err == nil
 }
 
+// SetProject writes the project name to .treeline.yml. If a project: line
+// exists, it's replaced in place. Otherwise the field is prepended.
+func (pc *ProjectConfig) SetProject(name string) error {
+	path := pc.configPath()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	content := string(raw)
+	newLine := fmt.Sprintf("project: %s", name)
+
+	lines := strings.Split(content, "\n")
+	found := false
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "project:") {
+			lines[i] = newLine
+			found = true
+			break
+		}
+	}
+	if !found {
+		lines = append([]string{newLine}, lines...)
+	}
+
+	pc.Data["project"] = name
+	return os.WriteFile(path, []byte(strings.Join(lines, "\n")), 0o644)
+}
+
 // migrateDefaultBranch rewrites default_branch → merge_target in the YAML
 // file if the old key is present. Runs once per load, idempotent.
 func (pc *ProjectConfig) migrateDefaultBranch() {

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -721,6 +721,67 @@ hooks:
 	}
 }
 
+func TestSetProject_ExistingKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".treeline.yml")
+	_ = os.WriteFile(path, []byte("project: old-name\nport_count: 2\n"), 0o644)
+
+	pc := LoadProjectConfig(dir)
+	if err := pc.SetProject("new-name"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if !strings.Contains(content, "project: new-name") {
+		t.Errorf("expected project: new-name, got:\n%s", content)
+	}
+	if strings.Contains(content, "old-name") {
+		t.Errorf("old name should be gone, got:\n%s", content)
+	}
+	if !strings.Contains(content, "port_count: 2") {
+		t.Errorf("expected other fields preserved, got:\n%s", content)
+	}
+	if pc.Project() != "new-name" {
+		t.Errorf("in-memory name: got %q, want %q", pc.Project(), "new-name")
+	}
+}
+
+func TestSetProject_NoExistingKey(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".treeline.yml")
+	_ = os.WriteFile(path, []byte("port_count: 2\n"), 0o644)
+
+	pc := LoadProjectConfig(dir)
+	if err := pc.SetProject("injected"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(path)
+	content := string(data)
+	if !strings.Contains(content, "project: injected") {
+		t.Errorf("expected project: injected prepended, got:\n%s", content)
+	}
+	if !strings.Contains(content, "port_count: 2") {
+		t.Errorf("expected existing content preserved, got:\n%s", content)
+	}
+}
+
+func TestSetProject_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".treeline.yml")
+	_ = os.WriteFile(path, []byte("project: myapp\n"), 0o644)
+
+	pc := LoadProjectConfig(dir)
+	_ = pc.SetProject("myapp")
+	_ = pc.SetProject("myapp")
+
+	data, _ := os.ReadFile(path)
+	if count := strings.Count(string(data), "project:"); count != 1 {
+		t.Errorf("expected exactly 1 project: line, got %d in:\n%s", count, string(data))
+	}
+}
+
 func TestRewriteEnvFileBlock_PreservesRestOfFile(t *testing.T) {
 	input := "project: myapp\n\nenv_file:\n  target: .env.local\n  source: .env.local\n\ndatabase:\n  adapter: postgresql\n"
 	got := rewriteEnvFileToSimple(input, ".env.local")


### PR DESCRIPTION
## Summary

When the `project` field in `.treeline.yml` is renamed after allocation, all persistent identifiers (database names, Redis key prefixes, router URLs, resolve links, port reservations) silently break because they're keyed to the original name. This PR adds drift detection to catch that before it causes damage.

### What it does

- **`gtl start` (fresh), `gtl setup`, `gtl env sync`** — on entry, compare `.treeline.yml` `project` against the registry allocation. On mismatch:
  - Warn with both names and explain what's at stake.
  - Prompt to revert `.treeline.yml` to the registry name (`[Y/n]`, default yes).
  - If the user accepts: rewrite the YAML, continue normally.
  - If the user declines: abort with guidance on the proper rename workflow (release all → update YAML → re-setup).
- **`gtl doctor`** — reports drift diagnostically in both text and `--json` output, without prompting.

### New files

| File | Purpose |
|------|---------|
| `cmd/drift.go` | `detectProjectDrift`, `checkDriftOrAbort`, `revertProjectInYAML`, `promptDefaultYes`, doctor helpers |
| `cmd/drift_test.go` | 9 tests — drift/no-drift detection, no-allocation, empty registry project, YAML revert, doctor text + JSON |

### Changes to existing files

| File | Change |
|------|--------|
| `internal/config/project.go` | Added `SetProject(name)` — line-level YAML replacement (or prepend if missing) |
| `internal/config/project_test.go` | 3 tests for `SetProject` (existing key, no key, idempotent) |
| `cmd/server.go` | Wire `checkDriftOrAbort` into fresh start path |
| `cmd/setup.go` | Wire `checkDriftOrAbort` before setup |
| `cmd/env_sync.go` | Wire `checkDriftOrAbort` before env sync |
| `cmd/doctor.go` | Wire `doctorProjectDrift` (text) and `doctorProjectDriftJSON` (JSON) |
| `CHANGELOG.md` | New entry under 0.37.0 |
| `README.md` | Updated `project` field description + new "Project name drift detection" section |
| `docs/CONFIG_LIFECYCLE.md` | Updated `project` row in quick reference + new "I changed project" scenario |

### Design decisions

- **Registry is authoritative.** Once allocated, the registry name is the source of truth. YAML is the "desired state" that must match.
- **Default-yes revert.** The safe action (revert) is the default because accidental YAML edits are far more common than intentional renames.
- **No `gtl rename` yet.** Full rename involves migrating databases, Redis keys, router routes, and user config reservations atomically — deferred to a future release. Drift detection provides the safety net in the meantime.
- **Testable core with DI.** Detection functions accept an explicit `*registry.Registry` for testing, with convenience wrappers that use the default registry for production paths.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (12 new tests)
- [x] `go vet ./...` clean
- [x] Manual: edit `project:` in a `.treeline.yml` for an allocated worktree, run `gtl start` — should see warning + revert prompt
- [x] Manual: decline the revert — should abort with release hint
- [x] Manual: run `gtl doctor` with drift — should see diagnostic line
- [x] Manual: run `gtl doctor --json` with drift — should see `project_drift` key