### PR TITLE
Auto-detect port in gtl serve alias when omitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [Unreleased]
+
+- **`gtl serve alias` auto-detects port** — running `gtl serve alias <name>` from a worktree directory now looks up the allocated port automatically. If the allocation has multiple ports, an interactive selector is shown. Explicit `gtl serve alias <name> <port>` still works as before.
+
 ## [0.38.0]
 
 - **Project name drift detection** — `gtl start`, `gtl setup`, and `gtl env sync` now detect when the `project` field in `.treeline.yml` doesn't match the registry allocation. On drift, the user is prompted to revert `.treeline.yml` to the registry name (default: yes). Declining aborts with a hint to release all worktrees first, then re-setup. `gtl doctor` reports drift diagnostically (text and `--json`).

--- a/README.md
+++ b/README.md
@@ -794,6 +794,7 @@ gtl db name --json         # {"database": "myapp_feature_xyz"}
 | `gtl serve install` | | One-time setup: CA trust, port forwarding, background service |
 | `gtl serve status` | | Show router routes and service health |
 | `gtl serve uninstall` | | Remove CA trust, port forwarding, and service |
+| `gtl serve alias [name] [port]` | `--remove` | Add/remove/list static subdomain aliases. Port auto-detected from current directory when omitted |
 | `gtl proxy <port> [target]` | `--tls` | Forward traffic from a stable port to a worktree port |
 | `gtl tunnel [port]` | `--domain` `--tunnel` | Expose a local port via Cloudflare tunnel (quick or named) |
 | `gtl tunnel setup` | | Interactive setup for named tunnels with BYO domain |

