### PR TITLE
Add gtl install command; make setup work without HTTPS router

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## [Unreleased]
 
-- **`gtl install` command** — single command to set up git-treeline for a project and machine. Creates user config, installs the post-checkout hook, allocates ports, and optionally enables the local HTTPS router (prompted with a docs link). Safe to run on first clone or any time after — every step is idempotent. Replaces the fragmented `gtl serve install` → `gtl init` → `gtl setup` flow for developers joining an existing project.
+- **`gtl install` command** — single command to set up git-treeline for a project and machine. Creates `.treeline.yml` if missing, creates user config, installs the post-checkout hook, allocates ports, and optionally enables the local HTTPS router (prompted with a docs link). Safe to run on first clone or any time after — every step is idempotent. Replaces the fragmented `gtl init` → `gtl setup` onboarding flow and works for both first-project setup and later joiners.
 - **Core worktree commands no longer require HTTPS router** — previously `gtl setup`, `gtl new`, `gtl clone`, and `gtl review` would hard-fail if `gtl serve install` hadn't been run. Now they print a warning and proceed, so developers can use localhost-only workflows without the HTTPS stack. The warning points to `gtl install` or `gtl serve install`.
-- **Suppress optional router reminders** — if a user declines the optional HTTPS router prompt during `gtl install`, Treeline now offers to save `warnings.router: false` so localhost-only users do not see the reminder forever.
+- **Explicit router intent** — `router.mode` now records whether HTTPS routing should be prompted, disabled, or repaired automatically. `warnings.router: false` still suppresses reminders, but no longer changes env interpolation or disables router URLs by itself.
 - **Cleaner start URLs** — `gtl start` now prints the localhost URL alongside the router URL and no longer prints the tunnel command hint in start output. Use `gtl routes` or `gtl tunnel` when you need tunnel URLs.
 
 ## [0.38.1]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased]
+
+- **`gtl install` command** — single command to set up git-treeline for a project and machine. Creates user config, installs the post-checkout hook, allocates ports, and optionally enables the local HTTPS router (prompted with a docs link). Safe to run on first clone or any time after — every step is idempotent. Replaces the fragmented `gtl serve install` → `gtl init` → `gtl setup` flow for developers joining an existing project.
+- **Core worktree commands no longer require HTTPS router** — previously `gtl setup`, `gtl new`, `gtl clone`, and `gtl review` would hard-fail if `gtl serve install` hadn't been run. Now they print a warning and proceed, so developers can use localhost-only workflows without the HTTPS stack. The warning points to `gtl install` or `gtl serve install`.
+- **Suppress optional router reminders** — if a user declines the optional HTTPS router prompt during `gtl install`, Treeline now offers to save `warnings.router: false` so localhost-only users do not see the reminder forever.
+- **Cleaner start URLs** — `gtl start` now prints the localhost URL alongside the router URL and no longer prints the tunnel command hint in start output. Use `gtl routes` or `gtl tunnel` when you need tunnel URLs.
+
 ## [0.38.1]
 
 - **`gtl serve alias` auto-detects port** — running `gtl serve alias <name>` from a worktree directory now looks up the allocated port automatically. If the allocation has multiple ports, an interactive selector is shown. Explicit `gtl serve alias <name> <port>` still works as before.

