### PR TITLE
Detect Rails app name during init

### DIFF
--- a/cmd/init_cmd.go
+++ b/cmd/init_cmd.go
@@ -50,15 +50,13 @@ var initCmd = &cobra.Command{
 			fmt.Println(style.Actionf("Created user config at %s", platform.ConfigFile()))
 		}
 
-		project := initProject
-		if project == "" {
-			cwd, _ := os.Getwd()
-			project = filepath.Base(cwd)
-		}
-
 		cwd, _ := os.Getwd()
 		detection := detect.Detect(cwd)
 		detection.MergeTarget = worktree.DetectDefaultBranch(cwd)
+		project := initProject
+		if project == "" {
+			project = defaultProjectName(cwd, detection)
+		}
 
 		templateDB := initTemplateDB
 		if templateDB == "" {
@@ -167,10 +165,40 @@ func splitLines(s string) []string {
 // for the detected framework: {project}_dev for Phoenix, {project}_development
 // for Rails and everything else.
 func defaultTemplateDB(project string, det *detect.Result) string {
-	if det != nil && det.Framework == "phoenix" {
-		return project + "_dev"
+	if det != nil && det.DBTemplate != "" {
+		return det.DBTemplate
 	}
-	return project + "_development"
+	dbProject := databaseIdentifierName(project)
+	if det != nil && det.Framework == "phoenix" {
+		return dbProject + "_dev"
+	}
+	return dbProject + "_development"
+}
+
+func databaseIdentifierName(name string) string {
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range name {
+		valid := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_'
+		if valid {
+			b.WriteRune(r)
+			lastUnderscore = r == '_'
+			continue
+		}
+		if !lastUnderscore {
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	result := strings.Trim(b.String(), "_")
+	if result == "" {
+		return "app"
+	}
+	first := result[0]
+	if (first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z') || first == '_' {
+		return result
+	}
+	return "db_" + result
 }
 
 func openInEditor(path string) {
@@ -195,7 +223,7 @@ func runInitForNew(mainRepo string, det *detect.Result) error {
 		return nil
 	}
 
-	project := filepath.Base(mainRepo)
+	project := defaultProjectName(mainRepo, det)
 	det.MergeTarget = worktree.DetectDefaultBranch(mainRepo)
 	templateDB := defaultTemplateDB(project, det)
 
@@ -211,4 +239,11 @@ func runInitForNew(mainRepo string, det *detect.Result) error {
 	}
 	fmt.Println(style.Actionf("%s", msg))
 	return nil
+}
+
+func defaultProjectName(root string, det *detect.Result) string {
+	if det != nil && det.ProjectName != "" {
+		return det.ProjectName
+	}
+	return filepath.Base(root)
 }

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/git-treeline/git-treeline/internal/config"
+	"github.com/git-treeline/git-treeline/internal/detect"
 	setupPkg "github.com/git-treeline/git-treeline/internal/setup"
 )
 
@@ -81,6 +82,56 @@ func TestInstallCmd_MissingProjectConfigFromSubdirInitializesRepoRoot(t *testing
 	}
 	if _, err := os.Stat(filepath.Join(subdir, ".treeline.yml")); !os.IsNotExist(err) {
 		t.Fatalf("expected no nested .treeline.yml in subdir, got err=%v", err)
+	}
+}
+
+func TestRunInitForNew_RailsUsesDetectedTemplateDatabase(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "honolulu-v1")
+	if err := os.MkdirAll(filepath.Join(dir, "config"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "Gemfile"), []byte("gem 'rails'\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config", "application.rb"), []byte("module HonoluluV1\nend\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config", "database.yml"), []byte(`default: &default
+  adapter: postgresql
+
+development:
+  <<: *default
+  database: honolulu_v1_development
+`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := runInitForNew(dir, detect.Detect(dir)); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, ".treeline.yml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "project: honolulu_v1") {
+		t.Errorf("expected project from Rails app name, got:\n%s", content)
+	}
+	if !strings.Contains(content, "template: honolulu_v1_development") {
+		t.Errorf("expected Rails template DB from database.yml, got:\n%s", content)
+	}
+	if strings.Contains(content, "template: honolulu-v1_development") {
+		t.Errorf("expected no hyphenated PostgreSQL template DB, got:\n%s", content)
+	}
+}
+
+func TestDefaultTemplateDB_SanitizesProjectForPostgreSQL(t *testing.T) {
+	if got := defaultTemplateDB("honolulu-v1", &detect.Result{Framework: "rails"}); got != "honolulu_v1_development" {
+		t.Errorf("expected sanitized Rails template DB, got %q", got)
+	}
+	if got := defaultTemplateDB("123-api", &detect.Result{Framework: "phoenix"}); got != "db_123_api_dev" {
+		t.Errorf("expected sanitized Phoenix template DB, got %q", got)
 	}
 }
 

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -14,11 +14,13 @@ import (
 // Result contains the detection findings for a project directory.
 // All fields are populated by Detect() based on filesystem analysis.
 type Result struct {
-	Framework      string   // "nextjs", "vite", "rails", "phoenix", "node", "django", "python", "rust", "go", "unknown"
+	Framework      string // "nextjs", "vite", "rails", "phoenix", "node", "django", "python", "rust", "go", "unknown"
+	ProjectName    string // framework-specific project/app name, when detected
 	HasPrisma      bool
-	HasJSBundler   bool     // jsbundling-rails/cssbundling-rails or multi-process Procfile.dev
-	HasDotenv      bool     // project has dotenv or equivalent wired up
-	DBAdapter      string   // "postgresql", "sqlite", ""
+	HasJSBundler   bool   // jsbundling-rails/cssbundling-rails or multi-process Procfile.dev
+	HasDotenv      bool   // project has dotenv or equivalent wired up
+	DBAdapter      string // "postgresql", "sqlite", ""
+	DBTemplate     string // static development database name, when detected
 	HasRedis       bool
 	HasEnvFile     bool     // true if any env file exists on disk
 	EnvFile        string   // best candidate: ".env.local", ".env.development", ".env", etc.
@@ -32,6 +34,7 @@ func Detect(root string) *Result {
 	r := &Result{Framework: "unknown"}
 
 	r.detectFramework(root)
+	r.detectProjectName(root)
 	r.detectPrisma(root)
 	r.detectJSBundler(root)
 	r.detectDotenv(root)
@@ -91,26 +94,96 @@ func (r *Result) detectFramework(root string) {
 	}
 }
 
+func (r *Result) detectProjectName(root string) {
+	if r.Framework != "rails" {
+		return
+	}
+	appRB := filepath.Join(root, "config", "application.rb")
+	if f, err := os.Open(appRB); err == nil {
+		defer func() { _ = f.Close() }()
+		r.ProjectName = parseRailsApplicationModule(f)
+	}
+}
+
+func parseRailsApplicationModule(f *os.File) string {
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if beforeComment, _, ok := strings.Cut(line, "#"); ok {
+			line = beforeComment
+		}
+		fields := strings.Fields(strings.TrimSpace(line))
+		if len(fields) < 2 || fields[0] != "module" {
+			continue
+		}
+		name := strings.Trim(fields[1], `"'`)
+		if name == "" {
+			continue
+		}
+		if project := rubyModuleToProjectName(name); project != "" {
+			return project
+		}
+	}
+	return ""
+}
+
+func rubyModuleToProjectName(name string) string {
+	name = strings.ReplaceAll(name, "::", "_")
+	var b strings.Builder
+	var prev rune
+	for i, r := range name {
+		if !isASCIIAlphaNum(r) {
+			if b.Len() > 0 && prev != '_' {
+				b.WriteByte('_')
+				prev = '_'
+			}
+			continue
+		}
+		if isUpper(r) {
+			if i > 0 && prev != '_' && (isLower(prev) || isDigit(prev)) {
+				b.WriteByte('_')
+			}
+			r += 'a' - 'A'
+		}
+		b.WriteRune(r)
+		prev = r
+	}
+	return strings.Trim(b.String(), "_")
+}
+
+func isASCIIAlphaNum(r rune) bool {
+	return isLower(r) || isUpper(r) || isDigit(r)
+}
+
+func isLower(r rune) bool {
+	return r >= 'a' && r <= 'z'
+}
+
+func isUpper(r rune) bool {
+	return r >= 'A' && r <= 'Z'
+}
+
+func isDigit(r rune) bool {
+	return r >= '0' && r <= '9'
+}
+
 func (r *Result) detectDatabase(root string) {
 	dbYml := filepath.Join(root, "config", "database.yml")
 	if f, err := os.Open(dbYml); err == nil {
 		defer func() { _ = f.Close() }()
-		scanner := bufio.NewScanner(f)
-		for scanner.Scan() {
-			line := strings.TrimSpace(scanner.Text())
-			if strings.HasPrefix(line, "adapter:") {
-				val := strings.TrimSpace(strings.TrimPrefix(line, "adapter:"))
-				switch {
-				case strings.Contains(val, "sqlite"):
-					r.DBAdapter = "sqlite"
-				case strings.Contains(val, "postgresql"), strings.Contains(val, "postgis"):
-					r.DBAdapter = "postgresql"
-				case strings.Contains(val, "mysql"):
-					r.DBAdapter = "mysql"
-				}
-				return
-			}
+		adapter, database := parseRailsDatabaseConfig(f)
+		switch {
+		case strings.Contains(adapter, "sqlite"):
+			r.DBAdapter = "sqlite"
+		case strings.Contains(adapter, "postgresql"), strings.Contains(adapter, "postgis"):
+			r.DBAdapter = "postgresql"
+		case strings.Contains(adapter, "mysql"):
+			r.DBAdapter = "mysql"
 		}
+		if r.DBAdapter == "postgresql" && isDatabaseIdentifier(database) {
+			r.DBTemplate = database
+		}
+		return
 	}
 
 	if r.Framework == "phoenix" {
@@ -131,6 +204,93 @@ func (r *Result) detectDatabase(root string) {
 	if r.HasPrisma {
 		r.DBAdapter = "postgresql"
 	}
+}
+
+func parseRailsDatabaseConfig(f *os.File) (adapter, database string) {
+	scanner := bufio.NewScanner(f)
+	inDevelopment := false
+	devIndent := -1
+	for scanner.Scan() {
+		raw := scanner.Text()
+		trimmed := strings.TrimSpace(raw)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+
+		indent := leadingSpaces(raw)
+		if indent == 0 && strings.HasSuffix(trimmed, ":") {
+			key := strings.TrimSpace(strings.TrimSuffix(trimmed, ":"))
+			inDevelopment = key == "development"
+			if inDevelopment {
+				devIndent = indent
+			}
+			continue
+		}
+		if inDevelopment && indent <= devIndent {
+			inDevelopment = false
+		}
+
+		key, value, ok := parseYAMLScalar(trimmed)
+		if !ok {
+			continue
+		}
+		if key == "adapter" && adapter == "" {
+			adapter = value
+		}
+		if inDevelopment {
+			switch key {
+			case "adapter":
+				adapter = value
+			case "database":
+				database = value
+			}
+		}
+	}
+	return adapter, database
+}
+
+func leadingSpaces(s string) int {
+	n := 0
+	for _, r := range s {
+		if r != ' ' {
+			break
+		}
+		n++
+	}
+	return n
+}
+
+func parseYAMLScalar(line string) (string, string, bool) {
+	idx := strings.Index(line, ":")
+	if idx < 0 {
+		return "", "", false
+	}
+	key := strings.TrimSpace(line[:idx])
+	value := strings.TrimSpace(line[idx+1:])
+	value = strings.Trim(value, `"'`)
+	if key == "" || value == "" || strings.Contains(value, "<%") {
+		return "", "", false
+	}
+	return key, value, true
+}
+
+func isDatabaseIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if i == 0 {
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_' {
+				continue
+			}
+			return false
+		}
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func (r *Result) detectRedis(root string) {

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -79,6 +79,45 @@ func TestDetect_Rails_PostgreSQL(t *testing.T) {
 	}
 }
 
+func TestDetect_Rails_PostgreSQLTemplateDatabase(t *testing.T) {
+	dir := setup(t, "Gemfile", "config/application.rb", "config/database.yml")
+	_ = os.WriteFile(filepath.Join(dir, "config/database.yml"), []byte(`default: &default
+  adapter: postgresql
+
+development:
+  <<: *default
+  database: honolulu_v1_development
+
+test:
+  <<: *default
+  database: honolulu_v1_test
+`), 0o644)
+
+	r := Detect(dir)
+	if r.DBAdapter != "postgresql" {
+		t.Errorf("expected postgresql, got %s", r.DBAdapter)
+	}
+	if r.DBTemplate != "honolulu_v1_development" {
+		t.Errorf("expected DBTemplate honolulu_v1_development, got %q", r.DBTemplate)
+	}
+}
+
+func TestDetect_RailsProjectNameFromApplicationModule(t *testing.T) {
+	dir := setup(t, "Gemfile", "config/application.rb")
+	_ = os.WriteFile(filepath.Join(dir, "config/application.rb"), []byte(`require_relative "boot"
+
+module HonoluluV1
+  class Application < Rails::Application
+  end
+end
+`), 0o644)
+
+	r := Detect(dir)
+	if r.ProjectName != "honolulu_v1" {
+		t.Errorf("expected ProjectName honolulu_v1, got %q", r.ProjectName)
+	}
+}
+
 func TestDetect_Rails_SQLite(t *testing.T) {
 	dir := setup(t, "Gemfile", "config/application.rb", "config/database.yml")
 	_ = os.WriteFile(filepath.Join(dir, "config/database.yml"), []byte("development:\n  adapter: sqlite3\n"), 0o644)


### PR DESCRIPTION
## Summary
- derive auto-generated Treeline project names from Rails application modules instead of directory basenames
- detect Rails development database names for PostgreSQL templates
- sanitize fallback database template names so generated PostgreSQL identifiers are valid

## Tests
- make ci