### PR TITLE
Add Phoenix framework support

### DIFF
--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -189,6 +189,8 @@ func doctorConfig(pc *config.ProjectConfig, det *detect.Result, absPath string) 
 		switch det.Framework {
 		case "vite":
 			doctorLine("port wiring", "⚠ Vite ignores PORT env — add {port} to commands.start")
+		case "phoenix":
+			doctorLine("port wiring", "⚠ Phoenix needs PORT in the command — use PORT={port} mix phx.server")
 		case "django", "python":
 			if !strings.Contains(sc, "$PORT") && !strings.Contains(sc, "${PORT") {
 				doctorLine("port wiring", "⚠ Django needs the port in the command — use {port}")

--- a/cmd/init_cmd.go
+++ b/cmd/init_cmd.go
@@ -56,14 +56,14 @@ var initCmd = &cobra.Command{
 			project = filepath.Base(cwd)
 		}
 
-		templateDB := initTemplateDB
-		if templateDB == "" {
-			templateDB = project + "_development"
-		}
-
 		cwd, _ := os.Getwd()
 		detection := detect.Detect(cwd)
 		detection.MergeTarget = worktree.DetectDefaultBranch(cwd)
+
+		templateDB := initTemplateDB
+		if templateDB == "" {
+			templateDB = defaultTemplateDB(project, detection)
+		}
 
 		if len(detection.EnvFiles) > 1 {
 			idx := confirm.Select(
@@ -163,6 +163,16 @@ func splitLines(s string) []string {
 	return strings.Split(s, "\n")
 }
 
+// defaultTemplateDB returns the conventional development database name
+// for the detected framework: {project}_dev for Phoenix, {project}_development
+// for Rails and everything else.
+func defaultTemplateDB(project string, det *detect.Result) string {
+	if det != nil && det.Framework == "phoenix" {
+		return project + "_dev"
+	}
+	return project + "_development"
+}
+
 func openInEditor(path string) {
 	editor := os.Getenv("VISUAL")
 	if editor == "" {
@@ -186,9 +196,8 @@ func runInitForNew(mainRepo string, det *detect.Result) error {
 	}
 
 	project := filepath.Base(mainRepo)
-	templateDB := project + "_development"
-
 	det.MergeTarget = worktree.DetectDefaultBranch(mainRepo)
+	templateDB := defaultTemplateDB(project, det)
 
 	content := templates.ForDetection(project, templateDB, det)
 

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -14,7 +14,7 @@ import (
 // Result contains the detection findings for a project directory.
 // All fields are populated by Detect() based on filesystem analysis.
 type Result struct {
-	Framework      string   // "nextjs", "vite", "rails", "node", "django", "python", "rust", "go", "unknown"
+	Framework      string   // "nextjs", "vite", "rails", "phoenix", "node", "django", "python", "rust", "go", "unknown"
 	HasPrisma      bool
 	HasJSBundler   bool     // jsbundling-rails/cssbundling-rails or multi-process Procfile.dev
 	HasDotenv      bool     // project has dotenv or equivalent wired up
@@ -23,7 +23,8 @@ type Result struct {
 	HasEnvFile     bool     // true if any env file exists on disk
 	EnvFile        string   // best candidate: ".env.local", ".env.development", ".env", etc.
 	EnvFiles       []string // all env files found, in priority order
-	PackageManager string   // "npm", "yarn", "pnpm", "bundle", "cargo", "pip", ""
+	PackageManager string   // "npm", "yarn", "pnpm", "bundle", "mix", "cargo", "pip", ""
+	IsUmbrella     bool     // Phoenix umbrella project (apps/*/mix.exs); not yet fully supported
 	MergeTarget    string   // set by caller when git context is available
 }
 
@@ -51,6 +52,11 @@ func (r *Result) detectFramework(root string) {
 
 	if fileExists(root, "Gemfile") && fileExists(root, "config/application.rb") {
 		r.Framework = "rails"
+		return
+	}
+
+	if fileExists(root, "mix.exs") && r.detectPhoenix(root) {
+		r.Framework = "phoenix"
 		return
 	}
 
@@ -107,6 +113,21 @@ func (r *Result) detectDatabase(root string) {
 		}
 	}
 
+	if r.Framework == "phoenix" {
+		if content, err := os.ReadFile(filepath.Join(root, "mix.exs")); err == nil {
+			s := string(content)
+			switch {
+			case strings.Contains(s, ":ecto_sqlite3"):
+				r.DBAdapter = "sqlite"
+			case strings.Contains(s, ":postgrex"):
+				r.DBAdapter = "postgresql"
+			case strings.Contains(s, ":myxql"):
+				r.DBAdapter = "mysql"
+			}
+		}
+		return
+	}
+
 	if r.HasPrisma {
 		r.DBAdapter = "postgresql"
 	}
@@ -129,6 +150,10 @@ func (r *Result) detectRedis(root string) {
 }
 
 func (r *Result) detectPackageManager(root string) {
+	if r.Framework == "phoenix" {
+		r.PackageManager = "mix"
+		return
+	}
 	switch {
 	case fileExists(root, "pnpm-lock.yaml"):
 		r.PackageManager = "pnpm"
@@ -138,6 +163,8 @@ func (r *Result) detectPackageManager(root string) {
 		r.PackageManager = "npm"
 	case fileExists(root, "Gemfile.lock") || fileExists(root, "Gemfile"):
 		r.PackageManager = "bundle"
+	case fileExists(root, "mix.lock") || fileExists(root, "mix.exs"):
+		r.PackageManager = "mix"
 	case fileExists(root, "Cargo.lock") || fileExists(root, "Cargo.toml"):
 		r.PackageManager = "cargo"
 	case fileExists(root, "requirements.txt") || fileExists(root, "pyproject.toml"):
@@ -215,6 +242,30 @@ func (r *Result) detectPrisma(root string) {
 	r.HasPrisma = fileExists(root, "prisma/schema.prisma")
 }
 
+// detectPhoenix returns true if mix.exs declares :phoenix as a dependency.
+// Also sets IsUmbrella when an apps/ directory of sub-projects is present.
+func (r *Result) detectPhoenix(root string) bool {
+	content, err := os.ReadFile(filepath.Join(root, "mix.exs"))
+	if err != nil {
+		return false
+	}
+	if !strings.Contains(string(content), ":phoenix") {
+		return false
+	}
+	if dirExists(root, "apps") {
+		entries, err := os.ReadDir(filepath.Join(root, "apps"))
+		if err == nil {
+			for _, e := range entries {
+				if e.IsDir() && fileExists(root, "apps", e.Name(), "mix.exs") {
+					r.IsUmbrella = true
+					break
+				}
+			}
+		}
+	}
+	return true
+}
+
 func (r *Result) detectJSBundler(root string) {
 	if content, err := os.ReadFile(filepath.Join(root, "Gemfile")); err == nil {
 		s := string(content)
@@ -262,7 +313,7 @@ func dirExists(root, rel string) bool {
 // development server (Rails, Node, Django, etc.) as opposed to a CLI or library.
 func (r *Result) IsServerFramework() bool {
 	switch r.Framework {
-	case "rails", "nextjs", "vite", "node", "django", "python":
+	case "rails", "nextjs", "vite", "node", "django", "python", "phoenix":
 		return true
 	case "go", "rust", "unknown":
 		return false

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -193,6 +193,102 @@ func TestDetect_Go(t *testing.T) {
 	}
 }
 
+func TestDetect_Phoenix_Postgres(t *testing.T) {
+	dir := setup(t, "mix.exs", "mix.lock", "lib/myapp/application.ex")
+	_ = os.WriteFile(filepath.Join(dir, "mix.exs"), []byte(`defmodule MyApp.MixProject do
+  def deps do
+    [
+      {:phoenix, "~> 1.7"},
+      {:ecto_sql, "~> 3.10"},
+      {:postgrex, ">= 0.0.0"},
+    ]
+  end
+end`), 0o644)
+
+	r := Detect(dir)
+	if r.Framework != "phoenix" {
+		t.Errorf("expected phoenix, got %s", r.Framework)
+	}
+	if r.DBAdapter != "postgresql" {
+		t.Errorf("expected postgresql, got %s", r.DBAdapter)
+	}
+	if r.PackageManager != "mix" {
+		t.Errorf("expected mix, got %s", r.PackageManager)
+	}
+	if r.IsUmbrella {
+		t.Error("expected IsUmbrella=false for single-app project")
+	}
+}
+
+func TestDetect_Phoenix_SQLite(t *testing.T) {
+	dir := setup(t, "mix.exs", "lib/myapp/application.ex")
+	_ = os.WriteFile(filepath.Join(dir, "mix.exs"), []byte(`defmodule MyApp.MixProject do
+  def deps do
+    [
+      {:phoenix, "~> 1.7"},
+      {:ecto_sqlite3, "~> 0.12"},
+    ]
+  end
+end`), 0o644)
+
+	r := Detect(dir)
+	if r.Framework != "phoenix" {
+		t.Errorf("expected phoenix, got %s", r.Framework)
+	}
+	if r.DBAdapter != "sqlite" {
+		t.Errorf("expected sqlite, got %s", r.DBAdapter)
+	}
+}
+
+func TestDetect_Phoenix_Umbrella(t *testing.T) {
+	dir := setup(t,
+		"mix.exs",
+		"apps/web/mix.exs",
+		"apps/web/lib/web/application.ex",
+		"apps/core/mix.exs",
+	)
+	_ = os.WriteFile(filepath.Join(dir, "mix.exs"), []byte(`defmodule MyApp.Umbrella.MixProject do
+  def deps do
+    [{:phoenix, "~> 1.7"}]
+  end
+end`), 0o644)
+	_ = os.WriteFile(filepath.Join(dir, "apps/web/mix.exs"), []byte(""), 0o644)
+
+	r := Detect(dir)
+	if r.Framework != "phoenix" {
+		t.Errorf("expected phoenix, got %s", r.Framework)
+	}
+	if !r.IsUmbrella {
+		t.Error("expected IsUmbrella=true when apps/*/mix.exs exists")
+	}
+}
+
+func TestDetect_Phoenix_NotElixirOnly(t *testing.T) {
+	// mix.exs without :phoenix should not be detected as phoenix
+	dir := setup(t, "mix.exs")
+	_ = os.WriteFile(filepath.Join(dir, "mix.exs"), []byte(`defmodule Lib.MixProject do
+  def deps, do: [{:jason, "~> 1.4"}]
+end`), 0o644)
+
+	r := Detect(dir)
+	if r.Framework == "phoenix" {
+		t.Error("expected non-phoenix framework for plain Elixir lib")
+	}
+}
+
+func TestDetect_Phoenix_PrefersMixOverNpm(t *testing.T) {
+	dir := setup(t, "mix.exs", "lib/myapp/application.ex", "package.json", "package-lock.json")
+	_ = os.WriteFile(filepath.Join(dir, "mix.exs"), []byte(`{:phoenix, "~> 1.7"}`), 0o644)
+
+	r := Detect(dir)
+	if r.Framework != "phoenix" {
+		t.Errorf("expected phoenix, got %s", r.Framework)
+	}
+	if r.PackageManager != "mix" {
+		t.Errorf("expected mix (not npm) for phoenix project, got %s", r.PackageManager)
+	}
+}
+
 func TestDetect_Vite(t *testing.T) {
 	dir := setup(t, "package.json", "vite.config.js")
 	r := Detect(dir)
@@ -338,6 +434,7 @@ func TestIsServerFramework(t *testing.T) {
 		{"node", true},
 		{"django", true},
 		{"python", true},
+		{"phoenix", true},
 		{"go", false},
 		{"rust", false},
 		{"unknown", false},

--- a/internal/templates/diagnostics.go
+++ b/internal/templates/diagnostics.go
@@ -18,8 +18,21 @@ func Diagnose(det *detect.Result) []Diagnostic {
 
 	diags = append(diags, diagnoseEnvLoading(det)...)
 	diags = append(diags, diagnosePortWiring(det)...)
+	diags = append(diags, diagnoseUmbrella(det)...)
 
 	return diags
+}
+
+func diagnoseUmbrella(det *detect.Result) []Diagnostic {
+	if !det.IsUmbrella {
+		return nil
+	}
+	return []Diagnostic{{
+		Level: "warn",
+		Message: "Phoenix umbrella project detected.\n" +
+			"  gtl treats the umbrella as a single app — per-app port/db isolation isn't supported yet.\n" +
+			"  File an issue at https://github.com/git-treeline/git-treeline if you need it.",
+	}}
 }
 
 func diagnoseEnvLoading(det *detect.Result) []Diagnostic {
@@ -54,6 +67,12 @@ func diagnoseEnvLoading(det *detect.Result) []Diagnostic {
 				Level:   "warn",
 				Message: "no python-dotenv detected.\n  Treeline writes .env but your app won't load it.\n  pip install python-dotenv",
 			})
+		case "phoenix":
+			diags = append(diags, Diagnostic{
+				Level: "info",
+				Message: fmt.Sprintf("Phoenix doesn't auto-load %s. The generated start command sets PORT inline.\n  For other env vars, source the file or use a library like dotenvy.",
+					target),
+			})
 		case "go", "rust":
 			diags = append(diags, Diagnostic{
 				Level: "info",
@@ -86,6 +105,8 @@ func frameworkName(det *detect.Result) string {
 		return "Vite"
 	case "rails":
 		return "Rails"
+	case "phoenix":
+		return "Phoenix"
 	case "django":
 		return "Django"
 	case "node":

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -20,6 +20,8 @@ func ForDetection(project, templateDB string, det *detect.Result) string {
 		return vite(project, det)
 	case "rails":
 		return rails(project, templateDB, det)
+	case "phoenix":
+		return phoenix(project, templateDB, det)
 	case "node":
 		return node(project, det)
 	case "django", "python":
@@ -137,6 +139,62 @@ func rails(project, templateDB string, det *detect.Result) string {
 
 	if det.MergeTarget == "" {
 		b.WriteString("\n# merge_target: develop            # branch that prune --merged checks against\n")
+	}
+
+	writeHooksComment(&b)
+	writeEditorComment(&b)
+	return b.String()
+}
+
+func phoenix(project, templateDB string, det *detect.Result) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "project: %s\n", project)
+	writeMergeTarget(&b, det)
+
+	emit := shouldEmitEnv(det)
+	if emit {
+		writeEnvFileBlock(&b, envTarget(det))
+	}
+
+	adapter := det.DBAdapter
+	if adapter == "" {
+		adapter = "postgresql"
+	}
+
+	fmt.Fprintf(&b, "\ndatabase:\n")
+	fmt.Fprintf(&b, "  adapter: %s\n", adapter)
+	if adapter == "sqlite" {
+		fmt.Fprintf(&b, "  template: %s_dev.db\n", project)
+		fmt.Fprintf(&b, "  pattern: \"%s_{worktree}.db\"\n", project)
+	} else {
+		tdb := templateDB
+		if tdb == "" {
+			tdb = project + "_dev"
+		}
+		fmt.Fprintf(&b, "  template: %s\n", tdb)
+		fmt.Fprintf(&b, "  pattern: \"{template}_{worktree}\"\n")
+	}
+
+	if emit {
+		b.WriteString("\nenv:\n")
+		fmt.Fprintf(&b, "  PORT: \"{port}\"\n")
+		if adapter == "sqlite" {
+			fmt.Fprintf(&b, "  DATABASE_PATH: \"{database}\"\n")
+		} else {
+			fmt.Fprintf(&b, "  DATABASE_URL: \"ecto://postgres:postgres@localhost:5432/{database}\"\n")
+		}
+		writeResolveComment(&b)
+	}
+
+	b.WriteString("\ncommands:\n")
+	b.WriteString("  setup:\n")
+	b.WriteString("    - mix deps.get\n")
+	b.WriteString("    - mix ecto.migrate\n")
+	b.WriteString("  start: PORT={port} mix phx.server\n")
+
+	if det.IsUmbrella {
+		b.WriteString("\n# Umbrella project detected. gtl currently treats umbrellas as a single app —\n")
+		b.WriteString("# per-app port/db isolation isn't supported yet. Open an issue if you need it.\n")
 	}
 
 	writeHooksComment(&b)
@@ -279,6 +337,8 @@ func startCommandFor(det *detect.Result) string {
 		return "" // already emitted inline for vite (npx vite)
 	case "rails":
 		return "" // already emitted inline for rails (bin/dev)
+	case "phoenix":
+		return "" // already emitted inline for phoenix (PORT={port} mix phx.server)
 	case "node":
 		return runCmd(det) + " dev"
 	case "django", "python":
@@ -326,6 +386,13 @@ Use {port} in your start command (gtl init does this automatically):
 
   const port = process.env.PORT || 3000;
   app.listen(port);`
+	case "phoenix":
+		return `Phoenix doesn't read PORT by default. Wire it up in config/dev.exs:
+
+  config :myapp, MyAppWeb.Endpoint,
+    http: [ip: {127, 0, 0, 1}, port: String.to_integer(System.get_env("PORT") || "4000")]
+
+The generated start command sets PORT for you (PORT={port} mix phx.server).`
 	case "django", "python":
 		return `Use {port} in your start command for the allocated port:
 

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -105,6 +105,73 @@ func TestForDetection_Rails_SQLite(t *testing.T) {
 	assertNotContains(t, content, "DATABASE_NAME")
 }
 
+func TestForDetection_Phoenix_Postgres(t *testing.T) {
+	det := &detect.Result{
+		Framework:      "phoenix",
+		HasEnvFile:     true,
+		DBAdapter:      "postgresql",
+		PackageManager: "mix",
+		EnvFile:        ".env",
+	}
+	content := ForDetection("myapp", "myapp_dev", det)
+
+	assertValidYAML(t, content)
+	assertContains(t, content, "project: myapp")
+	assertContains(t, content, "adapter: postgresql")
+	assertContains(t, content, "template: myapp_dev")
+	assertContains(t, content, "DATABASE_URL")
+	assertContains(t, content, "mix deps.get")
+	assertContains(t, content, "mix ecto.migrate")
+	assertContains(t, content, "start: PORT={port} mix phx.server")
+	assertNotContains(t, content, "DATABASE_PATH")
+	assertNotContains(t, content, "config/master.key")
+}
+
+func TestForDetection_Phoenix_SQLite(t *testing.T) {
+	det := &detect.Result{
+		Framework:      "phoenix",
+		HasEnvFile:     true,
+		DBAdapter:      "sqlite",
+		PackageManager: "mix",
+		EnvFile:        ".env",
+	}
+	content := ForDetection("myapp", "", det)
+
+	assertValidYAML(t, content)
+	assertContains(t, content, "adapter: sqlite")
+	assertContains(t, content, "myapp_dev.db")
+	assertContains(t, content, "DATABASE_PATH")
+	assertNotContains(t, content, "DATABASE_URL")
+}
+
+func TestForDetection_Phoenix_NoEnvFile(t *testing.T) {
+	det := &detect.Result{
+		Framework:      "phoenix",
+		HasEnvFile:     false,
+		PackageManager: "mix",
+	}
+	content := ForDetection("myapp", "", det)
+
+	assertValidYAML(t, content)
+	assertContains(t, content, "adapter: postgresql")
+	assertContains(t, content, "template: myapp_dev")
+	assertContains(t, content, "start: PORT={port} mix phx.server")
+	assertNotContains(t, content, "env_file")
+	assertNotContains(t, content, "DATABASE_URL")
+}
+
+func TestForDetection_Phoenix_Umbrella(t *testing.T) {
+	det := &detect.Result{
+		Framework:      "phoenix",
+		IsUmbrella:     true,
+		PackageManager: "mix",
+	}
+	content := ForDetection("myapp", "", det)
+
+	assertValidYAML(t, content)
+	assertContains(t, content, "Umbrella project detected")
+}
+
 func TestForDetection_Node(t *testing.T) {
 	det := &detect.Result{
 		Framework:      "node",
@@ -399,6 +466,47 @@ func TestPortHint_Rails(t *testing.T) {
 	hint := PortHint(det)
 	if hint != "" {
 		t.Errorf("expected no hint for Rails, got: %s", hint)
+	}
+}
+
+func TestPortHint_Phoenix(t *testing.T) {
+	det := &detect.Result{Framework: "phoenix"}
+	hint := PortHint(det)
+	if !strings.Contains(hint, "config/dev.exs") {
+		t.Errorf("expected Phoenix port hint to mention config/dev.exs, got: %s", hint)
+	}
+	if !strings.Contains(hint, "System.get_env") {
+		t.Errorf("expected Phoenix port hint to mention System.get_env, got: %s", hint)
+	}
+}
+
+func TestDiagnose_Phoenix_Umbrella(t *testing.T) {
+	det := &detect.Result{Framework: "phoenix", IsUmbrella: true}
+	diags := Diagnose(det)
+
+	hasUmbrellaWarning := false
+	for _, d := range diags {
+		if d.Level == "warn" && strings.Contains(d.Message, "umbrella") {
+			hasUmbrellaWarning = true
+		}
+	}
+	if !hasUmbrellaWarning {
+		t.Error("expected umbrella warning for Phoenix umbrella project")
+	}
+}
+
+func TestDiagnose_Phoenix_PortHint(t *testing.T) {
+	det := &detect.Result{Framework: "phoenix"}
+	diags := Diagnose(det)
+
+	hasPortWarning := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "config/dev.exs") {
+			hasPortWarning = true
+		}
+	}
+	if !hasPortWarning {
+		t.Error("expected port wiring diagnostic for Phoenix")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Detects Phoenix via `mix.exs` (with `:phoenix` dep) and picks the DB adapter from mix deps (`:postgrex`, `:ecto_sqlite3`, `:myxql`).
- Generates a `.treeline.yml` with `start: PORT={port} mix phx.server`, `mix deps.get` + `mix ecto.migrate` setup, and a default template DB of `{project}_dev` (Phoenix convention, not Rails' `_development`).
- Emits a strong port-wiring diagnostic showing how to wire `System.get_env("PORT")` into `config/dev.exs`, since Phoenix doesn't read `PORT` by default.
- Detects umbrella projects (`apps/*/mix.exs`) and surfaces a warning that gtl currently treats them as a single app — per-app port/db isolation isn't supported yet.
- `gtl doctor` now flags missing `{port}` in the start command for Phoenix.

## Test plan
- [x] `go test ./...` passes (5 new detect tests, 4 new template tests, 3 new diagnostic/hint tests)
- [x] Smoke-tested `gtl init` against a fake single-app Phoenix project (postgres) — generates expected YAML and prints port-wiring + env-loading diagnostics
- [x] Smoke-tested `gtl init` against a fake umbrella Phoenix project — additionally prints the umbrella warning
- [x] Try against a real Phoenix app + Postgres to confirm `gtl setup` and `gtl start` boot the server end-to-end