### PR TITLE
Auto-refresh stale router on gtl install

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -27,6 +27,8 @@ func init() {
 var installSelect = confirm.Select
 var installServeRunner = runServeInstall
 var routerHealthChecker = routerInstallIssues
+var routerStaleChecker = staleRouterReason
+var routerRefresher = refreshRouter
 
 var installCmd = &cobra.Command{
 	Use:   "install",
@@ -112,7 +114,16 @@ func maybeOfferServeInstall(uc *config.UserConfig) error {
 				fmt.Fprintln(os.Stderr, style.Warnf("Could not persist router preference: %v", err))
 			}
 		}
-		if mode != config.RouterModeDisabled {
+		if mode == config.RouterModeDisabled {
+			return nil
+		}
+		if reason := routerStaleChecker(); reason != "" {
+			fmt.Println(style.Actionf("HTTPS router is stale (%s), refreshing...", reason))
+			if err := routerRefresher(); err != nil {
+				return fmt.Errorf("refreshing router: %w", err)
+			}
+			fmt.Println(style.Dimf("HTTPS router: refreshed"))
+		} else {
 			fmt.Println(style.Dimf("HTTPS router: already running"))
 		}
 		return nil
@@ -273,4 +284,44 @@ func routerInstallIssuesWith(caInstalled, serviceRunning bool) []string {
 
 func routerIsHealthy() bool {
 	return len(routerHealthChecker()) == 0
+}
+
+// staleRouterReason returns a human-readable reason if the running router
+// service is out of date with the current CLI binary. Returns "" when the
+// router is up to date or its state cannot be determined.
+//
+// Two cases are detected:
+//  1. The plist/unit references a binary path that no longer exists on
+//     disk (typical after `brew upgrade` if the embedded path was a
+//     versioned Cellar path from before StableExecutablePath landed).
+//  2. The router process is running an older version than this CLI —
+//     launchd/systemd does not re-exec on binary upgrade, so the
+//     long-lived process keeps running the previous build.
+func staleRouterReason() string {
+	if binPath := service.InstalledBinaryPath(); binPath != "" {
+		if _, err := os.Stat(binPath); err != nil {
+			return fmt.Sprintf("installed binary %s missing", binPath)
+		}
+	}
+	running := service.RunningRouterVersion()
+	if running != "" && running != Version {
+		return fmt.Sprintf("running %s but CLI is %s", running, Version)
+	}
+	return ""
+}
+
+// refreshRouter rewrites the service definition with the current stable
+// executable path and bounces the service so the new binary is execed.
+// No sudo required — only the launchd plist / systemd unit is touched,
+// not the CA trust or port-forwarding rules.
+func refreshRouter() error {
+	gtlPath, err := service.StableExecutablePath()
+	if err != nil {
+		return fmt.Errorf("could not resolve executable path: %w", err)
+	}
+	uc := config.LoadUserConfig("")
+	if _, err := service.Install(gtlPath, uc.RouterPort()); err != nil {
+		return fmt.Errorf("rewriting router service: %w", err)
+	}
+	return nil
 }

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -294,6 +294,104 @@ func TestMaybeOfferServeInstall_DeclineKeepsPromptMode(t *testing.T) {
 	}
 }
 
+func TestMaybeOfferServeInstall_HealthyAndStaleTriggersRefresh(t *testing.T) {
+	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	t.Setenv("GTL_HEADLESS", "")
+
+	uc := loadTestUserConfig(t)
+	uc.SetRouterMode(config.RouterModeEnabled)
+	if err := uc.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHealth := routerHealthChecker
+	oldStale := routerStaleChecker
+	oldRefresh := routerRefresher
+	routerHealthChecker = func() []string { return nil }
+	routerStaleChecker = func() string { return "running 0.39.0 but CLI is 0.39.1" }
+	refreshed := false
+	routerRefresher = func() error { refreshed = true; return nil }
+	t.Cleanup(func() {
+		routerHealthChecker = oldHealth
+		routerStaleChecker = oldStale
+		routerRefresher = oldRefresh
+	})
+
+	out := captureStdout(t, func() {
+		if err := maybeOfferServeInstall(uc); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !refreshed {
+		t.Fatal("expected router refresh to run, but it did not")
+	}
+	if !strings.Contains(out, "stale") {
+		t.Errorf("expected stale-router message in output, got:\n%s", out)
+	}
+	if strings.Contains(out, "already running") {
+		t.Errorf("did not expect 'already running' when stale, got:\n%s", out)
+	}
+}
+
+func TestMaybeOfferServeInstall_HealthyAndFreshSkipsRefresh(t *testing.T) {
+	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	t.Setenv("GTL_HEADLESS", "")
+
+	uc := loadTestUserConfig(t)
+	uc.SetRouterMode(config.RouterModeEnabled)
+	if err := uc.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHealth := routerHealthChecker
+	oldStale := routerStaleChecker
+	oldRefresh := routerRefresher
+	routerHealthChecker = func() []string { return nil }
+	routerStaleChecker = func() string { return "" }
+	routerRefresher = func() error { t.Fatal("unexpected refresh call"); return nil }
+	t.Cleanup(func() {
+		routerHealthChecker = oldHealth
+		routerStaleChecker = oldStale
+		routerRefresher = oldRefresh
+	})
+
+	out := captureStdout(t, func() {
+		if err := maybeOfferServeInstall(uc); err != nil {
+			t.Fatal(err)
+		}
+	})
+	if !strings.Contains(out, "already running") {
+		t.Errorf("expected 'already running' message, got:\n%s", out)
+	}
+}
+
+func TestMaybeOfferServeInstall_DisabledSkipsStaleCheck(t *testing.T) {
+	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	t.Setenv("GTL_HEADLESS", "")
+
+	uc := loadTestUserConfig(t)
+	uc.SetRouterMode(config.RouterModeDisabled)
+	if err := uc.Save(); err != nil {
+		t.Fatal(err)
+	}
+
+	oldHealth := routerHealthChecker
+	oldStale := routerStaleChecker
+	oldRefresh := routerRefresher
+	routerHealthChecker = func() []string { return nil }
+	routerStaleChecker = func() string { t.Fatal("stale check should be skipped when disabled"); return "" }
+	routerRefresher = func() error { t.Fatal("refresh should not run when disabled"); return nil }
+	t.Cleanup(func() {
+		routerHealthChecker = oldHealth
+		routerStaleChecker = oldStale
+		routerRefresher = oldRefresh
+	})
+
+	if err := maybeOfferServeInstall(uc); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestRouterInstallIssuesWith_PortForwardingIsOptional(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -319,6 +319,9 @@ func installSystemd(gtlPath string, _ int) (string, error) {
 	if err := exec.Command("systemctl", "--user", "enable", "--now", SystemdUnit()).Run(); err != nil {
 		return path, fmt.Errorf("wrote unit but failed to enable: %w", err)
 	}
+	if err := exec.Command("systemctl", "--user", "restart", SystemdUnit()).Run(); err != nil {
+		return path, fmt.Errorf("wrote unit but failed to restart: %w", err)
+	}
 	return path, nil
 }
 


### PR DESCRIPTION
## Summary

Fixes a bug where `gtl install` after `brew upgrade git-treeline` reports `HTTPS router: already running` while the launchd/systemd service is still executing the previous binary. The new check detects two stale states and refreshes the service in place — no sudo required.

## Why

`launchctl` (and `systemctl`) does not re-exec a running process when its binary changes. After `brew upgrade`, the router stays alive on the old version (sometimes mapped to a deleted Cellar path because Unix keeps deleted-but-open files alive). The current `maybeOfferServeInstall` health check only verifies CA trust and `launchctl list <label>` returns success, both of which remain true for a stale router, so the install command silently bails.

## What changed

- `cmd/install.go`
  - `staleRouterReason()` returns a reason when `service.InstalledBinaryPath()` is missing on disk, or when `service.RunningRouterVersion()` ≠ CLI `Version`.
  - `refreshRouter()` rewrites the plist/unit using `service.StableExecutablePath()` and bounces the service. No CA-trust or port-forwarding work is performed, so no sudo prompt.
  - `maybeOfferServeInstall` calls these on the healthy path before printing `already running`.
- `internal/service/service.go`
  - `installSystemd` now `systemctl --user restart`s after `enable --now` so a reinstall on Linux actually picks up new binary bytes (previously only `enable --now` ran, which is a no-op when the unit is already active).
- `cmd/install_test.go`
  - Three new tests: refresh fires when stale, doesn't fire when fresh, doesn't fire when router mode is disabled.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [x] Manually verified on a real machine: `launchctl unload && load` of the plist while running 0.39.0 brought up 0.39.1 with the same plist path; `router.version` updated to 0.39.1.
- [ ] After this lands in a release: run `brew upgrade git-treeline` then `gtl install` and confirm output prints `HTTPS router is stale (...), refreshing...` followed by `HTTPS router: refreshed`, and the `RouterVersionFile` matches the new CLI version.