### PR TITLE
Add review.skip_switch_confirm user config

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ Fetches the PR branch via `gh`, creates a worktree, allocates resources, runs se
 
 When run from inside a worktree, `review` prompts to switch the current worktree to the PR branch (same as `gtl switch`). `new` warns that the worktree will be created elsewhere and asks for confirmation; pass `--force` / `-f` to skip the prompt. From the main repo, both commands behave as before.
 
+To bypass the switch confirmation in `review` permanently, set `review.skip_switch_confirm: true` in user config (`gtl config set review.skip_switch_confirm true`).
+
 ### 8. Open a worktree in the browser
 
 ```bash

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -64,6 +64,9 @@ resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 		mainRepo := worktree.DetectMainRepo(absPath)
 
 		if isInWorktree(absPath, mainRepo) {
+			pc := config.LoadProjectConfig(absPath)
+			uc := config.LoadUserConfig("")
+
 			currentBranch := worktree.CurrentBranch(absPath)
 			branchLabel := currentBranch
 			if branchLabel == "" {
@@ -71,7 +74,7 @@ resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 			}
 			fmt.Println()
 			fmt.Printf("You're in worktree '%s' (branch: %s).\n", filepath.Base(absPath), branchLabel)
-			if !confirm.Prompt(fmt.Sprintf("Switch to PR #%d (branch: %s)?", prNumber, branch), false, nil) {
+			if !confirm.Prompt(fmt.Sprintf("Switch to PR #%d (branch: %s)?", prNumber, branch), uc.ReviewSkipSwitchConfirm(), nil) {
 				return nil
 			}
 			fmt.Println()
@@ -79,8 +82,6 @@ resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 				return cliErr(cmd, err)
 			}
 
-			pc := config.LoadProjectConfig(absPath)
-			uc := config.LoadUserConfig("")
 			projectName := pc.Project()
 			reg := registry.New("")
 			alloc := reg.Find(absPath)

--- a/internal/config/user.go
+++ b/internal/config/user.go
@@ -186,6 +186,16 @@ func (uc *UserConfig) RouterWarningsEnabled() bool {
 	return true
 }
 
+// ReviewSkipSwitchConfirm returns whether `gtl review` should bypass the
+// "Switch to PR #N (branch: ...)?" prompt when invoked from inside another
+// worktree. Default: false. Set review.skip_switch_confirm: true to bypass.
+func (uc *UserConfig) ReviewSkipSwitchConfirm() bool {
+	if v, ok := Dig(uc.Data, "review", "skip_switch_confirm").(bool); ok {
+		return v
+	}
+	return false
+}
+
 // RouterAliases returns static alias routes from the user config (e.g.
 // {"grafana": 3100}). These are per-machine routes for personal services.
 func (uc *UserConfig) RouterAliases() map[string]int {
@@ -407,7 +417,7 @@ func (uc *UserConfig) Init() error {
 
 var userKnownKeys = map[string]bool{
 	"port": true, "redis": true, "router": true, "tunnel": true,
-	"worktree": true, "editor": true, "warnings": true,
+	"worktree": true, "editor": true, "warnings": true, "review": true,
 }
 
 func (uc *UserConfig) load() map[string]any {

--- a/internal/config/user_test.go
+++ b/internal/config/user_test.go
@@ -658,6 +658,23 @@ func TestUserConfig_RouterWarningsEnabled_Disabled(t *testing.T) {
 	}
 }
 
+func TestUserConfig_ReviewSkipSwitchConfirm_Default(t *testing.T) {
+	uc := LoadUserConfig(filepath.Join(t.TempDir(), "config.json"))
+	if uc.ReviewSkipSwitchConfirm() {
+		t.Error("expected default false (prompt shown)")
+	}
+}
+
+func TestUserConfig_ReviewSkipSwitchConfirm_Enabled(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	_ = os.WriteFile(path, []byte(`{"review":{"skip_switch_confirm":true}}`), 0o644)
+	uc := LoadUserConfig(path)
+	if !uc.ReviewSkipSwitchConfirm() {
+		t.Error("expected true when review.skip_switch_confirm is set")
+	}
+}
+
 func TestUserConfig_WorktreePathTemplate_Default(t *testing.T) {
 	uc := LoadUserConfig("/nonexistent/config.json")
 	if uc.WorktreePathTemplate() != "" {


### PR DESCRIPTION
## Summary

When \`gtl review <PR>\` is invoked from inside another worktree, it prompts to confirm switching the current worktree to the PR branch. This adds a user-config bypass for users who always want to switch.

- New \`review.skip_switch_confirm\` boolean (default \`false\`) in user config
- When \`true\`, \`gtl review <PR>\` skips the "Switch to PR #N (branch: …)?" prompt and switches directly
- Set with \`gtl config set review.skip_switch_confirm true\`

## Test plan

- [x] \`go test ./...\` passes
- [x] New unit tests cover default-false and enabled-true cases
- [ ] Manually verify: with \`review.skip_switch_confirm: true\`, \`gtl review <PR>\` from a worktree skips the prompt
- [ ] Manually verify: default behavior (prompt shown) is unchanged