--- a/README.md
+++ b/README.md
@@ -46,35 +46,42 @@ Download the latest binary from [GitHub Releases](https://github.com/git-treelin
 
 ## First-time setup on your machine
 
-Two different “setups”: **once per computer** (CLI + local HTTPS stack on macOS/Linux), and **once per git repository** (`gtl init`, then worktrees).
-
-- You do **not** need `gtl serve` before **`gtl init`**—only the binary on your `PATH`.
-- On **macOS and Linux**, you **do** need to run **`gtl serve install`** (or have the same local CA already present) **before** your first **`gtl setup`**, **`gtl new`**, or **`gtl clone`**: the CLI checks for the generated CA. That install also sets up the router, trusted certs, port forwarding, and background service—the product experience assumes this stack. See **`GTL_HEADLESS=1`** only for automation (CI) where you intentionally skip that check.
+Two paths depending on whether you're the **first developer** setting up git-treeline for a project, or **joining a project** that already has a `.treeline.yml`.
 
 ### 1. Install the CLI
 
 Use [Homebrew](#homebrew), [Go](#from-source-requires-go-126), or a [release binary](#from-release-binary). Installing `gtl` does **not** require `sudo` and does **not** install certificates or background services by itself.
 
-### 2. Local HTTPS router — `gtl serve install` (macOS / Linux)
+### 2a. First developer — `gtl init`
 
-Run **once per machine** before your first worktree allocation:
+If your project doesn't have a `.treeline.yml` yet, create one:
 
 ```bash
-gtl serve install
+cd your-project
+gtl init
 ```
 
-The installer will ask for your **system password twice** (via `sudo`):
+This generates the config and detects your framework. Then run `gtl install` (step 2b) to complete setup.
 
-1. **Trust a local certificate authority** — Adds a dev CA to your login keychain (macOS) or equivalent so browsers accept `https://*.prt.dev` without certificate errors. This CA is what **`gtl setup` / `gtl new` require** on macOS/Linux.
-2. **Forward port 443** — Installs a rule so HTTPS on port 443 is forwarded to Treeline’s router (default listen port `3001`, configurable as `router.port`). That’s what makes `https://project-branch.prt.dev` work **without** `:3001` in the URL.
+### 2b. Any developer — `gtl install`
 
-What gets installed: the CA, per-host server certs, a **background service** (`launchd` on macOS, `systemd` on Linux) that starts the router on boot, and the port-forward rule. See **`gtl serve status`** and **`gtl serve uninstall`** to inspect or remove.
+Whether you just ran `gtl init` or you're joining a project that already has `.treeline.yml`:
 
-**Safari on macOS** may not resolve custom domain subdomains without `/etc/hosts` entries. After you have routes, run **`gtl serve hosts sync`** (asks for `sudo`) to add a managed block to `/etc/hosts`, or use another browser. The default domain `prt.dev` has wildcard DNS pointing to 127.0.0.1; change it via `gtl config set router.domain yourdomain.dev`.
+```bash
+gtl install
+```
 
-### 3. Per repository — `gtl init` and worktrees
+This single command handles everything:
+1. **Creates user config** if missing
+2. **Installs the post-checkout hook** so future worktrees auto-setup
+3. **Allocates ports and writes env** for the current worktree
+4. **Optionally enables local HTTPS routing** — prompted with a link to the [networking docs](https://git-treeline.dev/docs/networking/#the-https-router-gtl-serve); requires sudo for CA trust and port forwarding. Can be skipped and run later via `gtl serve install`. If you skip it, Treeline can also save `warnings.router: false` so you are not reminded again.
 
-With the CLI on your `PATH`, go to your app repo and follow **[Quick start](#quick-start)** below (`gtl init` → `gtl new` / `gtl setup`). On macOS/Linux, complete **step 2** before **`gtl new` / `gtl setup`** (or run `gtl init` first—order between init and `serve install` is flexible as long as the CA exists before allocation).
+The HTTPS router gives you `https://project-branch.prt.dev` URLs. Without it, worktrees are accessible at `http://localhost:{port}`. `gtl setup`, `gtl new`, `gtl clone`, and `gtl review` all work without the router. See **`gtl serve status`** and **`gtl serve uninstall`** to inspect or remove the HTTPS stack.
+
+**Safari on macOS** may not resolve custom domain subdomains without `/etc/hosts` entries. After you have routes, run **`gtl serve hosts sync`** (asks for `sudo`) to add a managed block to `/etc/hosts`, or use another browser.
+
+> **`GTL_HEADLESS=1`** skips HTTPS router prompts and warnings — use in CI or automation only.
 
 ---
 
@@ -765,6 +772,7 @@ gtl db name --json         # {"database": "myapp_feature_xyz"}
 
 | Command | Flags | Description |
 |---|---|---|
+| `gtl install` | | Set up git-treeline for this project and machine (config, hook, setup, optional HTTPS) |
 | `gtl init` | `--project` `--template-db` `--skip-agent-config` | Generate `.treeline.yml` (auto-detects framework, writes `AGENTS.md` section) |
 | `gtl new <branch>` | `--base` `--path` `--start` `--open` `--dry-run` `--force`/`-f` | Create worktree + allocate + setup in one step |
 | `gtl review <PR#>` | `--path` `--start` `--open` | Check out a GitHub PR into a worktree with full setup (requires `gh`) |

--- a/README.md
+++ b/README.md
@@ -46,36 +46,25 @@ Download the latest binary from [GitHub Releases](https://github.com/git-treelin
 
 ## First-time setup on your machine
 
-Two paths depending on whether you're the **first developer** setting up git-treeline for a project, or **joining a project** that already has a `.treeline.yml`.
-
 ### 1. Install the CLI
 
 Use [Homebrew](#homebrew), [Go](#from-source-requires-go-126), or a [release binary](#from-release-binary). Installing `gtl` does **not** require `sudo` and does **not** install certificates or background services by itself.
 
-### 2a. First developer — `gtl init`
+### 2. Run `gtl install`
 
-If your project doesn't have a `.treeline.yml` yet, create one:
+Whether you're the first developer setting up the project or you're joining a repo that already has `.treeline.yml`:
 
 ```bash
 cd your-project
-gtl init
-```
-
-This generates the config and detects your framework. Then run `gtl install` (step 2b) to complete setup.
-
-### 2b. Any developer — `gtl install`
-
-Whether you just ran `gtl init` or you're joining a project that already has `.treeline.yml`:
-
-```bash
 gtl install
 ```
 
 This single command handles everything:
-1. **Creates user config** if missing
-2. **Installs the post-checkout hook** so future worktrees auto-setup
-3. **Allocates ports and writes env** for the current worktree
-4. **Optionally enables local HTTPS routing** — prompted with a link to the [networking docs](https://git-treeline.dev/docs/networking/#the-https-router-gtl-serve); requires sudo for CA trust and port forwarding. Can be skipped and run later via `gtl serve install`. If you skip it, Treeline can also save `warnings.router: false` so you are not reminded again.
+1. **Creates `.treeline.yml`** if missing and detects your framework
+2. **Creates user config** if missing
+3. **Installs the post-checkout hook** so future worktrees auto-setup
+4. **Allocates ports and writes env** for the current worktree
+5. **Optionally enables local HTTPS routing** — prompted with a link to the [networking docs](https://git-treeline.dev/docs/networking/#the-https-router-gtl-serve); requires sudo for CA trust and port forwarding. Can be skipped and run later via `gtl serve install`. If you skip it once, `router.mode` stays `prompt` and Treeline may offer it again later. If you disable future offers, Treeline saves `router.mode: disabled` and stays on localhost-only workflows until you manually run `gtl serve install` or reset the mode.
 
 The HTTPS router gives you `https://project-branch.prt.dev` URLs. Without it, worktrees are accessible at `http://localhost:{port}`. `gtl setup`, `gtl new`, `gtl clone`, and `gtl review` all work without the router. See **`gtl serve status`** and **`gtl serve uninstall`** to inspect or remove the HTTPS stack.
 
@@ -87,18 +76,18 @@ The HTTPS router gives you `https://project-branch.prt.dev` URLs. Without it, wo
 
 ## Quick start
 
-### 1. Initialize your project
+### 1. Install Treeline in the repo
 
 ```bash
 cd your-project
-gtl init
+gtl install
 ```
 
-`init` auto-detects your framework (Next.js, Vite, Rails, Express, Python, Rust, Go) and generates a tailored `.treeline.yml`. It also writes a treeline section to `AGENTS.md` (or `CLAUDE.md` if that exists) so AI agents know to use `gtl port` instead of assuming port 3000. This works with Cursor, Claude Code, and Codex.
+`install` auto-detects your framework when `.treeline.yml` is missing and generates a tailored config. It also creates user config if needed, installs the post-checkout hook, allocates resources for the current worktree, and optionally offers the HTTPS router.
 
-After generating the config, `init` runs framework-aware diagnostics and prints actionable warnings — for example, if your Vite project needs `vite.config.js` changes to read the allocated port, or if your Node project lacks a dotenv library. Commit the config so your team shares it.
+After generating the config, Treeline runs framework-aware diagnostics and prints actionable warnings — for example, if your Vite project needs `vite.config.js` changes to read the allocated port, or if your Node project lacks a dotenv library. Commit `.treeline.yml` so your team shares it.
 
-Use `--project myapp` to set the project name explicitly, or `--skip-agent-config` to skip agent context generation.
+Use `gtl init` directly only when you want to generate or regenerate `.treeline.yml` without running the rest of install.
 
 ### 2. Create and set up a worktree
 

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -44,9 +44,7 @@ The server is NOT auto-started. Review the project, then run 'gtl start'.`,
 			}
 		}
 
-		if err := requireServeInstalled(); err != nil {
-			return cliErr(cmd, err)
-		}
+		warnServeNotInstalled()
 
 		if len(args) == 0 {
 			return cliErr(cmd, &CliError{

--- a/cmd/clone.go
+++ b/cmd/clone.go
@@ -116,12 +116,9 @@ The server is NOT auto-started. Review the project, then run 'gtl start'.`,
 
 		fmt.Println(style.Actionf("Running setup..."))
 		s := setup.New(absPath, absPath, uc)
-		alloc, err := s.Run()
-		if err != nil {
+		if _, err := s.Run(); err != nil {
 			return cliErr(cmd, errSetupFailed(err))
 		}
-
-		printRouterAndTunnel(uc, s.ProjectConfig.Project(), alloc.Branch)
 
 		mainRepo := worktree.DetectMainRepo(absPath)
 		pc := config.LoadProjectConfig(mainRepo)

--- a/cmd/guard_test.go
+++ b/cmd/guard_test.go
@@ -175,15 +175,28 @@ func TestGuard_CliErrorUsesCliErr(t *testing.T) {
 	}
 }
 
+func TestGuard_OnboardingCommandsDoNotRequireServeInstalled(t *testing.T) {
+	for _, file := range []string{"setup.go", "new.go", "clone.go", "review.go"} {
+		t.Run(file, func(t *testing.T) {
+			data, err := os.ReadFile(file)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(data), "requireServeInstalled()") {
+				t.Fatalf("%s should not hard-require the HTTPS router; use warnServeNotInstalled instead", file)
+			}
+		})
+	}
+}
+
 // cliErrHelpers are functions that can return *CliError indirectly. Calls to
 // these inside RunE must be wrapped with cliErr(cmd, ...) just like direct
 // &CliError{} literals and errXxx() constructors.
 var cliErrHelpers = map[string]bool{
-	"awaitReady":           true,
-	"resolveTunnelTarget":  true,
-	"resolveStartHooks":    true,
+	"awaitReady":            true,
+	"resolveTunnelTarget":   true,
+	"resolveStartHooks":     true,
 	"validateTunnelPrereqs": true,
-	"requireServeInstalled": true,
 	"switchWorktreeBranch":  true,
 }
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -1,0 +1,276 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/git-treeline/git-treeline/internal/config"
+	"github.com/git-treeline/git-treeline/internal/confirm"
+	"github.com/git-treeline/git-treeline/internal/detect"
+	"github.com/git-treeline/git-treeline/internal/platform"
+	"github.com/git-treeline/git-treeline/internal/proxy"
+	"github.com/git-treeline/git-treeline/internal/service"
+	"github.com/git-treeline/git-treeline/internal/setup"
+	"github.com/git-treeline/git-treeline/internal/style"
+	"github.com/git-treeline/git-treeline/internal/templates"
+	"github.com/git-treeline/git-treeline/internal/worktree"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(installCmd)
+}
+
+var installSelect = confirm.Select
+var installServeRunner = runServeInstall
+var routerHealthChecker = routerInstallIssues
+
+var installCmd = &cobra.Command{
+	Use:   "install",
+	Short: "Set up git-treeline for this project and machine",
+	Long: `One command to get a developer productive with git-treeline.
+
+Safe to run on first clone or any time after — every step is idempotent.
+
+What it does:
+  1. Creates .treeline.yml if missing
+  2. Creates user config (if missing)
+  3. Installs the post-checkout hook for automatic worktree setup
+  4. Allocates ports and writes env for the current worktree
+  5. Optionally enables local HTTPS routing (requires sudo)`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		absPath, err := filepath.Abs(".")
+		if err != nil {
+			return fmt.Errorf("could not resolve current directory: %w", err)
+		}
+		worktreeRoot := worktree.DetectRepoRoot(absPath)
+		mainRepo := worktree.DetectMainRepo(worktreeRoot)
+
+		configPath := filepath.Join(worktreeRoot, config.ProjectConfigFile)
+		if _, err := os.Stat(configPath); err != nil {
+			fmt.Println(style.Actionf("No %s found, detecting framework...", config.ProjectConfigFile))
+			if err := runInitForNew(worktreeRoot, detect.Detect(worktreeRoot)); err != nil {
+				return err
+			}
+		}
+
+		// Step 1: user config
+		uc := config.LoadUserConfig("")
+		if !uc.Exists() {
+			if err := uc.Init(); err != nil {
+				return err
+			}
+			fmt.Println(style.Actionf("Created user config at %s", platform.ConfigFile()))
+		} else {
+			fmt.Println(style.Dimf("User config: %s", platform.ConfigFile()))
+		}
+
+		// Step 2: post-checkout hook
+		hookPath, err := templates.InstallPostCheckoutHook(mainRepo)
+		if err != nil {
+			fmt.Fprintln(os.Stderr, style.Warnf("Could not install post-checkout hook: %s", err))
+		} else if hookPath != "" {
+			fmt.Println(style.Actionf("Post-checkout hook: %s", hookPath))
+		}
+
+		// Step 3: setup (allocate ports, write env, copy files)
+		if err := checkDriftOrAbort(worktreeRoot); err != nil {
+			return cliErr(cmd, err)
+		}
+
+		s := setup.New(worktreeRoot, "", uc)
+		if _, err := s.Run(); err != nil {
+			return err
+		}
+
+		pc := config.LoadProjectConfig(worktreeRoot)
+		printSetupDiagnostics(worktreeRoot, pc)
+
+		// Step 4: HTTPS router (optional, prompted)
+		if err := maybeOfferServeInstall(uc); err != nil {
+			return err
+		}
+
+		fmt.Println()
+		fmt.Println(style.Actionf("Ready. Run %s to start your server.", style.Cmd("gtl start")))
+		return nil
+	},
+}
+
+// maybeOfferServeInstall checks if the HTTPS router is already configured.
+// If not, prompts the user to install it with a link to docs.
+func maybeOfferServeInstall(uc *config.UserConfig) error {
+	mode := uc.RouterMode()
+	if routerIsHealthy() {
+		if mode == config.RouterModePrompt {
+			uc.SetRouterMode(config.RouterModeEnabled)
+			if err := uc.Save(); err != nil {
+				fmt.Fprintln(os.Stderr, style.Warnf("Could not persist router preference: %v", err))
+			}
+		}
+		if mode != config.RouterModeDisabled {
+			fmt.Println(style.Dimf("HTTPS router: already running"))
+		}
+		return nil
+	}
+
+	if mode == config.RouterModeDisabled {
+		return nil
+	}
+
+	if os.Getenv("GTL_HEADLESS") != "" {
+		if mode == config.RouterModeEnabled {
+			fmt.Fprintln(os.Stderr, style.Warnf("HTTPS router is enabled in config but not installed; skipping router setup in headless mode."))
+			fmt.Fprintln(os.Stderr, style.Dimf("  Run 'gtl serve install' or re-run 'gtl install' interactively to repair it."))
+		}
+		return nil
+	}
+
+	if !supportsServeInstall() {
+		if mode == config.RouterModeEnabled {
+			return fmt.Errorf("HTTPS router is enabled in config but setup is only supported on macOS and Linux")
+		}
+		return nil
+	}
+
+	if mode == config.RouterModeEnabled {
+		fmt.Println()
+		fmt.Println(style.Actionf("Repairing HTTPS router..."))
+		if err := installServeRunner(uc); err != nil {
+			return err
+		}
+		if issues := routerHealthChecker(); len(issues) > 0 {
+			return fmt.Errorf("HTTPS router install incomplete: missing %s", strings.Join(issues, ", "))
+		}
+		fmt.Println(style.Dimf("HTTPS router: running"))
+		return nil
+	}
+
+	fmt.Println()
+	fmt.Printf("Local HTTPS routing lets you access worktrees at https://{project}-{branch}.%s\n", uc.RouterDomain())
+	fmt.Println("This requires sudo to trust a local CA and forward port 443.")
+	fmt.Println(style.Dimf("Learn more: https://git-treeline.dev/docs/networking/#the-https-router-gtl-serve"))
+	fmt.Println()
+
+	choice := installSelect("HTTPS router setup:", []string{
+		"Yes",
+		"No",
+		"No, and don't ask again",
+	}, 1, nil)
+	if choice != 0 {
+		fmt.Println(style.Dimf("Skipped. Run 'gtl serve install' any time to enable."))
+		if choice == 2 {
+			uc.SetRouterMode(config.RouterModeDisabled)
+			if err := uc.Save(); err != nil {
+				fmt.Fprintln(os.Stderr, style.Warnf("Could not save router preference: %v", err))
+			} else {
+				fmt.Println(style.Dimf("HTTPS router setup disabled. Re-enable with: gtl config set router.mode prompt"))
+			}
+		}
+		return nil
+	}
+	fmt.Println()
+
+	uc.SetRouterMode(config.RouterModeEnabled)
+	if err := uc.Save(); err != nil {
+		return fmt.Errorf("saving router preference: %w", err)
+	}
+	if err := installServeRunner(uc); err != nil {
+		return err
+	}
+	if issues := routerHealthChecker(); len(issues) > 0 {
+		return fmt.Errorf("HTTPS router install incomplete: missing %s", strings.Join(issues, ", "))
+	}
+	return nil
+}
+
+// runServeInstall performs the HTTPS router installation steps.
+// Extracted from serveInstallCmd so gtl install can reuse it.
+func runServeInstall(uc *config.UserConfig) error {
+	gtlPath, err := service.StableExecutablePath()
+	if err != nil {
+		return fmt.Errorf("could not resolve executable path: %w", err)
+	}
+
+	port := uc.RouterPort()
+
+	caCertFile, err := proxy.EnsureCA()
+	if err != nil {
+		return fmt.Errorf("CA generation failed: %w", err)
+	}
+
+	domain := uc.RouterDomain()
+
+	if !uc.HasExplicitRouterDomain() {
+		uc.Set("router.domain", domain)
+	}
+	uc.SetRouterMode(config.RouterModeEnabled)
+	if err := uc.Save(); err != nil {
+		return fmt.Errorf("saving router settings: %w", err)
+	}
+
+	fmt.Println("System password needed for:")
+	fmt.Printf("  1. Trusting the CA (browsers accept *.%s)\n", domain)
+	fmt.Printf("  2. Port forwarding (443 → %d)\n", port)
+	fmt.Println()
+
+	if err := proxy.TrustCA(caCertFile); err != nil {
+		fmt.Fprintln(os.Stderr, style.Warnf("CA trust failed: %v", err))
+		fmt.Fprintln(os.Stderr, style.Dimf("  HTTPS will work but browsers will show a certificate warning."))
+	}
+
+	if err := service.InstallPortForward(port); err != nil {
+		fmt.Fprintln(os.Stderr, style.Warnf("port forwarding skipped: %v", err))
+		fmt.Fprintln(os.Stderr, style.Dimf("  URLs will require a port number: https://{branch}.%s:%d", domain, port))
+		fmt.Println()
+	}
+
+	if _, err := service.Install(gtlPath, port); err != nil {
+		return err
+	}
+
+	hostsRequired := domain != "localhost"
+	if runtime.GOOS == "darwin" || hostsRequired {
+		hostnames := routeHostnames(domain)
+		if len(hostnames) > 0 {
+			if err := service.SyncHosts(hostnames); err != nil {
+				fmt.Fprintln(os.Stderr, style.Warnf("hosts sync failed: %v", err))
+				if hostsRequired {
+					fmt.Fprintln(os.Stderr, style.Dimf("  Custom TLD .%s requires /etc/hosts entries.", domain))
+				} else {
+					fmt.Fprintln(os.Stderr, style.Dimf("  Safari may not resolve *.localhost subdomains."))
+				}
+				fmt.Fprintln(os.Stderr, style.Dimf("  Run 'gtl serve hosts sync' manually."))
+			}
+		}
+	}
+
+	return nil
+}
+
+func supportsServeInstall() bool {
+	return runtime.GOOS == "darwin" || runtime.GOOS == "linux"
+}
+
+func routerInstallIssues() []string {
+	return routerInstallIssuesWith(proxy.IsCAInstalled(), service.IsRunning())
+}
+
+func routerInstallIssuesWith(caInstalled, serviceRunning bool) []string {
+	var issues []string
+	if !caInstalled {
+		issues = append(issues, "CA trust")
+	}
+	if !serviceRunning {
+		issues = append(issues, "router service")
+	}
+	return issues
+}
+
+func routerIsHealthy() bool {
+	return len(routerHealthChecker()) == 0
+}

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -1,0 +1,287 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/git-treeline/git-treeline/internal/config"
+	setupPkg "github.com/git-treeline/git-treeline/internal/setup"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stdout
+	os.Stdout = w
+	fn()
+	_ = w.Close()
+	os.Stdout = orig
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	return buf.String()
+}
+
+func loadTestUserConfig(t *testing.T) *config.UserConfig {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.json")
+	if err := os.WriteFile(path, []byte(`{"port":{"base":41000,"increment":10},"redis":{"strategy":"prefixed","url":"redis://localhost:6379"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return config.LoadUserConfig(path)
+}
+
+func TestInstallCmd_MissingProjectConfig(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	t.Chdir(dir)
+	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	t.Setenv("GTL_HEADLESS", "1")
+	oldRegistryPath := setupPkg.RegistryPath
+	setupPkg.RegistryPath = filepath.Join(t.TempDir(), "registry.json")
+	t.Cleanup(func() { setupPkg.RegistryPath = oldRegistryPath })
+
+	err := installCmd.RunE(installCmd, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".treeline.yml")); err != nil {
+		t.Fatalf("expected install to create .treeline.yml: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".git", "hooks", "post-checkout")); err != nil {
+		t.Fatalf("expected install to install post-checkout hook: %v", err)
+	}
+}
+
+func TestInstallCmd_MissingProjectConfigFromSubdirInitializesRepoRoot(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	subdir := filepath.Join(dir, "apps", "web")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(subdir)
+	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	t.Setenv("GTL_HEADLESS", "1")
+	oldRegistryPath := setupPkg.RegistryPath
+	setupPkg.RegistryPath = filepath.Join(t.TempDir(), "registry.json")
+	t.Cleanup(func() { setupPkg.RegistryPath = oldRegistryPath })
+
+	if err := installCmd.RunE(installCmd, nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".treeline.yml")); err != nil {
+		t.Fatalf("expected install to create .treeline.yml at repo root: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(subdir, ".treeline.yml")); !os.IsNotExist(err) {
+		t.Fatalf("expected no nested .treeline.yml in subdir, got err=%v", err)
+	}
+}
+
+func TestInstallCmd_HappyPathInstallsHookAndAllocates(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	t.Chdir(dir)
+	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	t.Setenv("GTL_HEADLESS", "1")
+
+	oldRegistryPath := setupPkg.RegistryPath
+	setupPkg.RegistryPath = filepath.Join(t.TempDir(), "registry.json")
+	t.Cleanup(func() { setupPkg.RegistryPath = oldRegistryPath })
+
+	yml := "project: installtest\nport_count: 1\nenv_file: .env.test\nenv:\n  PORT: \"{port}\"\n"
+	if err := os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(yml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := installCmd.RunE(installCmd, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, ".git", "hooks", "post-checkout")); err != nil {
+		t.Fatalf("expected post-checkout hook installed: %v", err)
+	}
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		resolvedDir = dir
+	}
+	envData, err := os.ReadFile(filepath.Join(resolvedDir, ".env.test"))
+	if err != nil {
+		t.Fatalf("expected env file written: %v", err)
+	}
+	if !strings.Contains(string(envData), "PORT=") {
+		t.Errorf("expected PORT in env file, got:\n%s", string(envData))
+	}
+
+	uc := config.LoadUserConfig("")
+	if got := uc.RouterDomain(); got != "prt.dev" {
+		t.Errorf("expected install-created config to default router domain to prt.dev, got %q", got)
+	}
+	if !uc.HasExplicitRouterDomain() {
+		t.Error("expected install-created config to persist router.domain explicitly")
+	}
+}
+
+func TestMaybeOfferServeInstall_HeadlessSkipsPrompt(t *testing.T) {
+	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	t.Setenv("GTL_HEADLESS", "1")
+
+	uc := loadTestUserConfig(t)
+	out := captureStdout(t, func() {
+		if err := maybeOfferServeInstall(uc); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if strings.Contains(out, "HTTPS router setup:") {
+		t.Errorf("expected no HTTPS prompt in headless mode, got:\n%s", out)
+	}
+}
+
+func TestMaybeOfferServeInstall_HeadlessEnabledModeWarnsAndContinues(t *testing.T) {
+	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	t.Setenv("GTL_HEADLESS", "1")
+
+	uc := loadTestUserConfig(t)
+	uc.SetRouterMode(config.RouterModeEnabled)
+	if err := uc.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHealth := routerHealthChecker
+	routerHealthChecker = func() []string { return []string{"router service"} }
+	t.Cleanup(func() { routerHealthChecker = oldHealth })
+
+	out := captureStderr(t, func() {
+		if err := maybeOfferServeInstall(uc); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !strings.Contains(out, "skipping router setup in headless mode") {
+		t.Errorf("expected headless warning, got:\n%s", out)
+	}
+}
+
+func TestMaybeOfferServeInstall_DisabledModeSkipsPrompt(t *testing.T) {
+	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	t.Setenv("GTL_HEADLESS", "")
+
+	uc := loadTestUserConfig(t)
+	uc.SetRouterMode(config.RouterModeDisabled)
+	if err := uc.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	oldSelect := installSelect
+	installSelect = func(message string, options []string, defaultIdx int, reader io.Reader) int {
+		t.Fatalf("unexpected prompt: %s", message)
+		return 0
+	}
+	t.Cleanup(func() { installSelect = oldSelect })
+
+	if err := maybeOfferServeInstall(uc); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestMaybeOfferServeInstall_DeclineDisablesFutureOffers(t *testing.T) {
+	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	t.Setenv("GTL_HEADLESS", "")
+
+	uc := loadTestUserConfig(t)
+
+	oldSelect := installSelect
+	oldHealth := routerHealthChecker
+	installSelect = func(message string, options []string, defaultIdx int, reader io.Reader) int {
+		return 2
+	}
+	routerHealthChecker = func() []string { return []string{"CA trust"} }
+	t.Cleanup(func() {
+		installSelect = oldSelect
+		routerHealthChecker = oldHealth
+	})
+
+	if err := maybeOfferServeInstall(uc); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded := config.LoadUserConfig(uc.Path)
+	if got := reloaded.RouterMode(); got != config.RouterModeDisabled {
+		t.Fatalf("expected router mode disabled, got %q", got)
+	}
+}
+
+func TestMaybeOfferServeInstall_DeclineKeepsPromptMode(t *testing.T) {
+	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	t.Setenv("GTL_HEADLESS", "")
+
+	uc := loadTestUserConfig(t)
+
+	oldSelect := installSelect
+	oldHealth := routerHealthChecker
+	installSelect = func(message string, options []string, defaultIdx int, reader io.Reader) int {
+		return 1
+	}
+	routerHealthChecker = func() []string { return []string{"CA trust"} }
+	t.Cleanup(func() {
+		installSelect = oldSelect
+		routerHealthChecker = oldHealth
+	})
+
+	if err := maybeOfferServeInstall(uc); err != nil {
+		t.Fatal(err)
+	}
+
+	reloaded := config.LoadUserConfig(uc.Path)
+	if got := reloaded.RouterMode(); got != config.RouterModePrompt {
+		t.Fatalf("expected router mode prompt after simple decline, got %q", got)
+	}
+}
+
+func TestRouterInstallIssuesWith_PortForwardingIsOptional(t *testing.T) {
+	tests := []struct {
+		name           string
+		caInstalled    bool
+		serviceRunning bool
+		want           []string
+	}{
+		{
+			name:           "healthy",
+			caInstalled:    true,
+			serviceRunning: true,
+			want:           nil,
+		},
+		{
+			name:           "missing ca trust",
+			caInstalled:    false,
+			serviceRunning: true,
+			want:           []string{"CA trust"},
+		},
+		{
+			name:           "missing router service",
+			caInstalled:    true,
+			serviceRunning: false,
+			want:           []string{"router service"},
+		},
+		{
+			name:           "missing both required pieces",
+			caInstalled:    false,
+			serviceRunning: false,
+			want:           []string{"CA trust", "router service"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			issues := routerInstallIssuesWith(tt.caInstalled, tt.serviceRunning)
+			if strings.Join(issues, "|") != strings.Join(tt.want, "|") {
+				t.Fatalf("routerInstallIssuesWith(%t, %t) = %v, want %v", tt.caInstalled, tt.serviceRunning, issues, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -78,11 +78,11 @@ Otherwise a new branch is created from --base (or the current branch).`,
 				fmt.Println()
 				fmt.Println("This project doesn't have a .treeline.yml yet.")
 				if confirm.Prompt("Set up port allocation and server management?", true, nil) {
-				fmt.Println()
-				if err := runInitInteractive(mainRepo, det); err != nil {
-					return err
-				}
-				pc = config.LoadProjectConfig(mainRepo)
+					fmt.Println()
+					if err := runInitInteractive(mainRepo, det); err != nil {
+						return err
+					}
+					pc = config.LoadProjectConfig(mainRepo)
 				} else {
 					// User declined — create worktree only, no allocation
 					return createWorktreeOnly(mainRepo, branch, uc, pc)
@@ -124,9 +124,8 @@ Otherwise a new branch is created from --base (or the current branch).`,
 				fmt.Printf("  Path:     %s\n", existingWT)
 				if len(ports) > 0 {
 					fmt.Printf("  Port:     %s\n", format.JoinInts(ports, ", "))
-					fmt.Printf("  URL:      http://localhost:%d\n", ports[0])
+					printLocalAndRouter(uc, projectName, branch, ports[0])
 				}
-				printRouterAndTunnel(uc, projectName, branch)
 
 				if newOpen && len(ports) > 0 {
 					url := buildOpenURL(ports[0], projectName, branch, uc.RouterDomain(), uc.RouterPort(), service.IsRunning(), service.IsPortForwardConfigured())
@@ -198,8 +197,6 @@ Otherwise a new branch is created from --base (or the current branch).`,
 		if err != nil {
 			return cliErr(cmd, errSetupFailed(err))
 		}
-
-		printRouterAndTunnel(uc, projectName, alloc.Branch)
 
 		if newOpen && alloc.Port > 0 {
 			url := buildOpenURL(alloc.Port, projectName, alloc.Branch, uc.RouterDomain(), uc.RouterPort(), service.IsRunning(), service.IsPortForwardConfigured())

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -93,9 +93,7 @@ Otherwise a new branch is created from --base (or the current branch).`,
 			}
 		}
 
-		if err := requireServeInstalled(); err != nil {
-			return cliErr(cmd, err)
-		}
+		warnServeNotInstalled()
 
 		projectName := pc.Project()
 		wtPath := resolveNewWorktreePath(mainRepo, projectName, branch, uc)

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -12,21 +12,19 @@ import (
 	"github.com/git-treeline/git-treeline/internal/worktree"
 )
 
-// errServeNotInstalled is the shared error returned when commands require
-// the HTTPS router but it hasn't been installed yet.
-var errServeNotInstalled error = &CliError{
-	Message: "HTTPS router not installed.",
-	Hint:    "Run 'gtl serve install' first (one-time setup).",
-	DocsURL: "https://git-treeline.dev/docs/#getting-started",
-}
-
-// requireServeInstalled returns errServeNotInstalled when the HTTPS CA is
-// absent and GTL_HEADLESS is not set. Call from commands that need the router.
-func requireServeInstalled() error {
-	if !proxy.IsCAInstalled() && os.Getenv("GTL_HEADLESS") == "" {
-		return errServeNotInstalled
+// warnServeNotInstalled prints a non-blocking warning when the HTTPS router
+// is not installed. Used by commands that benefit from but don't require it.
+func warnServeNotInstalled() {
+	if proxy.IsCAInstalled() || os.Getenv("GTL_HEADLESS") != "" {
+		return
 	}
-	return nil
+	uc := config.LoadUserConfig("")
+	if !uc.RouterWarningsEnabled() {
+		return
+	}
+	fmt.Fprintln(os.Stderr, style.Warnf("HTTPS router not installed — local URLs will use http://localhost:{port}."))
+	fmt.Fprintln(os.Stderr, style.Dimf("  Run 'gtl install' or 'gtl serve install' to enable HTTPS routing."))
+	fmt.Fprintln(os.Stderr)
 }
 
 // printRouterAndTunnel prints the Router URL and Tunnel hint after setup.

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -15,7 +15,7 @@ import (
 // warnServeNotInstalled prints a non-blocking warning when the HTTPS router
 // is not installed. Used by commands that benefit from but don't require it.
 func warnServeNotInstalled() {
-	if proxy.IsCAInstalled() || os.Getenv("GTL_HEADLESS") != "" {
+	if routerIsHealthy() || os.Getenv("GTL_HEADLESS") != "" {
 		return
 	}
 	uc := config.LoadUserConfig("")
@@ -27,19 +27,27 @@ func warnServeNotInstalled() {
 	fmt.Fprintln(os.Stderr)
 }
 
-// printRouterAndTunnel prints the Router URL and Tunnel hint after setup.
-// Called from setup, new, and clone to avoid duplication.
-func printRouterAndTunnel(uc *config.UserConfig, project, branch string) {
-	routeKey := proxy.RouteKey(project, branch)
+// printLocalAndRouter prints immediately usable URLs after start.
+// Tunnels are intentionally omitted here; use gtl routes or gtl tunnel for
+// public sharing URLs.
+func printLocalAndRouter(uc *config.UserConfig, project, branch string, port int) {
+	if port > 0 {
+		fmt.Println(style.Actionf("Local:  %s", style.Link(fmt.Sprintf("http://localhost:%d", port))))
+	}
+
+	printRouterURL(uc, project, branch)
+}
+
+// printRouterURL prints the local HTTPS router URL when the router is running.
+func printRouterURL(uc *config.UserConfig, project, branch string) {
+	if uc.RouterMode() == config.RouterModeDisabled {
+		return
+	}
 	domain := uc.RouterDomain()
 
 	if service.IsRunning() {
 		url := proxy.BuildRouterURL(0, project, branch, domain, uc.RouterPort(), true, service.IsPortForwardConfigured())
 		fmt.Println(style.Actionf("Router: %s", style.Link(url)))
-	}
-
-	if tunnelDomain := uc.TunnelDomain(""); tunnelDomain != "" {
-		fmt.Println(style.Actionf("Tunnel: run %s → %s", style.Cmd("gtl tunnel"), style.Link("https://"+routeKey+"."+tunnelDomain)))
 	}
 }
 

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -24,12 +25,70 @@ func TestErrServeNotInstalled_ContainsGuidance(t *testing.T) {
 	}
 }
 
+var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func TestWarnServeNotInstalled_MentionsInstallCommands(t *testing.T) {
+	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	t.Setenv("GTL_HEADLESS", "")
+
+	out := captureStderr(t, warnServeNotInstalled)
+	if !strings.Contains(out, "gtl install") {
+		t.Errorf("expected gtl install in warning, got:\n%s", out)
+	}
+	if !strings.Contains(out, "gtl serve install") {
+		t.Errorf("expected gtl serve install in warning, got:\n%s", out)
+	}
+}
+
+func TestWarnServeNotInstalled_HeadlessSilent(t *testing.T) {
+	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	t.Setenv("GTL_HEADLESS", "1")
+
+	out := captureStderr(t, warnServeNotInstalled)
+	if out != "" {
+		t.Errorf("expected no warning in headless mode, got:\n%s", out)
+	}
+}
+
+func TestWarnServeNotInstalled_DisabledByUserConfig(t *testing.T) {
+	gtlHome := filepath.Join(t.TempDir(), "gtl-home")
+	t.Setenv("GTL_HOME", gtlHome)
+	t.Setenv("GTL_HEADLESS", "")
+	if err := os.MkdirAll(gtlHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gtlHome, "config.json"), []byte(`{"warnings":{"router":false}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out := captureStderr(t, warnServeNotInstalled)
+	if out != "" {
+		t.Errorf("expected warning suppressed by user config, got:\n%s", out)
+	}
+}
+
+func TestPrintLocalAndRouter_PrintsLocalButNotTunnel(t *testing.T) {
+	uc := loadTestUserConfig(t)
+	uc.Set("tunnel.default", "personal")
+	uc.Set("tunnel.tunnels.personal.domain", "example.com")
+
+	out := captureStdout(t, func() {
+		printLocalAndRouter(uc, "myapp", "feature-x", 3010)
+	})
+	out = ansiEscapeRE.ReplaceAllString(out, "")
+	if !strings.Contains(out, "http://localhost:3010") {
+		t.Errorf("expected localhost URL, got:\n%s", out)
+	}
+	if strings.Contains(out, "Tunnel:") || strings.Contains(out, "gtl tunnel") || strings.Contains(out, "example.com") {
+		t.Errorf("expected no tunnel hint, got:\n%s", out)
+	}
+}
 func TestSortedRouteKeys(t *testing.T) {
 	routes := map[string]int{
-		"myapp-feature":  3010,
-		"myapp-main":     3000,
-		"other-dev":      3020,
-		"api-staging":    4000,
+		"myapp-feature": 3010,
+		"myapp-main":    3000,
+		"other-dev":     3020,
+		"api-staging":   4000,
 	}
 	keys := sortedRouteKeys(routes)
 	if len(keys) != 4 {

--- a/cmd/output_test.go
+++ b/cmd/output_test.go
@@ -7,29 +7,25 @@ import (
 	"regexp"
 	"strings"
 	"testing"
-)
 
-func TestErrServeNotInstalled_ContainsGuidance(t *testing.T) {
-	ce, ok := errServeNotInstalled.(*CliError)
-	if !ok {
-		t.Fatal("expected *CliError")
-	}
-	if !strings.Contains(ce.Message, "router") {
-		t.Errorf("expected 'router' in message, got: %s", ce.Message)
-	}
-	if !strings.Contains(ce.Hint, "gtl serve install") {
-		t.Errorf("expected 'gtl serve install' in hint, got: %s", ce.Hint)
-	}
-	if !strings.Contains(ce.DocsURL, "git-treeline.dev") {
-		t.Errorf("expected docs URL, got: %s", ce.DocsURL)
-	}
-}
+	"github.com/git-treeline/git-treeline/internal/config"
+)
 
 var ansiEscapeRE = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
 func TestWarnServeNotInstalled_MentionsInstallCommands(t *testing.T) {
-	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	gtlHome := filepath.Join(t.TempDir(), "gtl-home")
+	t.Setenv("GTL_HOME", gtlHome)
 	t.Setenv("GTL_HEADLESS", "")
+	oldHealth := routerHealthChecker
+	routerHealthChecker = func() []string { return []string{"CA trust"} }
+	t.Cleanup(func() { routerHealthChecker = oldHealth })
+	if err := os.MkdirAll(gtlHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gtlHome, "config.json"), []byte(`{"router":{"mode":"prompt"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	out := captureStderr(t, warnServeNotInstalled)
 	if !strings.Contains(out, "gtl install") {
@@ -41,8 +37,18 @@ func TestWarnServeNotInstalled_MentionsInstallCommands(t *testing.T) {
 }
 
 func TestWarnServeNotInstalled_HeadlessSilent(t *testing.T) {
-	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	gtlHome := filepath.Join(t.TempDir(), "gtl-home")
+	t.Setenv("GTL_HOME", gtlHome)
 	t.Setenv("GTL_HEADLESS", "1")
+	oldHealth := routerHealthChecker
+	routerHealthChecker = func() []string { return []string{"CA trust"} }
+	t.Cleanup(func() { routerHealthChecker = oldHealth })
+	if err := os.MkdirAll(gtlHome, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gtlHome, "config.json"), []byte(`{"router":{"mode":"prompt"}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
 	out := captureStderr(t, warnServeNotInstalled)
 	if out != "" {
@@ -54,6 +60,9 @@ func TestWarnServeNotInstalled_DisabledByUserConfig(t *testing.T) {
 	gtlHome := filepath.Join(t.TempDir(), "gtl-home")
 	t.Setenv("GTL_HOME", gtlHome)
 	t.Setenv("GTL_HEADLESS", "")
+	oldHealth := routerHealthChecker
+	routerHealthChecker = func() []string { return []string{"CA trust"} }
+	t.Cleanup(func() { routerHealthChecker = oldHealth })
 	if err := os.MkdirAll(gtlHome, 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -66,7 +75,6 @@ func TestWarnServeNotInstalled_DisabledByUserConfig(t *testing.T) {
 		t.Errorf("expected warning suppressed by user config, got:\n%s", out)
 	}
 }
-
 func TestPrintLocalAndRouter_PrintsLocalButNotTunnel(t *testing.T) {
 	uc := loadTestUserConfig(t)
 	uc.Set("tunnel.default", "personal")
@@ -81,6 +89,19 @@ func TestPrintLocalAndRouter_PrintsLocalButNotTunnel(t *testing.T) {
 	}
 	if strings.Contains(out, "Tunnel:") || strings.Contains(out, "gtl tunnel") || strings.Contains(out, "example.com") {
 		t.Errorf("expected no tunnel hint, got:\n%s", out)
+	}
+}
+
+func TestPrintRouterURL_DisabledRouterModeSilent(t *testing.T) {
+	uc := loadTestUserConfig(t)
+	uc.SetRouterMode(config.RouterModeDisabled)
+
+	out := captureStdout(t, func() {
+		printRouterURL(uc, "myapp", "feature-x")
+	})
+	out = ansiEscapeRE.ReplaceAllString(out, "")
+	if strings.Contains(out, "Router:") {
+		t.Errorf("expected no router output when router mode is disabled, got:\n%s", out)
 	}
 }
 func TestSortedRouteKeys(t *testing.T) {

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -37,9 +37,7 @@ var reviewCmd = &cobra.Command{
 resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := requireServeInstalled(); err != nil {
-			return cliErr(cmd, err)
-		}
+		warnServeNotInstalled()
 
 		prNumber, err := strconv.Atoi(args[0])
 		if err != nil {

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -82,12 +82,17 @@ resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 			pc := config.LoadProjectConfig(absPath)
 			uc := config.LoadUserConfig("")
 			projectName := pc.Project()
-			printRouterAndTunnel(uc, projectName, branch)
+			reg := registry.New("")
+			alloc := reg.Find(absPath)
+			ports := format.GetPorts(format.Allocation(alloc))
+			primaryPort := 0
+			if len(ports) > 0 {
+				primaryPort = ports[0]
+			}
+			printLocalAndRouter(uc, projectName, branch, primaryPort)
 
 			if reviewOpen {
-				reg := registry.New("")
-				if alloc := reg.Find(absPath); alloc != nil {
-					ports := format.GetPorts(format.Allocation(alloc))
+				if alloc != nil {
 					if len(ports) > 0 {
 						url := buildOpenURL(ports[0], projectName, branch, uc.RouterDomain(), uc.RouterPort(), service.IsRunning(), service.IsPortForwardConfigured())
 						fmt.Printf("Opening %s\n", url)
@@ -144,10 +149,12 @@ resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 
 			if alloc != nil {
 				printExistingAllocation(prNumber, branch, existing, alloc)
-				printRouterAndTunnel(uc, projectName, branch)
+				ports := format.GetPorts(format.Allocation(alloc))
+				if len(ports) > 0 {
+					printLocalAndRouter(uc, projectName, branch, ports[0])
+				}
 
 				if reviewOpen {
-					ports := format.GetPorts(format.Allocation(alloc))
 					if len(ports) > 0 {
 						url := buildOpenURL(ports[0], projectName, branch, uc.RouterDomain(), uc.RouterPort(), service.IsRunning(), service.IsPortForwardConfigured())
 						fmt.Printf("Opening %s\n", url)
@@ -187,16 +194,12 @@ resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 			return cliErr(cmd, errSetupFailed(err))
 		}
 
-		if alloc != nil {
-			printRouterAndTunnel(uc, projectName, alloc.Branch)
-		}
-
 		fmt.Println()
 		fmt.Printf("PR #%d ready for review:\n", prNumber)
 		fmt.Printf("  Branch:   %s\n", branch)
 		fmt.Printf("  Path:     %s\n", wtPath)
 		if alloc != nil {
-			fmt.Printf("  URL:      http://localhost:%d\n", alloc.Port)
+			printLocalAndRouter(uc, projectName, alloc.Branch, alloc.Port)
 		}
 
 		if reviewOpen && alloc != nil && alloc.Port > 0 {
@@ -228,7 +231,6 @@ func printExistingAllocation(prNumber int, branch, path string, alloc registry.A
 	fmt.Printf("  Path:     %s\n", path)
 	if len(ports) > 0 {
 		fmt.Printf("  Port:     %s\n", format.JoinInts(ports, ", "))
-		fmt.Printf("  URL:      http://localhost:%d\n", ports[0])
 	}
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -7,6 +7,7 @@ import (
 	"runtime"
 	"sort"
 	"strconv"
+	"strings"
 
 	"github.com/git-treeline/git-treeline/internal/config"
 	"github.com/git-treeline/git-treeline/internal/confirm"
@@ -84,64 +85,15 @@ After install, access worktrees at https://{project}-{branch}.{domain}`,
 			})
 		}
 
-		gtlPath, err := service.StableExecutablePath()
-		if err != nil {
-			return fmt.Errorf("could not resolve executable path: %w", err)
-		}
-
 		uc := config.LoadUserConfig("")
-		port := uc.RouterPort()
-
-		caCertFile, err := proxy.EnsureCA()
-		if err != nil {
-			return fmt.Errorf("CA generation failed: %w", err)
+		if err := runServeInstall(uc); err != nil {
+			return err
+		}
+		if issues := routerInstallIssues(); len(issues) > 0 {
+			return fmt.Errorf("HTTPS router install incomplete: missing %s", strings.Join(issues, ", "))
 		}
 
 		domain := uc.RouterDomain()
-
-		if !uc.HasExplicitRouterDomain() {
-			uc.Set("router.domain", domain)
-			if err := uc.Save(); err != nil {
-				fmt.Fprintf(os.Stderr, "Warning: could not persist router.domain: %s\n", err)
-			}
-		}
-
-		fmt.Println("System password needed for:")
-		fmt.Printf("  1. Trusting the CA (browsers accept *.%s)\n", domain)
-		fmt.Printf("  2. Port forwarding (443 → %d)\n", port)
-		fmt.Println()
-
-		if err := proxy.TrustCA(caCertFile); err != nil {
-			fmt.Fprintln(os.Stderr, style.Warnf("CA trust failed: %v", err))
-			fmt.Fprintln(os.Stderr, style.Dimf("  HTTPS will work but browsers will show a certificate warning."))
-		}
-
-		if err := service.InstallPortForward(port); err != nil {
-			fmt.Fprintln(os.Stderr, style.Warnf("port forwarding skipped: %v", err))
-			fmt.Fprintln(os.Stderr, style.Dimf("  URLs will require a port number: https://{branch}.%s:%d", domain, port))
-			fmt.Println()
-		}
-
-		if _, err := service.Install(gtlPath, port); err != nil {
-			return err
-		}
-
-		hostsRequired := domain != "localhost"
-		if runtime.GOOS == "darwin" || hostsRequired {
-			hostnames := routeHostnames(domain)
-			if len(hostnames) > 0 {
-				if err := service.SyncHosts(hostnames); err != nil {
-					fmt.Fprintln(os.Stderr, style.Warnf("hosts sync failed: %v", err))
-					if hostsRequired {
-						fmt.Fprintln(os.Stderr, style.Dimf("  Custom TLD .%s requires /etc/hosts entries.", domain))
-					} else {
-						fmt.Fprintln(os.Stderr, style.Dimf("  Safari may not resolve *.localhost subdomains."))
-					}
-					fmt.Fprintln(os.Stderr, style.Dimf("  Run 'gtl serve hosts sync' manually."))
-				}
-			}
-		}
-
 		fmt.Println()
 		fmt.Println(style.Actionf("Router running."))
 		fmt.Printf("  Status: %s\n", style.Cmd("gtl serve status"))
@@ -273,7 +225,7 @@ func runRouter() error {
 	router := proxy.NewRouter(port, reg).
 		WithBaseDomain(domain).
 		WithAliases(func() map[string]int { return config.LoadUserConfig("").RouterAliases() }).
-			WithAliases(projectAliases(reg))
+		WithAliases(projectAliases(reg))
 	if proxy.IsCAInstalled() {
 		router.WithTLS()
 	}

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -124,7 +124,7 @@ resumes the server in the original terminal. Ctrl+C exits the supervisor.`,
 		}
 		branch := worktree.CurrentBranch(absPath)
 		setup.ConfigureEditor(absPath, pc, uc, port, branch)
-		printRouterAndTunnel(uc, pc.Project(), branch)
+		printLocalAndRouter(uc, pc.Project(), branch, port)
 
 		if startAwait {
 			sv := supervisor.New(startCommand, absPath, sockPath)

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -11,7 +11,6 @@ import (
 	"github.com/git-treeline/git-treeline/internal/setup"
 	"github.com/git-treeline/git-treeline/internal/style"
 	"github.com/git-treeline/git-treeline/internal/templates"
-	"github.com/git-treeline/git-treeline/internal/worktree"
 	"github.com/spf13/cobra"
 )
 
@@ -53,9 +52,7 @@ var setupCmd = &cobra.Command{
 	Short: "Allocate resources and set up a worktree environment",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if err := requireServeInstalled(); err != nil {
-			return cliErr(cmd, err)
-		}
+		warnServeNotInstalled()
 
 		path := "."
 		if len(args) > 0 {
@@ -80,8 +77,7 @@ var setupCmd = &cobra.Command{
 		}
 
 		absPath, _ := filepath.Abs(path)
-		mainRepo := worktree.DetectMainRepo(absPath)
-		pc := config.LoadProjectConfig(mainRepo)
+		pc := config.LoadProjectConfig(absPath)
 		printSetupDiagnostics(absPath, pc)
 
 		return nil

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -67,13 +67,8 @@ var setupCmd = &cobra.Command{
 		uc := config.LoadUserConfig("")
 		s := setup.New(path, setupMainRepo, uc)
 		s.Options.DryRun = setupDryRun
-		alloc, err := s.Run()
-		if err != nil {
+		if _, err := s.Run(); err != nil {
 			return err
-		}
-
-		if !setupDryRun {
-			printRouterAndTunnel(uc, s.ProjectConfig.Project(), alloc.Branch)
 		}
 
 		absPath, _ := filepath.Abs(path)

--- a/internal/config/merge.go
+++ b/internal/config/merge.go
@@ -17,13 +17,13 @@ func DeepMerge(base, override map[string]any) map[string]any {
 	result := make(map[string]any, len(base))
 
 	for k, v := range override {
-		result[k] = v
+		result[k] = cloneValue(v)
 	}
 
 	for k, baseVal := range base {
 		overrideVal, exists := result[k]
 		if !exists {
-			result[k] = baseVal
+			result[k] = cloneValue(baseVal)
 			continue
 		}
 
@@ -35,6 +35,25 @@ func DeepMerge(base, override map[string]any) map[string]any {
 	}
 
 	return result
+}
+
+func cloneValue(v any) any {
+	switch val := v.(type) {
+	case map[string]any:
+		cloned := make(map[string]any, len(val))
+		for k, child := range val {
+			cloned[k] = cloneValue(child)
+		}
+		return cloned
+	case []any:
+		cloned := make([]any, len(val))
+		for i, child := range val {
+			cloned[i] = cloneValue(child)
+		}
+		return cloned
+	default:
+		return v
+	}
 }
 
 // Dig traverses nested maps by keys, returning nil if any step fails.

--- a/internal/config/merge_test.go
+++ b/internal/config/merge_test.go
@@ -44,6 +44,21 @@ func TestDeepMerge_OverrideReplacesNonMap(t *testing.T) {
 	}
 }
 
+func TestDeepMerge_DoesNotAliasBaseMaps(t *testing.T) {
+	base := map[string]any{
+		"router": map[string]any{"port": 3001},
+	}
+	result := DeepMerge(base, map[string]any{})
+
+	router := result["router"].(map[string]any)
+	router["mode"] = "disabled"
+
+	baseRouter := base["router"].(map[string]any)
+	if _, ok := baseRouter["mode"]; ok {
+		t.Fatal("expected base router map to remain unchanged")
+	}
+}
+
 func TestDig(t *testing.T) {
 	m := map[string]any{
 		"port": map[string]any{
@@ -124,7 +139,10 @@ func TestWarnUnknownKeys_NoSuggestionForDistantKey(t *testing.T) {
 }
 
 func TestLevenshtein(t *testing.T) {
-	tests := []struct{ a, b string; want int }{
+	tests := []struct {
+		a, b string
+		want int
+	}{
 		{"port", "port", 0},
 		{"port", "prot", 2},
 		{"port", "ports", 1},

--- a/internal/config/user.go
+++ b/internal/config/user.go
@@ -24,6 +24,12 @@ var UserDefaults = map[string]any{
 	"tunnel": map[string]any{},
 }
 
+const (
+	RouterModePrompt   = "prompt"
+	RouterModeDisabled = "disabled"
+	RouterModeEnabled  = "enabled"
+)
+
 type UserConfig struct {
 	Path string
 	Data map[string]any
@@ -137,10 +143,44 @@ func (uc *UserConfig) HasExplicitRouterDomain() bool {
 	return ok && v != ""
 }
 
+// RouterMode returns the user's intent for the optional HTTPS router.
+// prompt means offer setup during install, disabled means localhost-only,
+// and enabled means install/repair the router when needed.
+func (uc *UserConfig) RouterMode() string {
+	if v, ok := Dig(uc.Data, "router", "mode").(string); ok {
+		switch v {
+		case RouterModePrompt, RouterModeDisabled, RouterModeEnabled:
+			return v
+		}
+	}
+	return RouterModePrompt
+}
+
+// SetRouterMode stores the user's router intent. Call Save() to persist.
+func (uc *UserConfig) SetRouterMode(mode string) {
+	switch mode {
+	case RouterModePrompt, RouterModeDisabled, RouterModeEnabled:
+		uc.Set("router.mode", mode)
+		uc.Set("warnings.router", mode != RouterModeDisabled)
+	}
+}
+
 // SafariWarningsEnabled returns whether to show Safari/hosts sync warnings.
 // Default: true. Set warnings.safari: false to disable.
 func (uc *UserConfig) SafariWarningsEnabled() bool {
 	if v, ok := Dig(uc.Data, "warnings", "safari").(bool); ok {
+		return v
+	}
+	return true
+}
+
+// RouterWarningsEnabled returns whether to show reminders about the optional
+// local HTTPS router. Default: true. Set warnings.router: false to disable.
+func (uc *UserConfig) RouterWarningsEnabled() bool {
+	if uc.RouterMode() == RouterModeDisabled {
+		return false
+	}
+	if v, ok := Dig(uc.Data, "warnings", "router").(bool); ok {
 		return v
 	}
 	return true
@@ -333,15 +373,36 @@ func (uc *UserConfig) Exists() bool {
 	return err == nil
 }
 
+// initDefaults returns the config shape written for brand-new user configs.
+// Keep router.domain explicit here so new installs use the modern prt.dev
+// default, while older configs that never set the key still preserve their
+// legacy localhost behavior at load time.
+func initDefaults() map[string]any {
+	data := copyMap(UserDefaults)
+	router, ok := data["router"].(map[string]any)
+	if !ok {
+		router = make(map[string]any)
+		data["router"] = router
+	}
+	router["domain"] = "prt.dev"
+	router["mode"] = RouterModePrompt
+	return data
+}
+
 func (uc *UserConfig) Init() error {
 	if err := os.MkdirAll(filepath.Dir(uc.Path), platform.DirMode); err != nil {
 		return err
 	}
-	data, err := json.MarshalIndent(UserDefaults, "", "  ")
+	initial := initDefaults()
+	data, err := json.MarshalIndent(initial, "", "  ")
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(uc.Path, append(data, '\n'), platform.PrivateFileMode)
+	if err := os.WriteFile(uc.Path, append(data, '\n'), platform.PrivateFileMode); err != nil {
+		return err
+	}
+	uc.Data = initial
+	return nil
 }
 
 var userKnownKeys = map[string]bool{

--- a/internal/config/user_test.go
+++ b/internal/config/user_test.go
@@ -55,6 +55,20 @@ func TestUserConfig_Init(t *testing.T) {
 	if !uc.Exists() {
 		t.Error("expected Exists() to be true after init")
 	}
+	if got := uc.RouterDomain(); got != "prt.dev" {
+		t.Errorf("expected init to pin prt.dev, got %s", got)
+	}
+	if !uc.HasExplicitRouterDomain() {
+		t.Error("expected init to write an explicit router.domain")
+	}
+
+	reloaded := LoadUserConfig(path)
+	if got := reloaded.RouterDomain(); got != "prt.dev" {
+		t.Errorf("expected reloaded init config to keep prt.dev, got %s", got)
+	}
+	if !reloaded.HasExplicitRouterDomain() {
+		t.Error("expected reloaded init config to keep explicit router.domain")
+	}
 }
 
 func TestRouterDomain_ExplicitValue(t *testing.T) {
@@ -100,6 +114,46 @@ func TestHasExplicitRouterDomain(t *testing.T) {
 	uc2 := LoadUserConfig(path2)
 	if uc2.HasExplicitRouterDomain() {
 		t.Error("expected false when domain is absent")
+	}
+}
+
+func TestRouterMode_DefaultPrompt(t *testing.T) {
+	uc := LoadUserConfig("/nonexistent/path/config.json")
+	if got := uc.RouterMode(); got != RouterModePrompt {
+		t.Fatalf("expected %q, got %q", RouterModePrompt, got)
+	}
+}
+
+func TestRouterMode_WarningsDoesNotChangeMode(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	_ = os.WriteFile(path, []byte(`{"warnings":{"router":false}}`), 0o644)
+
+	uc := LoadUserConfig(path)
+	if got := uc.RouterMode(); got != RouterModePrompt {
+		t.Fatalf("expected %q, got %q", RouterModePrompt, got)
+	}
+	if uc.RouterWarningsEnabled() {
+		t.Fatal("expected warnings.router=false to suppress prompts without changing mode")
+	}
+}
+
+func TestUserConfig_SetRouterMode(t *testing.T) {
+	uc := LoadUserConfig(filepath.Join(t.TempDir(), "config.json"))
+	uc.SetRouterMode(RouterModeEnabled)
+	if got := uc.RouterMode(); got != RouterModeEnabled {
+		t.Fatalf("expected %q, got %q", RouterModeEnabled, got)
+	}
+	if !uc.RouterWarningsEnabled() {
+		t.Fatal("expected router warnings enabled outside disabled mode")
+	}
+
+	uc.SetRouterMode(RouterModeDisabled)
+	if got := uc.RouterMode(); got != RouterModeDisabled {
+		t.Fatalf("expected %q, got %q", RouterModeDisabled, got)
+	}
+	if uc.RouterWarningsEnabled() {
+		t.Fatal("expected router warnings disabled in disabled mode")
 	}
 }
 
@@ -584,6 +638,23 @@ func TestUserConfig_RouterAliases(t *testing.T) {
 	}
 	if aliases["pgweb"] != 8082 {
 		t.Errorf("expected pgweb=8082, got %d", aliases["pgweb"])
+	}
+}
+
+func TestUserConfig_RouterWarningsEnabled_Default(t *testing.T) {
+	uc := LoadUserConfig(filepath.Join(t.TempDir(), "config.json"))
+	if !uc.RouterWarningsEnabled() {
+		t.Error("expected router warnings enabled by default")
+	}
+}
+
+func TestUserConfig_RouterWarningsEnabled_Disabled(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	_ = os.WriteFile(path, []byte(`{"warnings":{"router":false}}`), 0o644)
+	uc := LoadUserConfig(path)
+	if uc.RouterWarningsEnabled() {
+		t.Error("expected router warnings disabled")
 	}
 }
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/git-treeline/git-treeline/internal/proxy"
 	"github.com/git-treeline/git-treeline/internal/registry"
 	"github.com/git-treeline/git-treeline/internal/resolve"
+	"github.com/git-treeline/git-treeline/internal/service"
 	"github.com/git-treeline/git-treeline/internal/style"
 	"github.com/git-treeline/git-treeline/internal/worktree"
 )
@@ -146,7 +147,11 @@ func (s *Setup) Run() (*allocator.Allocation, error) {
 		_, _ = fmt.Fprintln(s.Log, style.Dimf("  Database: %s", alloc.Database))
 	}
 	_, _ = fmt.Fprintln(s.Log, style.Dimf("  Redis:    %s", redisURL))
-	_, _ = fmt.Fprintln(s.Log, style.Dimf("  URL:      http://localhost:%d", alloc.Port))
+	_, _ = fmt.Fprintln(s.Log, style.Dimf("  Local:    http://localhost:%d", alloc.Port))
+	if s.UserConfig.RouterMode() != config.RouterModeDisabled && service.IsRunning() {
+		routerURL := proxy.BuildRouterURL(0, s.ProjectConfig.Project(), branch, s.UserConfig.RouterDomain(), s.UserConfig.RouterPort(), true, service.IsPortForwardConfigured())
+		_, _ = fmt.Fprintln(s.Log, style.Dimf("  Router:   %s", routerURL))
+	}
 	_, _ = fmt.Fprintln(s.Log, style.Dimf("  Dir:      %s", s.WorktreePath))
 
 	return alloc, nil
@@ -241,7 +246,11 @@ func (s *Setup) copyFiles() {
 
 func (s *Setup) buildEnvVars(alloc interpolation.Allocation, redisURL string) (map[string]string, error) {
 	branch, _ := alloc["branch"].(string)
-	InjectRouterTokens(alloc, s.ProjectConfig.Project(), branch, s.UserConfig.RouterDomain(), s.UserConfig.TunnelDomain(""))
+	routerDomain := s.UserConfig.RouterDomain()
+	if s.UserConfig.RouterMode() == config.RouterModeDisabled {
+		routerDomain = ""
+	}
+	InjectRouterTokens(alloc, s.ProjectConfig.Project(), branch, routerDomain, s.UserConfig.TunnelDomain(""))
 	if s.Resolver != nil {
 		return BuildEnvVarsWithResolver(s.ProjectConfig, alloc, redisURL, s.Resolver)
 	}
@@ -251,6 +260,14 @@ func (s *Setup) buildEnvVars(alloc interpolation.Allocation, redisURL string) (m
 // InjectRouterTokens adds router_url, router_domain, and tunnel_host to an
 // allocation map so the corresponding env tokens can be resolved.
 func InjectRouterTokens(alloc interpolation.Allocation, project, branch, routerDomain, tunnelDomain string) {
+	if routerDomain == "" {
+		alloc["router_url"] = ""
+		alloc["router_domain"] = ""
+		if tunnelDomain != "" {
+			alloc["tunnel_host"] = tunnelDomain
+		}
+		return
+	}
 	routeKey := proxy.RouteKey(project, branch)
 	alloc["router_url"] = fmt.Sprintf("https://%s.%s", routeKey, routerDomain)
 	alloc["router_domain"] = routerDomain
@@ -490,14 +507,18 @@ func ConfigureEditor(worktreePath string, pc *config.ProjectConfig, uc *config.U
 
 	project := pc.Project()
 	routerDomain := uc.RouterDomain()
-	routeKey := proxy.RouteKey(project, branch)
+	routerURL := ""
+	if uc.RouterMode() != config.RouterModeDisabled {
+		routeKey := proxy.RouteKey(project, branch)
+		routerURL = fmt.Sprintf("https://%s.%s", routeKey, routerDomain)
+	}
 
 	replacer := strings.NewReplacer(
 		"{project}", project,
 		"{port}", fmt.Sprintf("%d", port),
 		"{branch}", branch,
 		"{url}", fmt.Sprintf("http://localhost:%d", port),
-		"{router_url}", fmt.Sprintf("https://%s.%s", routeKey, routerDomain),
+		"{router_url}", routerURL,
 	)
 
 	title := ""

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -605,6 +605,20 @@ func TestInjectRouterTokens_EmptyBranch(t *testing.T) {
 	}
 }
 
+func TestInjectRouterTokens_DisabledRouter(t *testing.T) {
+	alloc := interpolation.Allocation{"port": float64(3010)}
+	InjectRouterTokens(alloc, "salt", "feature", "", "gtltunnel.dev")
+	if got := alloc["router_url"].(string); got != "" {
+		t.Errorf("router_url: expected empty string when router disabled, got %q", got)
+	}
+	if got := alloc["router_domain"].(string); got != "" {
+		t.Errorf("router_domain: expected empty string when router disabled, got %q", got)
+	}
+	if got := alloc["tunnel_host"].(string); got != "gtltunnel.dev" {
+		t.Errorf("tunnel_host: expected gtltunnel.dev, got %q", got)
+	}
+}
+
 func TestRun_SummaryBlockFormat(t *testing.T) {
 	s, mainRepo, _ := testSetup(t, `
 project: test
@@ -625,8 +639,8 @@ env:
 	if !strings.Contains(plain, "Done!") {
 		t.Error("expected Done! in summary output")
 	}
-	if !strings.Contains(plain, "Port:") || !strings.Contains(plain, "Redis:") {
-		t.Error("expected Port: and Redis: in summary output")
+	if !strings.Contains(plain, "Port:") || !strings.Contains(plain, "Redis:") || !strings.Contains(plain, "Local:") {
+		t.Error("expected Port:, Redis:, and Local: in summary output")
 	}
 }
 

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -51,6 +51,16 @@ func gitCheck(dir string, args ...string) bool {
 	return cmd.Run() == nil
 }
 
+// DetectRepoRoot returns the top-level directory of the current git worktree.
+// Falls back to the given path if detection fails.
+func DetectRepoRoot(path string) string {
+	root := gitOutput(path, "rev-parse", "--show-toplevel")
+	if root == "" {
+		return path
+	}
+	return root
+}
+
 // Create adds a git worktree at path. If newBranch is true, it creates a new
 // branch from base. Otherwise it checks out an existing branch.
 func Create(path, branch string, newBranch bool, base string) error {


### PR DESCRIPTION
## Summary

- **`gtl install`** — single onboarding command that creates user config, installs the post-checkout hook, allocates ports, and optionally enables HTTPS routing (prompted with a docs link). Idempotent. Solves the gap where only the `gtl init` runner got hooks and every subsequent developer had a fragmented multi-command setup.
- **`gtl setup` no longer gates on HTTPS router** — prints a warning instead of hard-failing when `gtl serve install` hasn't been run. Developers can allocate ports without the HTTPS stack.
- **`gtl serve install` refactored** — router install logic extracted into `runServeInstall()`, shared between `gtl serve install` and `gtl install`. No duplicated code.
- README rewritten: "First-time setup" section now has two clear paths (first dev → `gtl init` + `gtl install`, any dev → `gtl install`).

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass (including guard tests for CliError wrapping)
- [x] `gtl install` from a project dir with `.treeline.yml`: creates config, installs hook, runs setup, prompts for HTTPS
- [x] `gtl install` without `.treeline.yml`: clear error with hint to run `gtl init`
- [x] `gtl setup` without HTTPS router: warns but proceeds (no longer errors)
- [x] `gtl serve install`: still works as before (uses shared `runServeInstall`)