--- a/cmd/drift_test.go
+++ b/cmd/drift_test.go
@@ -13,8 +13,7 @@ func TestDetectProjectDrift_NoDrift(t *testing.T) {
 	dir := t.TempDir()
 	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: myapp\n"), 0o644)
 
-	regFile := filepath.Join(t.TempDir(), "registry.json")
-	reg := registry.New(regFile)
+	reg := newTestRegistry(t)
 	_ = reg.Allocate(registry.Allocation{
 		"worktree": dir,
 		"project":  "myapp",
@@ -31,8 +30,7 @@ func TestDetectProjectDrift_Drifted(t *testing.T) {
 	dir := t.TempDir()
 	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: new-name\n"), 0o644)
 
-	regFile := filepath.Join(t.TempDir(), "registry.json")
-	reg := registry.New(regFile)
+	reg := newTestRegistry(t)
 	_ = reg.Allocate(registry.Allocation{
 		"worktree": dir,
 		"project":  "old-name",
@@ -55,8 +53,7 @@ func TestDetectProjectDrift_NoAllocation(t *testing.T) {
 	dir := t.TempDir()
 	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: myapp\n"), 0o644)
 
-	regFile := filepath.Join(t.TempDir(), "registry.json")
-	reg := registry.New(regFile)
+	reg := newTestRegistry(t)
 
 	_, _, drifted := detectProjectDriftWith(dir, reg)
 	if drifted {
@@ -68,8 +65,7 @@ func TestDetectProjectDrift_EmptyRegistryProject(t *testing.T) {
 	dir := t.TempDir()
 	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: myapp\n"), 0o644)
 
-	regFile := filepath.Join(t.TempDir(), "registry.json")
-	reg := registry.New(regFile)
+	reg := newTestRegistry(t)
 	_ = reg.Allocate(registry.Allocation{
 		"worktree": dir,
 		"port":     3002,
@@ -85,8 +81,7 @@ func TestDoctorProjectDrift_NoDrift(t *testing.T) {
 	dir := t.TempDir()
 	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: myapp\n"), 0o644)
 
-	regFile := filepath.Join(t.TempDir(), "registry.json")
-	reg := registry.New(regFile)
+	reg := newTestRegistry(t)
 	_ = reg.Allocate(registry.Allocation{
 		"worktree": dir,
 		"project":  "myapp",
@@ -103,8 +98,7 @@ func TestDoctorProjectDrift_Drifted(t *testing.T) {
 	dir := t.TempDir()
 	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: renamed\n"), 0o644)
 
-	regFile := filepath.Join(t.TempDir(), "registry.json")
-	reg := registry.New(regFile)
+	reg := newTestRegistry(t)
 	_ = reg.Allocate(registry.Allocation{
 		"worktree": dir,
 		"project":  "original",
@@ -149,8 +143,7 @@ func TestDoctorProjectDriftWith_NoDrift(t *testing.T) {
 	dir := t.TempDir()
 	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: myapp\n"), 0o644)
 
-	regFile := filepath.Join(t.TempDir(), "registry.json")
-	reg := registry.New(regFile)
+	reg := newTestRegistry(t)
 	_ = reg.Allocate(registry.Allocation{
 		"worktree": dir,
 		"project":  "myapp",
@@ -166,8 +159,7 @@ func TestDoctorProjectDriftWith_Drifted(t *testing.T) {
 	dir := t.TempDir()
 	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: new\n"), 0o644)
 
-	regFile := filepath.Join(t.TempDir(), "registry.json")
-	reg := registry.New(regFile)
+	reg := newTestRegistry(t)
 	_ = reg.Allocate(registry.Allocation{
 		"worktree": dir,
 		"project":  "old",

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"runtime"
 	"sort"
 	"strconv"
 
 	"github.com/git-treeline/git-treeline/internal/config"
+	"github.com/git-treeline/git-treeline/internal/confirm"
 	"github.com/git-treeline/git-treeline/internal/proxy"
 	"github.com/git-treeline/git-treeline/internal/registry"
 	"github.com/git-treeline/git-treeline/internal/service"
@@ -320,6 +322,7 @@ var serveAliasCmd = &cobra.Command{
 
 Aliases let you route non-gtl services through the router:
   gtl serve alias redis-ui 8081    → redis-ui.{domain}:8081
+  gtl serve alias redis-ui         → detect port from current directory
   gtl serve alias --remove redis-ui
   gtl serve alias                  → list all aliases`,
 	Args: cobra.MaximumNArgs(2),
@@ -368,16 +371,19 @@ Aliases let you route non-gtl services through the router:
 			return nil
 		}
 
-		if len(args) < 2 {
-			return cliErr(cmd, &CliError{
-				Message: "Missing port for alias.",
-				Hint:    "Usage: gtl serve alias <name> <port>",
-			})
-		}
-
-		port, err := strconv.Atoi(args[1])
-		if err != nil || port < 1 || port > 65535 {
-			return cliErr(cmd, errInvalidPort(args[1]))
+		var port int
+		if len(args) >= 2 {
+			var err error
+			port, err = strconv.Atoi(args[1])
+			if err != nil || port < 1 || port > 65535 {
+				return cliErr(cmd, errInvalidPort(args[1]))
+			}
+		} else {
+			detected, err := detectAliasPort()
+			if err != nil {
+				return cliErr(cmd, err)
+			}
+			port = detected
 		}
 
 		uc.Set("router.aliases."+name, float64(port))
@@ -388,6 +394,50 @@ Aliases let you route non-gtl services through the router:
 		fmt.Println("The router will pick this up on next refresh (~5s).")
 		return nil
 	},
+}
+
+// detectAliasPort resolves the port for the current directory's allocation.
+// If the allocation has multiple ports, the user is prompted to choose.
+func detectAliasPort() (int, error) {
+	absPath, err := os.Getwd()
+	if err != nil {
+		return 0, &CliError{
+			Message: "Could not determine current directory.",
+			Hint:    "Usage: gtl serve alias <name> <port>",
+		}
+	}
+	return detectAliasPortFrom(absPath, registry.New(""), nil)
+}
+
+// detectAliasPortFrom is the testable core. reader overrides stdin for the
+// multi-port prompt; pass nil for real interactive use.
+func detectAliasPortFrom(absPath string, reg *registry.Registry, reader io.Reader) (int, error) {
+	alloc := reg.Find(absPath)
+	if alloc == nil {
+		return 0, &CliError{
+			Message: "No port found for this directory.",
+			Hint:    "Run 'gtl setup' to allocate a port, or specify one explicitly:\n  gtl serve alias <name> <port>",
+		}
+	}
+
+	ports := registry.ExtractPorts(alloc)
+	if len(ports) == 0 {
+		return 0, &CliError{
+			Message: "Allocation exists but has no ports assigned.",
+			Hint:    "Run 'gtl start' to assign a port, or specify one explicitly:\n  gtl serve alias <name> <port>",
+		}
+	}
+
+	if len(ports) == 1 {
+		return ports[0], nil
+	}
+
+	options := make([]string, len(ports))
+	for i, p := range ports {
+		options[i] = strconv.Itoa(p)
+	}
+	idx := confirm.Select("Multiple ports allocated — which one?", options, 0, reader)
+	return ports[idx], nil
 }
 
 var serveHostsCmd = &cobra.Command{

--- a/cmd/serve_alias_test.go
+++ b/cmd/serve_alias_test.go
@@ -1,0 +1,174 @@
+package cmd
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/git-treeline/git-treeline/internal/registry"
+)
+
+func newTestRegistry(t *testing.T) *registry.Registry {
+	t.Helper()
+	return registry.New(filepath.Join(t.TempDir(), "registry.json"))
+}
+
+func TestDetectAliasPort_SinglePort(t *testing.T) {
+	reg := newTestRegistry(t)
+	if err := reg.Allocate(registry.Allocation{
+		"worktree": "/wt/myapp",
+		"project":  "myapp",
+		"port":     float64(3000),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	port, err := detectAliasPortFrom("/wt/myapp", reg, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port != 3000 {
+		t.Errorf("expected 3000, got %d", port)
+	}
+}
+
+func TestDetectAliasPort_MultiplePorts_SelectsFirst(t *testing.T) {
+	reg := newTestRegistry(t)
+	if err := reg.Allocate(registry.Allocation{
+		"worktree": "/wt/myapp",
+		"project":  "myapp",
+		"ports":    []any{float64(3000), float64(3001), float64(3002)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := strings.NewReader("\n")
+	port, err := detectAliasPortFrom("/wt/myapp", reg, reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port != 3000 {
+		t.Errorf("expected 3000 (default), got %d", port)
+	}
+}
+
+func TestDetectAliasPort_MultiplePorts_SelectsSecond(t *testing.T) {
+	reg := newTestRegistry(t)
+	if err := reg.Allocate(registry.Allocation{
+		"worktree": "/wt/myapp",
+		"project":  "myapp",
+		"ports":    []any{float64(3000), float64(3001)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	reader := strings.NewReader("2\n")
+	port, err := detectAliasPortFrom("/wt/myapp", reg, reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port != 3001 {
+		t.Errorf("expected 3001, got %d", port)
+	}
+}
+
+func TestDetectAliasPort_NoAllocation(t *testing.T) {
+	reg := newTestRegistry(t)
+
+	_, err := detectAliasPortFrom("/wt/missing", reg, nil)
+	if err == nil {
+		t.Fatal("expected error for missing allocation")
+	}
+	cliError, ok := err.(*CliError)
+	if !ok {
+		t.Fatalf("expected *CliError, got %T", err)
+	}
+	if !strings.Contains(cliError.Message, "No port found") {
+		t.Errorf("expected 'No port found' message, got: %s", cliError.Message)
+	}
+	if !strings.Contains(cliError.Hint, "gtl setup") {
+		t.Errorf("expected hint to mention 'gtl setup', got: %s", cliError.Hint)
+	}
+}
+
+func TestDetectAliasPort_AllocationWithoutPorts(t *testing.T) {
+	reg := newTestRegistry(t)
+	if err := reg.Allocate(registry.Allocation{
+		"worktree": "/wt/myapp",
+		"project":  "myapp",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := detectAliasPortFrom("/wt/myapp", reg, nil)
+	if err == nil {
+		t.Fatal("expected error for allocation without ports")
+	}
+	cliError, ok := err.(*CliError)
+	if !ok {
+		t.Fatalf("expected *CliError, got %T", err)
+	}
+	if !strings.Contains(cliError.Message, "no ports assigned") {
+		t.Errorf("expected 'no ports assigned' message, got: %s", cliError.Message)
+	}
+	if !strings.Contains(cliError.Hint, "gtl start") {
+		t.Errorf("expected hint to mention 'gtl start', got: %s", cliError.Hint)
+	}
+}
+
+func TestDetectAliasPort_EmptyPortsArray(t *testing.T) {
+	reg := newTestRegistry(t)
+	if err := reg.Allocate(registry.Allocation{
+		"worktree": "/wt/myapp",
+		"project":  "myapp",
+		"ports":    []any{},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := detectAliasPortFrom("/wt/myapp", reg, nil)
+	if err == nil {
+		t.Fatal("expected error for empty ports array")
+	}
+}
+
+func TestDetectAliasPort_EmptyPortsArrayWithLegacyPort(t *testing.T) {
+	reg := newTestRegistry(t)
+	if err := reg.Allocate(registry.Allocation{
+		"worktree": "/wt/myapp",
+		"project":  "myapp",
+		"ports":    []any{},
+		"port":     float64(4000),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	port, err := detectAliasPortFrom("/wt/myapp", reg, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port != 4000 {
+		t.Errorf("expected legacy fallback to 4000, got %d", port)
+	}
+}
+
+func TestDetectAliasPort_MultiplePorts_InvalidInput(t *testing.T) {
+	reg := newTestRegistry(t)
+	if err := reg.Allocate(registry.Allocation{
+		"worktree": "/wt/myapp",
+		"project":  "myapp",
+		"ports":    []any{float64(5000), float64(5001)},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Invalid input falls back to default (first port)
+	reader := strings.NewReader("99\n")
+	port, err := detectAliasPortFrom("/wt/myapp", reg, reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if port != 5000 {
+		t.Errorf("expected default fallback to 5000, got %d", port)
+	}
+}


### PR DESCRIPTION
## Summary

- `gtl serve alias <name>` (without a port) now auto-detects the port from the current directory's registry allocation instead of erroring.
- Single port: used directly, no prompt.
- Multiple ports: `confirm.Select` picker lets the user choose which port to alias.
- No allocation / no ports: actionable error with hints to `gtl setup` or `gtl start`.
- DRYs up `drift_test.go` to share `newTestRegistry` helper with the new test file.
- Adds `gtl serve alias` to the README command table.

## Test plan

- [x] `TestDetectAliasPort_SinglePort` — legacy `port` field resolved
- [x] `TestDetectAliasPort_MultiplePorts_SelectsFirst` — Enter picks default (first)
- [x] `TestDetectAliasPort_MultiplePorts_SelectsSecond` — explicit selection
- [x] `TestDetectAliasPort_NoAllocation` — clear error with `gtl setup` hint
- [x] `TestDetectAliasPort_AllocationWithoutPorts` — clear error with `gtl start` hint
- [x] `TestDetectAliasPort_EmptyPortsArray` — empty `ports: []` treated as no ports
- [x] `TestDetectAliasPort_EmptyPortsArrayWithLegacyPort` — falls back to legacy `port`
- [x] `TestDetectAliasPort_MultiplePorts_InvalidInput` — garbage input defaults to first port
- [x] Full suite: `go test ./...` passes, `go vet ./...` clean