### PR TITLE
Doctor & serve overhaul: real diagnostics, real bounce, registry safety net

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [0.40.0]
+
+- **Doctor & serve overhaul** — fixes a stack of issues exposed when a hard reboot dropped pf rules and a `brew upgrade` left the router running an older build. Most-impactful changes:
+
+  - **`gtl serve restart`** — fast bounce of the router service via `launchctl kickstart -k` (or `systemctl --user restart` on Linux). No sudo, no plist rewrite, no pf reload. Replaces the silent `launchctl unload`/`load` pair that previously no-op'd on modern macOS, which is the cause of "I ran `gtl serve install` and nothing changed" reports.
+  - **`gtl serve reload-pf`** — targeted `pfctl` reload for when only the port-forwarding rules dropped (after a reboot), without paying the cost of a full `gtl serve install`.
+  - **`gtl doctor` actually verifies things.** Now compares the listener PID to `launchctl print`'s registered PID instead of substring-matching the process name (the legitimate `git-treeline` router was getting flagged as "rogue" because that string doesn't contain `gtl`). Adds a real HTTP liveness probe to `/_treeline/health` so a deadlocked router isn't reported as healthy. Reads pf state from the kernel (`pfctl -s nat`) instead of trusting `pf.conf` on disk — fixes `Port forwarding: active` lying when rules weren't loaded.
+  - **Doctor: Request flow** — new section that walks the chain a worktree URL takes (app port → router → router_responding → pf → CA) and surfaces the FIRST failure as the actionable diagnosis. The other sections stay for detail; you no longer have to guess which one is the cause.
+  - **Doctor: app-not-listening surfaces `commands.start`** as the fix instead of just printing "not listening".
+  - **`gtl doctor --fix`** auto-runs the remediations the doctor was already printing as `fix:` hints (router restart, pf reload, registry prune for orphaned entries).
+  - **`gtl reallocate`** — bulk re-runs setup. Modes: explicit paths, `--from <dir>` (scans Conductor-style layouts), `--all-registry` (every entry whose dir still exists). Defaults to dry-run.
+  - **`gtl registry validate` / `repair` / `forget`** — read-only audit of the registry, safe automatic repair (pruning orphans, with a backup), and a single-entry removal for tooling integrations.
+  - **`gtl prune --stale` no longer deletes Conductor workspaces.** The previous implementation cross-referenced `git worktree list` of the CWD as the only ground truth — Conductor uses standalone clones, not worktrees of a parent repo, so they all looked stale and got nuked. Now `--stale` distinguishes worktrees (`.git` is a file) from clones (`.git` is a directory) and only applies the worktree-list check to actual worktrees. When the worktree query fails, defaults to keep — never prune on a transient git error.
+  - **Stale-router warning on every `gtl <cmd>`** — when the running router's version disagrees with the CLI binary, every command prints a single yellow line pointing at `gtl serve restart`. Suppressed for self-repairing commands (`install`, `serve …`) and via `GTL_NO_STALE_WARN=1`.
+
 ## [0.39.4]
 
 - **`review.skip_switch_confirm` user config** — when `gtl review <PR>` is invoked from inside another worktree it prompts to confirm switching the current worktree to the PR branch. Setting `review.skip_switch_confirm: true` (e.g. `gtl config set review.skip_switch_confirm true`) bypasses the prompt for users who always want to switch. Default remains `false`, so the existing interactive flow is unchanged.

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -48,9 +48,10 @@ var doctorCmd = &cobra.Command{
 		doctorProjectDrift(absPath)
 		doctorPortConfig()
 		doctorAllocation(absPath)
-		doctorRuntime(absPath)
+		doctorRuntime(absPath, pc)
 		doctorServe()
 		doctorDiagnostics(det)
+		doctorRequestFlow(absPath, pc)
 
 		return nil
 	},
@@ -271,7 +272,7 @@ func doctorAllocation(absPath string) {
 	}
 }
 
-func doctorRuntime(absPath string) {
+func doctorRuntime(absPath string, pc *config.ProjectConfig) {
 	fmt.Println("\nRuntime")
 
 	reg := registry.New("")
@@ -284,6 +285,9 @@ func doctorRuntime(absPath string) {
 				doctorLine(fmt.Sprintf("Port %d", ports[0]), "listening")
 			} else {
 				doctorLine(fmt.Sprintf("Port %d", ports[0]), "not listening")
+				if sc := pc.StartCommand(); sc != "" {
+					fmt.Printf("  fix: %s\n", sc)
+				}
 			}
 		}
 	}
@@ -297,6 +301,125 @@ func doctorRuntime(absPath string) {
 	}
 }
 
+// doctorRequestFlow walks the request chain a worktree URL takes (app port
+// → router → router has the route → port forwarding → CA) and surfaces the
+// FIRST failing link as the actionable diagnosis. Everything else is noise
+// when the first link is broken.
+func doctorRequestFlow(absPath string, pc *config.ProjectConfig) {
+	fmt.Println("\nRequest flow")
+
+	step := firstFailingStep(absPath, pc)
+	if step == nil {
+		doctorLine("Status", "✓ all links healthy")
+		return
+	}
+	doctorLine("Blocked at", "✗ "+step.label)
+	if step.detail != "" {
+		fmt.Printf("    %s\n", step.detail)
+	}
+	if step.fix != "" {
+		fmt.Printf("    fix: %s\n", step.fix)
+	}
+}
+
+type flowStep struct {
+	label  string
+	detail string
+	fix    string
+}
+
+// flowInput is the snapshot of state evaluateRequestFlow examines. Extracted
+// so the orchestration logic can be tested without standing up a real
+// router / launchd / pf / CA.
+type flowInput struct {
+	allocatedPorts  []int
+	appListening    bool
+	startCommand    string
+	serviceChecks   []service.HealthCheck
+	caInstalled     bool
+}
+
+func firstFailingStep(absPath string, pc *config.ProjectConfig) *flowStep {
+	uc := config.LoadUserConfig("")
+	reg := registry.New("")
+	alloc := reg.Find(absPath)
+
+	in := flowInput{
+		startCommand:  pc.StartCommand(),
+		serviceChecks: service.CheckHealth(uc.RouterPort(), Version),
+		caInstalled:   proxy.IsCAInstalled(),
+	}
+	if alloc != nil {
+		in.allocatedPorts = format.GetPorts(format.Allocation(alloc))
+		if len(in.allocatedPorts) > 0 {
+			in.appListening = allocator.CheckPortsListening(in.allocatedPorts)
+		}
+	}
+	return evaluateRequestFlow(in)
+}
+
+func evaluateRequestFlow(in flowInput) *flowStep {
+	// 1. App listening on its allocated port?
+	if len(in.allocatedPorts) > 0 && !in.appListening {
+		fix := "start the dev server"
+		if in.startCommand != "" {
+			fix = in.startCommand
+		}
+		return &flowStep{
+			label:  fmt.Sprintf("app on :%d", in.allocatedPorts[0]),
+			detail: "the dev server is not listening — the router has nowhere to forward to",
+			fix:    fix,
+		}
+	}
+
+	// 2. Router service registered + listening + responding.
+	for _, c := range in.serviceChecks {
+		if c.Name == "port_forwarding" {
+			continue // handled below
+		}
+		if c.Status == "error" || (c.Status == "warn" && c.Name == "router_responding") {
+			return &flowStep{
+				label:  c.Name,
+				detail: c.Detail,
+				fix:    c.Fix,
+			}
+		}
+	}
+	// router_version mismatch isn't a hard block but is the most likely
+	// surprise after a brew upgrade — call it out specifically.
+	for _, c := range in.serviceChecks {
+		if c.Name == "router_version" && c.Status == "warn" {
+			return &flowStep{
+				label:  "router_version",
+				detail: c.Detail,
+				fix:    "gtl serve restart",
+			}
+		}
+	}
+
+	// 3. Port forwarding loaded in kernel.
+	for _, c := range in.serviceChecks {
+		if c.Name == "port_forwarding" && c.Status != "ok" {
+			return &flowStep{
+				label:  "port_forwarding",
+				detail: c.Detail,
+				fix:    c.Fix,
+			}
+		}
+	}
+
+	// 4. CA cert installed and not expired (browser will warn otherwise,
+	// but the request still reaches the router — soft warning only).
+	if !in.caInstalled {
+		return &flowStep{
+			label:  "ca_cert",
+			detail: "CA not installed — browsers will reject HTTPS",
+			fix:    "gtl serve install",
+		}
+	}
+	return nil
+}
+
 func doctorServe() {
 	uc := config.LoadUserConfig("")
 	port := uc.RouterPort()
@@ -304,10 +427,12 @@ func doctorServe() {
 	fmt.Println("\nServe")
 
 	displayNames := map[string]string{
-		"service":         "Service",
-		"binary":          "Binary",
-		"router_port":     "Router port",
-		"port_forwarding": "Port forwarding",
+		"service":           "Service",
+		"binary":            "Binary",
+		"router_version":    "Router version",
+		"router_port":       "Router port",
+		"router_responding": "Router responding",
+		"port_forwarding":   "Port forwarding",
 	}
 
 	checks := service.CheckHealth(port, Version)

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -20,10 +20,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var doctorJSON bool
+var (
+	doctorJSON bool
+	doctorFix  bool
+)
 
 func init() {
 	doctorCmd.Flags().BoolVar(&doctorJSON, "json", false, "Output as JSON")
+	doctorCmd.Flags().BoolVar(&doctorFix, "fix", false, "Run auto-remediation for detected issues (router restart, pf reload, registry prune)")
 	rootCmd.AddCommand(doctorCmd)
 }
 
@@ -52,7 +56,9 @@ var doctorCmd = &cobra.Command{
 		doctorServe()
 		doctorDiagnostics(det)
 		doctorRequestFlow(absPath, pc)
-
+		if doctorFix {
+			return doctorAutoFix(absPath, pc)
+		}
 		return nil
 	},
 }
@@ -492,6 +498,111 @@ func doctorDiagnostics(det *detect.Result) {
 			}
 		}
 	}
+}
+
+// fixAction names a remediation that doctor --fix can apply automatically.
+type fixAction string
+
+const (
+	fixServeRestart fixAction = "gtl serve restart"
+	fixReloadPF     fixAction = "gtl serve reload-pf"
+	fixPrune        fixAction = "gtl prune"
+)
+
+// planAutoFix maps the doctor's findings to a deduplicated, ordered list of
+// actions to run. Pure function for testability — the caller actually
+// executes the actions.
+func planAutoFix(in flowInput, registryHasOrphans bool) []fixAction {
+	seen := map[fixAction]bool{}
+	var plan []fixAction
+	add := func(a fixAction) {
+		if !seen[a] {
+			seen[a] = true
+			plan = append(plan, a)
+		}
+	}
+
+	// First failing link in the request flow drives most fixes.
+	step := evaluateRequestFlow(in)
+	if step != nil {
+		switch step.fix {
+		case "gtl serve restart":
+			add(fixServeRestart)
+		case "gtl serve reload-pf":
+			add(fixReloadPF)
+		}
+	}
+	// Independent of the flow chain: a stale router-version warning, even if
+	// the router is responding, deserves a restart.
+	for _, c := range in.serviceChecks {
+		if c.Name == "router_version" && c.Status == "warn" {
+			add(fixServeRestart)
+		}
+	}
+	// Registry orphans (entries whose worktree directory is gone) are safe
+	// to prune.
+	if registryHasOrphans {
+		add(fixPrune)
+	}
+	return plan
+}
+
+func doctorAutoFix(absPath string, pc *config.ProjectConfig) error {
+	in := buildFlowInput(absPath, pc)
+	plan := planAutoFix(in, shouldUseRegistryRepair())
+
+	fmt.Println("\nAuto-fix")
+	if len(plan) == 0 {
+		doctorLine("Status", "nothing to fix automatically")
+		return nil
+	}
+
+	for _, a := range plan {
+		fmt.Printf("  → %s\n", a)
+		if err := runAutoFix(a); err != nil {
+			fmt.Fprintf(os.Stderr, "  ✗ %v\n", err)
+			return err
+		}
+		fmt.Println("    done.")
+	}
+	return nil
+}
+
+func buildFlowInput(absPath string, pc *config.ProjectConfig) flowInput {
+	uc := config.LoadUserConfig("")
+	reg := registry.New("")
+	alloc := reg.Find(absPath)
+	in := flowInput{
+		startCommand:  pc.StartCommand(),
+		serviceChecks: service.CheckHealth(uc.RouterPort(), Version),
+		caInstalled:   proxy.IsCAInstalled(),
+	}
+	if alloc != nil {
+		in.allocatedPorts = format.GetPorts(format.Allocation(alloc))
+		if len(in.allocatedPorts) > 0 {
+			in.appListening = allocator.CheckPortsListening(in.allocatedPorts)
+		}
+	}
+	return in
+}
+
+// runAutoFixFn is the indirection point for tests — replaces the real
+// remediation actions with no-ops.
+var runAutoFixFn = runAutoFixDefault
+
+func runAutoFix(a fixAction) error { return runAutoFixFn(a) }
+
+func runAutoFixDefault(a fixAction) error {
+	switch a {
+	case fixServeRestart:
+		return service.Bounce(service.DefaultBounceTimeout)
+	case fixReloadPF:
+		return service.ReloadPortForward()
+	case fixPrune:
+		_, err := registry.New("").Prune()
+		return err
+	}
+	return fmt.Errorf("unknown fix action: %s", a)
 }
 
 func doctorLine(label, value string) {

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -203,3 +203,109 @@ func TestEvaluateRequestFlow_CANotInstalled(t *testing.T) {
 		t.Errorf("expected ca_cert step, got %+v", step)
 	}
 }
+
+// --- planAutoFix ---
+
+func TestPlanAutoFix_NothingToDoOnHealthy(t *testing.T) {
+	plan := planAutoFix(flowInput{
+		allocatedPorts: []int{3022},
+		appListening:   true,
+		serviceChecks:  healthyChecks(),
+		caInstalled:    true,
+	}, false)
+	if len(plan) != 0 {
+		t.Errorf("expected empty plan, got %+v", plan)
+	}
+}
+
+func TestPlanAutoFix_StaleRouterPlansRestart(t *testing.T) {
+	checks := healthyChecks()
+	for i := range checks {
+		if checks[i].Name == "router_version" {
+			checks[i].Status = "warn"
+			checks[i].Detail = "router=0.39.2, cli=0.39.4"
+		}
+	}
+	plan := planAutoFix(flowInput{
+		allocatedPorts: []int{3022},
+		appListening:   true,
+		serviceChecks:  checks,
+		caInstalled:    true,
+	}, false)
+	if len(plan) != 1 || plan[0] != fixServeRestart {
+		t.Errorf("expected [fixServeRestart], got %+v", plan)
+	}
+}
+
+func TestPlanAutoFix_PFErrorPlansReload(t *testing.T) {
+	checks := healthyChecks()
+	for i := range checks {
+		if checks[i].Name == "port_forwarding" {
+			checks[i].Status = "error"
+			checks[i].Fix = "gtl serve reload-pf"
+		}
+	}
+	plan := planAutoFix(flowInput{
+		allocatedPorts: []int{3022},
+		appListening:   true,
+		serviceChecks:  checks,
+		caInstalled:    true,
+	}, false)
+	found := false
+	for _, a := range plan {
+		if a == fixReloadPF {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected fixReloadPF in plan, got %+v", plan)
+	}
+}
+
+func TestPlanAutoFix_RegistryOrphansPlanPrune(t *testing.T) {
+	plan := planAutoFix(flowInput{
+		allocatedPorts: []int{3022},
+		appListening:   true,
+		serviceChecks:  healthyChecks(),
+		caInstalled:    true,
+	}, true)
+	found := false
+	for _, a := range plan {
+		if a == fixPrune {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected fixPrune in plan, got %+v", plan)
+	}
+}
+
+func TestPlanAutoFix_DedupesMultipleSignals(t *testing.T) {
+	// Both router_version warn AND router_responding warn should
+	// produce a SINGLE serve restart action, not two.
+	checks := healthyChecks()
+	for i := range checks {
+		if checks[i].Name == "router_version" {
+			checks[i].Status = "warn"
+		}
+		if checks[i].Name == "router_responding" {
+			checks[i].Status = "warn"
+			checks[i].Fix = "gtl serve restart"
+		}
+	}
+	plan := planAutoFix(flowInput{
+		allocatedPorts: []int{3022},
+		appListening:   true,
+		serviceChecks:  checks,
+		caInstalled:    true,
+	}, false)
+	count := 0
+	for _, a := range plan {
+		if a == fixServeRestart {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected serve restart once, got %d in %+v", count, plan)
+	}
+}

--- a/cmd/doctor_test.go
+++ b/cmd/doctor_test.go
@@ -1,6 +1,11 @@
 package cmd
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/git-treeline/cli/internal/service"
+)
 
 func TestClassifyPortConfig_Conflict(t *testing.T) {
 	got := classifyPortConfig(8443, 8443)
@@ -28,5 +33,173 @@ func TestClassifyPortConfig_ConflictWhenBaseEqualsRouter(t *testing.T) {
 	got := classifyPortConfig(3000, 3000)
 	if got != "conflict" {
 		t.Errorf("classifyPortConfig(3000, 3000) = %q, want %q", got, "conflict")
+	}
+}
+
+// healthyChecks returns a healthcheck slice where every link is "ok".
+func healthyChecks() []service.HealthCheck {
+	return []service.HealthCheck{
+		{Name: "service", Status: "ok"},
+		{Name: "binary", Status: "ok"},
+		{Name: "router_version", Status: "ok"},
+		{Name: "router_port", Status: "ok"},
+		{Name: "router_responding", Status: "ok"},
+		{Name: "port_forwarding", Status: "ok"},
+	}
+}
+
+func TestEvaluateRequestFlow_AllHealthy(t *testing.T) {
+	step := evaluateRequestFlow(flowInput{
+		allocatedPorts: []int{3022},
+		appListening:   true,
+		serviceChecks:  healthyChecks(),
+		caInstalled:    true,
+	})
+	if step != nil {
+		t.Errorf("expected no failing step, got %+v", step)
+	}
+}
+
+func TestEvaluateRequestFlow_AppNotListening_UsesStartCommand(t *testing.T) {
+	step := evaluateRequestFlow(flowInput{
+		allocatedPorts: []int{3022},
+		appListening:   false,
+		startCommand:   "bin/dev",
+		serviceChecks:  healthyChecks(),
+		caInstalled:    true,
+	})
+	if step == nil {
+		t.Fatal("expected a failing step")
+	}
+	if !strings.Contains(step.label, "3022") {
+		t.Errorf("expected label to include port, got %q", step.label)
+	}
+	if step.fix != "bin/dev" {
+		t.Errorf("expected fix=bin/dev, got %q", step.fix)
+	}
+}
+
+func TestEvaluateRequestFlow_AppNotListening_NoStartCommand(t *testing.T) {
+	step := evaluateRequestFlow(flowInput{
+		allocatedPorts: []int{3022},
+		appListening:   false,
+		serviceChecks:  healthyChecks(),
+		caInstalled:    true,
+	})
+	if step == nil {
+		t.Fatal("expected a failing step")
+	}
+	if step.fix != "start the dev server" {
+		t.Errorf("expected generic fix, got %q", step.fix)
+	}
+}
+
+// App-not-listening must take precedence over a stale router — the user
+// won't see anything regardless of router state if their backend is dead.
+func TestEvaluateRequestFlow_AppLossBeatsRouterStale(t *testing.T) {
+	checks := healthyChecks()
+	for i := range checks {
+		if checks[i].Name == "router_version" {
+			checks[i].Status = "warn"
+			checks[i].Detail = "router=0.39.2, cli=0.39.4"
+		}
+	}
+	step := evaluateRequestFlow(flowInput{
+		allocatedPorts: []int{3022},
+		appListening:   false,
+		startCommand:   "bin/dev",
+		serviceChecks:  checks,
+		caInstalled:    true,
+	})
+	if step == nil || !strings.Contains(step.label, "3022") {
+		t.Errorf("expected app step first, got %+v", step)
+	}
+}
+
+func TestEvaluateRequestFlow_RouterErrorBeatsPFAndCA(t *testing.T) {
+	checks := healthyChecks()
+	for i := range checks {
+		if checks[i].Name == "router_port" {
+			checks[i].Status = "error"
+			checks[i].Detail = "port not listening"
+			checks[i].Fix = "gtl serve restart"
+		}
+		if checks[i].Name == "port_forwarding" {
+			checks[i].Status = "error"
+			checks[i].Detail = "rule not loaded"
+			checks[i].Fix = "gtl serve reload-pf"
+		}
+	}
+	step := evaluateRequestFlow(flowInput{
+		allocatedPorts: []int{3022},
+		appListening:   true,
+		serviceChecks:  checks,
+		caInstalled:    false,
+	})
+	if step == nil || step.label != "router_port" {
+		t.Errorf("expected router_port first, got %+v", step)
+	}
+}
+
+func TestEvaluateRequestFlow_PFFailureSurfaced(t *testing.T) {
+	checks := healthyChecks()
+	for i := range checks {
+		if checks[i].Name == "port_forwarding" {
+			checks[i].Status = "error"
+			checks[i].Detail = "rule not loaded in kernel"
+			checks[i].Fix = "gtl serve reload-pf"
+		}
+	}
+	step := evaluateRequestFlow(flowInput{
+		allocatedPorts: []int{3022},
+		appListening:   true,
+		serviceChecks:  checks,
+		caInstalled:    true,
+	})
+	if step == nil {
+		t.Fatal("expected pf step")
+	}
+	if step.label != "port_forwarding" {
+		t.Errorf("expected port_forwarding label, got %q", step.label)
+	}
+	if step.fix != "gtl serve reload-pf" {
+		t.Errorf("expected reload-pf fix, got %q", step.fix)
+	}
+}
+
+func TestEvaluateRequestFlow_RouterStaleSurfaced(t *testing.T) {
+	checks := healthyChecks()
+	for i := range checks {
+		if checks[i].Name == "router_version" {
+			checks[i].Status = "warn"
+			checks[i].Detail = "router=0.39.2, cli=0.39.4"
+		}
+	}
+	step := evaluateRequestFlow(flowInput{
+		allocatedPorts: []int{3022},
+		appListening:   true,
+		serviceChecks:  checks,
+		caInstalled:    true,
+	})
+	if step == nil {
+		t.Fatal("expected stale-router step")
+	}
+	if step.label != "router_version" {
+		t.Errorf("expected router_version label, got %q", step.label)
+	}
+	if step.fix != "gtl serve restart" {
+		t.Errorf("expected serve restart fix, got %q", step.fix)
+	}
+}
+
+func TestEvaluateRequestFlow_CANotInstalled(t *testing.T) {
+	step := evaluateRequestFlow(flowInput{
+		allocatedPorts: []int{3022},
+		appListening:   true,
+		serviceChecks:  healthyChecks(),
+		caInstalled:    false,
+	})
+	if step == nil || step.label != "ca_cert" {
+		t.Errorf("expected ca_cert step, got %+v", step)
 	}
 }

--- a/cmd/reallocate.go
+++ b/cmd/reallocate.go
@@ -1,0 +1,201 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/git-treeline/cli/internal/config"
+	"github.com/git-treeline/cli/internal/registry"
+	"github.com/git-treeline/cli/internal/setup"
+	"github.com/spf13/cobra"
+)
+
+var (
+	reallocateFrom    string
+	reallocateApply   bool
+	reallocateAllReg  bool
+)
+
+func init() {
+	reallocateCmd.Flags().StringVar(&reallocateFrom, "from", "", "Scan this directory for treeline projects (recursive, depth 3)")
+	reallocateCmd.Flags().BoolVar(&reallocateApply, "apply", false, "Actually run setup on each candidate (default: dry-run)")
+	reallocateCmd.Flags().BoolVar(&reallocateAllReg, "all-registry", false, "Re-run setup for every entry currently in the registry whose directory still exists")
+	rootCmd.AddCommand(reallocateCmd)
+}
+
+var reallocateCmd = &cobra.Command{
+	Use:   "reallocate [path...]",
+	Short: "Re-allocate ports/databases for one or many worktrees",
+	Long: `Re-runs the allocation pipeline (port + database + Redis assignment, env
+file write) for one or many directories. Use this to recover from registry
+loss or corruption — for example after 'gtl prune --stale' incorrectly
+removed standalone Conductor clones, or after manually editing
+registry.json went sideways.
+
+Modes:
+  gtl reallocate                        # the current directory only
+  gtl reallocate <path1> <path2> ...    # explicit paths
+  gtl reallocate --from ~/conductor/workspaces  # scan a parent
+  gtl reallocate --all-registry         # every existing registry entry
+
+By default this is dry-run — pass --apply to actually run setup. Each
+target must be an existing directory containing a .treeline.yml.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		paths, err := collectReallocateTargets(args, reallocateFrom, reallocateAllReg)
+		if err != nil {
+			return err
+		}
+		if len(paths) == 0 {
+			fmt.Println("No targets found.")
+			return nil
+		}
+
+		fmt.Printf("Found %d candidate worktree(s):\n", len(paths))
+		for _, p := range paths {
+			fmt.Printf("  %s\n", p)
+		}
+
+		if !reallocateApply {
+			fmt.Println()
+			fmt.Println("Dry run — pass --apply to run setup on each.")
+			return nil
+		}
+
+		uc := config.LoadUserConfig("")
+		successes := 0
+		var failures []string
+		for _, p := range paths {
+			fmt.Printf("\n→ %s\n", p)
+			s := setup.New(p, "", uc)
+			if _, err := s.Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "  ✗ %v\n", err)
+				failures = append(failures, p)
+				continue
+			}
+			successes++
+		}
+
+		fmt.Println()
+		fmt.Printf("Reallocated: %d. Failed: %d.\n", successes, len(failures))
+		if len(failures) > 0 {
+			for _, p := range failures {
+				fmt.Printf("  ✗ %s\n", p)
+			}
+			return fmt.Errorf("%d reallocation(s) failed", len(failures))
+		}
+		return nil
+	},
+}
+
+// collectReallocateTargets resolves the input arguments to a deduplicated,
+// sorted list of absolute paths. Each path must already exist and contain a
+// .treeline.yml (otherwise it can't be reallocated meaningfully).
+func collectReallocateTargets(args []string, from string, allRegistry bool) ([]string, error) {
+	seen := map[string]bool{}
+	var out []string
+
+	add := func(p string) {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return
+		}
+		if seen[abs] {
+			return
+		}
+		if !hasProjectConfig(abs) {
+			return
+		}
+		seen[abs] = true
+		out = append(out, abs)
+	}
+
+	if allRegistry {
+		reg := registry.New("")
+		for _, a := range reg.Allocations() {
+			wt := registry.GetString(a, "worktree")
+			if wt == "" {
+				continue
+			}
+			if info, err := os.Stat(wt); err == nil && info.IsDir() {
+				add(wt)
+			}
+		}
+	}
+
+	if from != "" {
+		matches, err := scanForTreelineProjects(from)
+		if err != nil {
+			return nil, err
+		}
+		for _, m := range matches {
+			add(m)
+		}
+	}
+
+	if len(args) == 0 && from == "" && !allRegistry {
+		// Default to current directory.
+		cwd, err := os.Getwd()
+		if err != nil {
+			return nil, err
+		}
+		add(cwd)
+	}
+	for _, a := range args {
+		add(a)
+	}
+
+	sort.Strings(out)
+	return out, nil
+}
+
+// scanForTreelineProjects walks <root> up to 3 levels deep looking for
+// directories that contain a .treeline.yml. Conductor's standard layout
+// (~/conductor/workspaces/<project>/<workspace>) lives at depth 2.
+func scanForTreelineProjects(root string) ([]string, error) {
+	root, err := filepath.Abs(root)
+	if err != nil {
+		return nil, err
+	}
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("scan root %s: %w", root, err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", root)
+	}
+
+	const maxDepth = 3
+	var found []string
+	var walk func(dir string, depth int)
+	walk = func(dir string, depth int) {
+		if hasProjectConfig(dir) {
+			found = append(found, dir)
+			return // don't descend into a treeline project
+		}
+		if depth >= maxDepth {
+			return
+		}
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			if e.Name() == ".git" || e.Name() == "node_modules" || e.Name()[0] == '.' {
+				continue
+			}
+			walk(filepath.Join(dir, e.Name()), depth+1)
+		}
+	}
+	walk(root, 0)
+	return found, nil
+}
+
+func hasProjectConfig(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, config.ProjectConfigFile))
+	return err == nil
+}

--- a/cmd/reallocate_test.go
+++ b/cmd/reallocate_test.go
@@ -1,0 +1,103 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+)
+
+func writeProjectConfig(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScanForTreelineProjects_FindsConductorLayout(t *testing.T) {
+	root := t.TempDir()
+	// Conductor layout: <root>/<project>/<workspace>/.treeline.yml
+	writeProjectConfig(t, filepath.Join(root, "salt", "honolulu-v1"))
+	writeProjectConfig(t, filepath.Join(root, "salt", "admin-stats"))
+	writeProjectConfig(t, filepath.Join(root, "wildlife", "marketplace"))
+
+	got, err := scanForTreelineProjects(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sort.Strings(got)
+	want := []string{
+		filepath.Join(root, "salt", "admin-stats"),
+		filepath.Join(root, "salt", "honolulu-v1"),
+		filepath.Join(root, "wildlife", "marketplace"),
+	}
+	sort.Strings(want)
+
+	if len(got) != len(want) {
+		t.Fatalf("scan found %d projects, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("[%d] got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestScanForTreelineProjects_DoesNotDescendIntoTreelineProject(t *testing.T) {
+	// If a project at depth 1 has its own .treeline.yml, we should NOT descend
+	// into its subdirectories looking for nested ones.
+	root := t.TempDir()
+	writeProjectConfig(t, filepath.Join(root, "main-project"))
+	// Add a nested .treeline.yml that should be ignored.
+	writeProjectConfig(t, filepath.Join(root, "main-project", "subdir", "nested"))
+
+	got, err := scanForTreelineProjects(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Errorf("expected 1 project (no descent), got %d: %+v", len(got), got)
+	}
+}
+
+func TestScanForTreelineProjects_RespectsMaxDepth(t *testing.T) {
+	root := t.TempDir()
+	// Depth 4 — should NOT be found (maxDepth = 3)
+	writeProjectConfig(t, filepath.Join(root, "a", "b", "c", "deep"))
+	got, err := scanForTreelineProjects(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected nothing past max depth, got: %+v", got)
+	}
+}
+
+func TestCollectReallocateTargets_DedupesAndFiltersToProjectsOnly(t *testing.T) {
+	root := t.TempDir()
+	withCfg := filepath.Join(root, "with-cfg")
+	withoutCfg := filepath.Join(root, "without-cfg")
+	writeProjectConfig(t, withCfg)
+	if err := os.MkdirAll(withoutCfg, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pass the same project twice + one without a config.
+	got, err := collectReallocateTargets(
+		[]string{withCfg, withCfg, withoutCfg},
+		"",
+		false,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 target (deduped, filtered), got %d: %+v", len(got), got)
+	}
+	if got[0] != withCfg {
+		t.Errorf("expected %q, got %q", withCfg, got[0])
+	}
+}

--- a/cmd/registry_cmd.go
+++ b/cmd/registry_cmd.go
@@ -1,0 +1,195 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/git-treeline/cli/internal/confirm"
+	"github.com/git-treeline/cli/internal/registry"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	registryCmd.AddCommand(registryValidateCmd)
+	registryRepairCmd.Flags().BoolVar(&registryRepairForce, "force", false, "Skip confirmation prompts")
+	registryCmd.AddCommand(registryRepairCmd)
+	registryCmd.AddCommand(registryForgetCmd)
+	rootCmd.AddCommand(registryCmd)
+}
+
+var registryRepairForce bool
+
+var registryCmd = &cobra.Command{
+	Use:   "registry",
+	Short: "Inspect and repair the allocation registry",
+	Long: `Tools for working directly with the allocation registry — the JSON file
+that maps worktrees to ports, databases, and Redis assignments.
+
+Subcommands:
+  validate  Report integrity issues without changing anything
+  repair    Fix safe-to-fix issues (with confirmation)
+  forget    Drop a single entry by path`,
+}
+
+var registryValidateCmd = &cobra.Command{
+	Use:   "validate",
+	Short: "Report integrity issues in the registry",
+	Long: `Walks the registry and surfaces:
+  - missing_worktree   directory listed in registry no longer exists
+  - duplicate_worktree two entries share the same worktree path
+  - duplicate_branch   two entries claim the same project + branch
+  - duplicate_port     a port is held by more than one entry
+  - missing_ports      an entry has no ports assigned
+
+Exits 0 when clean, 1 when issues are found. Read-only.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		reg := registry.New("")
+		issues, err := reg.Validate()
+		if err != nil {
+			return err
+		}
+		if len(issues) == 0 {
+			fmt.Println("Registry is healthy.")
+			return nil
+		}
+		fmt.Printf("Registry has %d issue(s):\n\n", len(issues))
+		printIssues(issues)
+		return cliErr(cmd, fmt.Errorf("registry has %d unresolved issue(s)", len(issues)))
+	},
+}
+
+var registryRepairCmd = &cobra.Command{
+	Use:   "repair",
+	Short: "Fix safe-to-fix registry issues (with confirmation)",
+	Long: `Backs up registry.json then applies repairs that are safe to do
+automatically: prune entries whose worktree directory no longer exists.
+
+Other findings (duplicate ports, duplicate worktree paths, entries
+missing ports) are listed but require manual judgment — the command
+points to the right tool ('gtl reallocate', 'gtl registry forget').`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		reg := registry.New("")
+		issues, err := reg.Validate()
+		if err != nil {
+			return err
+		}
+		if len(issues) == 0 {
+			fmt.Println("Registry is healthy. Nothing to repair.")
+			return nil
+		}
+
+		fmt.Printf("Found %d issue(s):\n\n", len(issues))
+		printIssues(issues)
+
+		autoFixable := 0
+		for _, iss := range issues {
+			if iss.Kind == "missing_worktree" {
+				autoFixable++
+			}
+		}
+		if autoFixable == 0 {
+			fmt.Println()
+			fmt.Println("No automatic fixes are available. Resolve the issues above manually.")
+			return nil
+		}
+
+		fmt.Println()
+		if !confirm.Prompt(fmt.Sprintf("Prune %d entries with missing worktrees?", autoFixable), registryRepairForce, nil) {
+			fmt.Println("Aborted.")
+			return nil
+		}
+
+		backup, err := reg.Backup(time.Now().UTC().Format("20060102-150405"))
+		if err != nil {
+			return fmt.Errorf("creating backup before repair: %w", err)
+		}
+		fmt.Printf("Backed up registry to %s\n", backup)
+
+		count, err := reg.Prune()
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Pruned %d entries.\n", count)
+		return nil
+	},
+}
+
+var registryForgetCmd = &cobra.Command{
+	Use:   "forget <path>",
+	Short: "Drop the registry entry for the given worktree path",
+	Long: `Removes one allocation from the registry without touching the worktree
+directory, ports, or databases. Useful when an external tool (Conductor,
+manual rm -rf) deleted a workspace and the registry still has the
+entry. Idempotent — exits 0 even when no entry matches.
+
+Prefer 'gtl prune' for general cleanup; this command is a precise
+single-entry removal for tooling integrations.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path, err := filepath.Abs(args[0])
+		if err != nil {
+			return err
+		}
+		reg := registry.New("")
+		removed, err := reg.Release(path)
+		if err != nil {
+			return err
+		}
+		if removed {
+			fmt.Printf("Removed allocation for %s.\n", path)
+		} else {
+			fmt.Printf("No allocation found for %s.\n", path)
+		}
+		return nil
+	},
+}
+
+func printIssues(issues []registry.Issue) {
+	// Group by kind for readability.
+	for _, iss := range issues {
+		marker := "  ⚠"
+		fmt.Printf("%s [%s] %s\n", marker, iss.Kind, iss.Detail)
+		if iss.Fix != "" {
+			fmt.Printf("    fix: %s\n", iss.Fix)
+		}
+	}
+}
+
+// shouldUseRegistryRepair reports whether the doctor should suggest running
+// 'gtl registry repair'. Used by integration points that want a soft hint
+// without scolding.
+func shouldUseRegistryRepair() bool {
+	reg := registry.New("")
+	issues, err := reg.Validate()
+	if err != nil {
+		return false
+	}
+	for _, iss := range issues {
+		if iss.Kind == "missing_worktree" {
+			return true
+		}
+	}
+	return false
+}
+
+// registrySnippet returns a short, single-line summary suitable for embedding
+// in another command's output. Returns "" when the registry is clean.
+func registrySnippet() string {
+	reg := registry.New("")
+	issues, err := reg.Validate()
+	if err != nil || len(issues) == 0 {
+		return ""
+	}
+	kinds := map[string]int{}
+	for _, iss := range issues {
+		kinds[iss.Kind]++
+	}
+	parts := make([]string, 0, len(kinds))
+	for kind, n := range kinds {
+		parts = append(parts, fmt.Sprintf("%d %s", n, kind))
+	}
+	return fmt.Sprintf("registry has %d issue(s): %s — run 'gtl registry validate'", len(issues), strings.Join(parts, ", "))
+}
+

--- a/cmd/registry_cmd.go
+++ b/cmd/registry_cmd.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/git-treeline/cli/internal/confirm"
@@ -172,24 +171,5 @@ func shouldUseRegistryRepair() bool {
 		}
 	}
 	return false
-}
-
-// registrySnippet returns a short, single-line summary suitable for embedding
-// in another command's output. Returns "" when the registry is clean.
-func registrySnippet() string {
-	reg := registry.New("")
-	issues, err := reg.Validate()
-	if err != nil || len(issues) == 0 {
-		return ""
-	}
-	kinds := map[string]int{}
-	for _, iss := range issues {
-		kinds[iss.Kind]++
-	}
-	parts := make([]string, 0, len(kinds))
-	for kind, n := range kinds {
-		parts = append(parts, fmt.Sprintf("%d %s", n, kind))
-	}
-	return fmt.Sprintf("registry has %d issue(s): %s — run 'gtl registry validate'", len(issues), strings.Join(parts, ", "))
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,9 +1,13 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/git-treeline/cli/internal/platform"
+	"github.com/git-treeline/cli/internal/service"
+	"github.com/git-treeline/cli/internal/style"
 	"github.com/spf13/cobra"
 )
 
@@ -13,7 +17,69 @@ var rootCmd = &cobra.Command{
 	SilenceErrors: true,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		_ = platform.EnsureConfigDir()
+		maybeWarnStaleRouter(cmd)
 	},
+}
+
+// commandsThatSelfRepair are commands the user runs to FIX a stale router —
+// emitting a "router is stale" warning during these is just noise.
+var commandsThatSelfRepair = map[string]bool{
+	"install":      true,
+	"serve":        true, // covers all serve subcommands
+	"version":      true,
+	"help":         true,
+	"completion":   true,
+	"__complete":   true, // shell completion handler
+	"__completeNoDesc": true,
+}
+
+// maybeWarnStaleRouter prints a one-line warning when the running router's
+// version disagrees with the CLI binary. Suppressed for commands that are
+// themselves intended to fix the situation.
+//
+// Cost: a single os.ReadFile of a tiny version file. No network, no sudo.
+// Suppress entirely with GTL_NO_STALE_WARN=1 (CI environments).
+func maybeWarnStaleRouter(cmd *cobra.Command) {
+	if !shouldWarnStaleRouter(rootCommandName(cmd), Version, service.RunningRouterVersion(),
+		os.Getenv("GTL_NO_STALE_WARN")) {
+		return
+	}
+	fmt.Fprintln(os.Stderr, style.Warnf("Router is running %s but CLI is %s.", service.RunningRouterVersion(), Version))
+	fmt.Fprintln(os.Stderr, style.Dimf("  Run 'gtl serve restart' to update the router (or 'gtl serve install' for a full reset)."))
+	fmt.Fprintln(os.Stderr, style.Dimf("  Suppress this warning: GTL_NO_STALE_WARN=1"))
+}
+
+// shouldWarnStaleRouter is the pure decision logic, exposed for testing.
+func shouldWarnStaleRouter(rootCmd, cliVersion, runningVersion, suppressEnv string) bool {
+	if suppressEnv != "" {
+		return false
+	}
+	if cliVersion == "" || cliVersion == "dev" {
+		return false
+	}
+	if commandsThatSelfRepair[rootCmd] {
+		return false
+	}
+	if runningVersion == "" || runningVersion == cliVersion {
+		return false
+	}
+	return true
+}
+
+// rootCommandName returns the top-level subcommand name used to invoke this
+// run. For 'gtl serve restart' it returns "serve"; for 'gtl status' it
+// returns "status".
+func rootCommandName(cmd *cobra.Command) string {
+	root := cmd.Root()
+	for c := cmd; c != nil; c = c.Parent() {
+		if c.Parent() == root {
+			return strings.SplitN(c.Use, " ", 2)[0]
+		}
+		if c == root {
+			return ""
+		}
+	}
+	return ""
 }
 
 func Execute() {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import "testing"
+
+func TestShouldWarnStaleRouter_Truthy(t *testing.T) {
+	if !shouldWarnStaleRouter("status", "0.39.4", "0.39.2", "") {
+		t.Error("expected warning when version mismatches and command is not self-repairing")
+	}
+}
+
+func TestShouldWarnStaleRouter_SuppressedByEnv(t *testing.T) {
+	if shouldWarnStaleRouter("status", "0.39.4", "0.39.2", "1") {
+		t.Error("GTL_NO_STALE_WARN should suppress")
+	}
+}
+
+func TestShouldWarnStaleRouter_SuppressedDuringSelfRepair(t *testing.T) {
+	for _, c := range []string{"install", "serve"} {
+		if shouldWarnStaleRouter(c, "0.39.4", "0.39.2", "") {
+			t.Errorf("%q is self-repairing — should not warn", c)
+		}
+	}
+}
+
+func TestShouldWarnStaleRouter_QuietWhenVersionsMatch(t *testing.T) {
+	if shouldWarnStaleRouter("status", "0.39.4", "0.39.4", "") {
+		t.Error("matching versions should not warn")
+	}
+}
+
+func TestShouldWarnStaleRouter_QuietForDevBuild(t *testing.T) {
+	if shouldWarnStaleRouter("status", "dev", "0.39.2", "") {
+		t.Error("dev builds shouldn't nag (unstable Version string)")
+	}
+}
+
+func TestShouldWarnStaleRouter_QuietWhenNoRunningRouter(t *testing.T) {
+	if shouldWarnStaleRouter("status", "0.39.4", "", "") {
+		t.Error("router never started — nothing to warn about")
+	}
+}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -37,6 +37,9 @@ func routeHostnames(baseDomain string) []string {
 func init() {
 	serveCmd.AddCommand(serveInstallCmd)
 	serveCmd.AddCommand(serveUninstallCmd)
+	serveRestartCmd.Flags().BoolVar(&serveRestartReloadPF, "pf", false, "Also reload pf rules (port forwarding)")
+	serveCmd.AddCommand(serveRestartCmd)
+	serveCmd.AddCommand(serveReloadPFCmd)
 	serveCmd.AddCommand(serveStatusCmd)
 	serveCmd.AddCommand(serveRunCmd)
 	serveHostsCmd.AddCommand(serveHostsSyncCmd)
@@ -45,6 +48,46 @@ func init() {
 	serveAliasCmd.Flags().BoolVar(&serveAliasRemove, "remove", false, "Remove the named alias")
 	serveCmd.AddCommand(serveAliasCmd)
 	rootCmd.AddCommand(serveCmd)
+}
+
+var serveRestartReloadPF bool
+
+var serveRestartCmd = &cobra.Command{
+	Use:   "restart",
+	Short: "Restart the router daemon (kickstart)",
+	Long: `Restart the running router so it picks up changes such as a Homebrew
+upgrade of the gtl binary. Cheaper and faster than 'gtl serve install' —
+no sudo, no plist rewrite, no pf reload.
+
+Pass --pf to also reload port-forwarding rules (useful after a reboot
+that dropped them).`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+			return cliErr(cmd, &CliError{
+				Message: fmt.Sprintf("gtl serve restart requires macOS or Linux (detected %s).", runtime.GOOS),
+			})
+		}
+		fmt.Println(style.Actionf("Restarting router service..."))
+		if err := service.Bounce(service.DefaultBounceTimeout); err != nil {
+			return cliErr(cmd, &CliError{
+				Message: fmt.Sprintf("Could not restart router: %v", err),
+				Hint:    "If this persists, run 'gtl serve install' for a full reset.",
+			})
+		}
+		fmt.Println(style.Dimf("Router restarted (running %s).", Version))
+
+		if serveRestartReloadPF {
+			fmt.Println(style.Actionf("Reloading pf rules..."))
+			if err := service.ReloadPortForward(); err != nil {
+				return cliErr(cmd, &CliError{
+					Message: fmt.Sprintf("Could not reload pf: %v", err),
+					Hint:    "Run 'gtl serve install' to repair the pf configuration.",
+				})
+			}
+			fmt.Println(style.Dimf("pf rules reloaded."))
+		}
+		return nil
+	},
 }
 
 var serveCmd = &cobra.Command{
@@ -263,6 +306,33 @@ func warnRouterVersionMismatch() {
 	}
 	fmt.Fprintln(os.Stderr, style.Warnf("Router is running %s but CLI is %s.", running, Version))
 	fmt.Fprintln(os.Stderr, style.Dimf("  Run 'gtl serve install' to update the router."))
+}
+
+var serveReloadPFCmd = &cobra.Command{
+	Use:   "reload-pf",
+	Short: "Reload port-forwarding rules into the running kernel",
+	Long: `Re-applies the port-forwarding rules from /etc/pf.conf into pf's running
+ruleset. Useful after a reboot or network state change that left pf.conf on
+disk but cleared the kernel ruleset (a common cause of "port 443 not
+reachable" with the router otherwise healthy).
+
+Requires sudo on macOS.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+			return cliErr(cmd, &CliError{
+				Message: fmt.Sprintf("gtl serve reload-pf requires macOS or Linux (detected %s).", runtime.GOOS),
+			})
+		}
+		fmt.Println(style.Actionf("Reloading pf rules..."))
+		if err := service.ReloadPortForward(); err != nil {
+			return cliErr(cmd, &CliError{
+				Message: fmt.Sprintf("Could not reload pf: %v", err),
+				Hint:    "Run 'gtl serve install' for a full reset.",
+			})
+		}
+		fmt.Println(style.Dimf("pf rules reloaded."))
+		return nil
+	},
 }
 
 var serveAliasRemove bool

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -153,7 +153,19 @@ func (r *Router) Run() error {
 
 const maxProxyHops = 5
 
+// HealthEndpoint is the path the doctor probes to confirm the running
+// router is responsive (not just bound to a port).
+const HealthEndpoint = "/_treeline/health"
+
 func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	if req.URL.Path == HealthEndpoint {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		w.Header().Set("X-Treeline-Router", "1")
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, "ok\n")
+		return
+	}
+
 	hops := 0
 	if v := req.Header.Get("X-Gtl-Hops"); v != "" {
 		hops, _ = strconv.Atoi(v)

--- a/internal/proxy/router_test.go
+++ b/internal/proxy/router_test.go
@@ -167,6 +167,50 @@ func TestRouterStatusPage(t *testing.T) {
 	}
 }
 
+// The doctor's liveness probe hits this endpoint to distinguish "router
+// bound to socket" from "router actually answers". A 200 here is the
+// signal that the running router speaks our protocol.
+func TestRouter_HealthEndpoint(t *testing.T) {
+	reg := testRegistry(t, nil)
+	router := NewRouter(3000, reg)
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + HealthEndpoint)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200, got %d", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Treeline-Router"); got != "1" {
+		t.Errorf("expected X-Treeline-Router=1, got %q", got)
+	}
+}
+
+// Health endpoint must short-circuit BEFORE subdomain lookup, so it works
+// even with no Host or a Host that has no matching route.
+func TestRouter_HealthEndpointBypassesRouting(t *testing.T) {
+	reg := testRegistry(t, nil)
+	router := NewRouter(3000, reg)
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	req, _ := http.NewRequest("GET", ts.URL+HealthEndpoint, nil)
+	req.Host = "no-such-route.example.com"
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != 200 {
+		t.Errorf("expected 200 even with unmatched host, got %d", resp.StatusCode)
+	}
+}
+
 func TestRouteKey_LongLabelTruncated(t *testing.T) {
 	key := RouteKey("my-long-company-name", "feature/redesign-entire-authentication-flow-for-enterprise-clients")
 	if len(key) > 63 {

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -289,20 +289,18 @@ func (r *Registry) Prune() (int, error) {
 }
 
 // PruneStale removes allocations where the directory doesn't exist OR the
-// directory exists but is not a registered git worktree.
+// directory exists, is a git worktree (not a standalone clone), and is not
+// registered with its parent repo's worktree list.
+//
+// Standalone clones are explicitly preserved: they are full repositories
+// not tied to a parent's worktree list, and the older check incorrectly
+// flagged them as stale (this is what nuked Conductor workspaces).
 func (r *Registry) PruneStale() (int, error) {
-	knownWorktrees := listGitWorktrees()
-
 	count := 0
 	err := r.withLock(func(data *RegistryData) {
 		filtered := make([]Allocation, 0, len(data.Allocations))
 		for _, a := range data.Allocations {
-			wt := GetString(a, "worktree")
-			if _, err := os.Stat(wt); err != nil {
-				count++
-				continue
-			}
-			if knownWorktrees != nil && !knownWorktrees[wt] {
+			if isStaleEntry(a) {
 				count++
 				continue
 			}
@@ -313,8 +311,43 @@ func (r *Registry) PruneStale() (int, error) {
 	return count, err
 }
 
-func listGitWorktrees() map[string]bool {
-	out, err := exec.Command("git", "worktree", "list", "--porcelain").Output()
+// isStaleEntry returns true when the registry entry should be removed by
+// PruneStale. Stale = directory missing, OR the entry is a git worktree
+// (not a standalone clone) that no longer appears in the parent repo's
+// worktree list.
+func isStaleEntry(a Allocation) bool {
+	wt := GetString(a, "worktree")
+	if wt == "" {
+		return false
+	}
+	info, err := os.Stat(wt)
+	if err != nil || !info.IsDir() {
+		return true
+	}
+	gitMarker, err := os.Stat(filepath.Join(wt, ".git"))
+	if err != nil {
+		// No .git at all — directory is not a git checkout; treat as stale.
+		return true
+	}
+	if gitMarker.IsDir() {
+		// Standalone clone — directory exists, full repo. Keep.
+		return false
+	}
+	// Git worktree (.git is a pointer file). Cross-reference parent's
+	// worktree list. If the parent can't be queried, prefer to keep the
+	// entry rather than nuke it.
+	known := listGitWorktreesFor(wt)
+	if known == nil {
+		return false
+	}
+	return !known[wt]
+}
+
+// listGitWorktreesFor returns the worktrees registered with the parent of
+// the given worktree directory (`git -C <dir> worktree list --porcelain`).
+// Returns nil if the command fails so callers can default to "keep".
+func listGitWorktreesFor(dir string) map[string]bool {
+	out, err := exec.Command("git", "-C", dir, "worktree", "list", "--porcelain").Output()
 	if err != nil {
 		return nil
 	}

--- a/internal/registry/validate.go
+++ b/internal/registry/validate.go
@@ -1,0 +1,169 @@
+package registry
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Issue describes a registry-integrity finding.
+type Issue struct {
+	// Kind is a short stable identifier (e.g. "missing_worktree",
+	// "duplicate_port", "duplicate_worktree", "duplicate_branch",
+	// "missing_ports").
+	Kind string
+	// Worktree is the entry's worktree path. Empty when the issue spans
+	// multiple entries.
+	Worktree string
+	// Detail is a one-line human-readable description.
+	Detail string
+	// Fix is a short hint at what to run to repair this. May be empty.
+	Fix string
+}
+
+// Validate scans the registry and returns a list of integrity findings.
+// Read-only — safe to call without holding the lock.
+//
+// Detected:
+//   - Worktree directory listed in the registry no longer exists on disk
+//     ("missing_worktree"; fix: gtl prune)
+//   - Two entries share the same worktree path ("duplicate_worktree")
+//   - Two entries share the same project + branch combo
+//     ("duplicate_branch")
+//   - A port is allocated to more than one worktree
+//     ("duplicate_port")
+//   - An entry has no ports assigned at all ("missing_ports"; fix:
+//     gtl reallocate)
+func (r *Registry) Validate() ([]Issue, error) {
+	data, err := r.load()
+	if err != nil {
+		return nil, err
+	}
+	return validateData(data), nil
+}
+
+func validateData(data RegistryData) []Issue {
+	var issues []Issue
+
+	// Per-entry checks.
+	worktreeOwners := map[string][]string{}
+	branchOwners := map[string][]string{}
+	portOwners := map[int][]string{}
+
+	for _, a := range data.Allocations {
+		wt := GetString(a, "worktree")
+		project := GetString(a, "project")
+		branch := GetString(a, "branch")
+
+		if wt != "" {
+			if info, err := os.Stat(wt); err != nil || !info.IsDir() {
+				issues = append(issues, Issue{
+					Kind:     "missing_worktree",
+					Worktree: wt,
+					Detail:   fmt.Sprintf("worktree directory does not exist: %s", wt),
+					Fix:      "gtl prune",
+				})
+			}
+			worktreeOwners[wt] = append(worktreeOwners[wt], wt)
+		}
+
+		if project != "" && branch != "" {
+			key := project + "@" + branch
+			branchOwners[key] = append(branchOwners[key], wt)
+		}
+
+		ports := ExtractPorts(a)
+		if len(ports) == 0 {
+			issues = append(issues, Issue{
+				Kind:     "missing_ports",
+				Worktree: wt,
+				Detail:   "allocation has no ports",
+				Fix:      "gtl reallocate",
+			})
+		}
+		for _, p := range ports {
+			portOwners[p] = append(portOwners[p], wt)
+		}
+	}
+
+	// Cross-entry duplicate checks.
+	for wt, owners := range worktreeOwners {
+		if len(owners) > 1 {
+			issues = append(issues, Issue{
+				Kind:     "duplicate_worktree",
+				Worktree: wt,
+				Detail:   fmt.Sprintf("worktree path appears %d times", len(owners)),
+				Fix:      "remove the duplicate manually with: gtl config edit",
+			})
+		}
+	}
+	for key, owners := range branchOwners {
+		if len(owners) > 1 {
+			issues = append(issues, Issue{
+				Kind:   "duplicate_branch",
+				Detail: fmt.Sprintf("project/branch %q owned by %d entries: %v", key, len(owners), owners),
+				Fix:    "drop the duplicate with gtl prune --force or 'gtl registry forget <path>'",
+			})
+		}
+	}
+
+	// Sort port keys so output is stable.
+	dupPorts := make([]int, 0)
+	for p, owners := range portOwners {
+		if len(owners) > 1 {
+			dupPorts = append(dupPorts, p)
+		}
+		_ = owners
+	}
+	sort.Ints(dupPorts)
+	for _, p := range dupPorts {
+		issues = append(issues, Issue{
+			Kind:   "duplicate_port",
+			Detail: fmt.Sprintf("port %d is held by %d entries: %v", p, len(portOwners[p]), portOwners[p]),
+			Fix:    "run 'gtl reallocate' to assign a fresh port to one of them",
+		})
+	}
+
+	// Stable order: missing_worktree first (ready for prune), then
+	// duplicates, then missing_ports.
+	sort.SliceStable(issues, func(i, j int) bool {
+		return issueOrder(issues[i].Kind) < issueOrder(issues[j].Kind)
+	})
+	return issues
+}
+
+func issueOrder(kind string) int {
+	switch kind {
+	case "missing_worktree":
+		return 0
+	case "duplicate_worktree":
+		return 1
+	case "duplicate_branch":
+		return 2
+	case "duplicate_port":
+		return 3
+	case "missing_ports":
+		return 4
+	default:
+		return 99
+	}
+}
+
+// Backup writes a copy of the current registry file to <path>.bak-<suffix>.
+// Caller picks a suffix (typically a timestamp) so multiple backups don't
+// clobber each other. Returns the backup path or an error.
+func (r *Registry) Backup(suffix string) (string, error) {
+	data, err := os.ReadFile(r.Path)
+	if err != nil {
+		return "", fmt.Errorf("reading registry: %w", err)
+	}
+	backupPath := r.Path + ".bak-" + suffix
+	if err := os.MkdirAll(filepath.Dir(backupPath), 0o755); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(backupPath, data, 0o600); err != nil {
+		return "", err
+	}
+	return backupPath, nil
+}

--- a/internal/registry/validate_test.go
+++ b/internal/registry/validate_test.go
@@ -14,17 +14,6 @@ func mkClone(t *testing.T, dir string) {
 	}
 }
 
-func mkWorktreeMarker(t *testing.T, dir, parent string) {
-	t.Helper()
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(filepath.Join(dir, ".git"),
-		[]byte("gitdir: "+parent+"/.git/worktrees/x\n"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-}
-
 func TestValidate_HealthyRegistry(t *testing.T) {
 	reg := newTestRegistry(t)
 	dir := filepath.Dir(reg.Path)

--- a/internal/registry/validate_test.go
+++ b/internal/registry/validate_test.go
@@ -1,0 +1,242 @@
+package registry
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func mkClone(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mkWorktreeMarker(t *testing.T, dir, parent string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".git"),
+		[]byte("gitdir: "+parent+"/.git/worktrees/x\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestValidate_HealthyRegistry(t *testing.T) {
+	reg := newTestRegistry(t)
+	dir := filepath.Dir(reg.Path)
+	a := filepath.Join(dir, "wt-a")
+	b := filepath.Join(dir, "wt-b")
+	mkClone(t, a)
+	mkClone(t, b)
+
+	_ = reg.Allocate(Allocation{
+		"project": "alpha", "branch": "main", "worktree": a, "port": float64(3002),
+	})
+	_ = reg.Allocate(Allocation{
+		"project": "beta", "branch": "main", "worktree": b, "port": float64(3004),
+	})
+
+	issues, err := reg.Validate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(issues) != 0 {
+		t.Errorf("expected no issues, got: %+v", issues)
+	}
+}
+
+func TestValidate_FlagsMissingWorktree(t *testing.T) {
+	reg := newTestRegistry(t)
+	dir := filepath.Dir(reg.Path)
+	keep := filepath.Join(dir, "keep")
+	gone := filepath.Join(dir, "gone")
+	mkClone(t, keep)
+
+	_ = reg.Allocate(Allocation{
+		"project": "k", "branch": "main", "worktree": keep, "port": float64(3002),
+	})
+	_ = reg.Allocate(Allocation{
+		"project": "g", "branch": "main", "worktree": gone, "port": float64(3004),
+	})
+
+	issues, err := reg.Validate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, iss := range issues {
+		if iss.Kind == "missing_worktree" && iss.Worktree == gone {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected missing_worktree issue for %s, got: %+v", gone, issues)
+	}
+}
+
+func TestValidate_FlagsCrossEntryDuplicatePort(t *testing.T) {
+	reg := newTestRegistry(t)
+	dir := filepath.Dir(reg.Path)
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+	mkClone(t, a)
+	mkClone(t, b)
+
+	_ = reg.Allocate(Allocation{"project": "a", "branch": "x", "worktree": a, "port": float64(3022)})
+	_ = reg.Allocate(Allocation{"project": "b", "branch": "y", "worktree": b, "port": float64(3022)})
+
+	issues, err := reg.Validate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dup := false
+	for _, iss := range issues {
+		if iss.Kind == "duplicate_port" && strings.Contains(iss.Detail, "3022") {
+			dup = true
+		}
+	}
+	if !dup {
+		t.Errorf("expected duplicate_port issue mentioning 3022, got: %+v", issues)
+	}
+}
+
+func TestValidate_DoesNotFlagSamePortInLegacyAndPortsArray(t *testing.T) {
+	// Real-world entries have both `port: 3022` and `ports: [3022]` set on the
+	// same allocation — that's not a duplicate, just legacy field redundancy.
+	reg := newTestRegistry(t)
+	dir := filepath.Dir(reg.Path)
+	a := filepath.Join(dir, "a")
+	mkClone(t, a)
+
+	_ = reg.Allocate(Allocation{
+		"project": "p", "branch": "main", "worktree": a,
+		"port":  float64(3022),
+		"ports": []any{float64(3022)},
+	})
+	issues, err := reg.Validate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, iss := range issues {
+		if iss.Kind == "duplicate_port" {
+			t.Errorf("port + ports[] on the same entry should not look like duplicates: %+v", iss)
+		}
+	}
+}
+
+func TestValidate_FlagsDuplicateBranch(t *testing.T) {
+	reg := newTestRegistry(t)
+	dir := filepath.Dir(reg.Path)
+	a := filepath.Join(dir, "a")
+	b := filepath.Join(dir, "b")
+	mkClone(t, a)
+	mkClone(t, b)
+
+	_ = reg.Allocate(Allocation{"project": "salt", "branch": "feature", "worktree": a, "port": float64(3010)})
+	_ = reg.Allocate(Allocation{"project": "salt", "branch": "feature", "worktree": b, "port": float64(3012)})
+
+	issues, err := reg.Validate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	dup := false
+	for _, iss := range issues {
+		if iss.Kind == "duplicate_branch" {
+			dup = true
+		}
+	}
+	if !dup {
+		t.Errorf("expected duplicate_branch, got: %+v", issues)
+	}
+}
+
+func TestValidate_FlagsMissingPorts(t *testing.T) {
+	reg := newTestRegistry(t)
+	dir := filepath.Dir(reg.Path)
+	a := filepath.Join(dir, "a")
+	mkClone(t, a)
+
+	_ = reg.Allocate(Allocation{"project": "p", "branch": "main", "worktree": a})
+	issues, err := reg.Validate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	missing := false
+	for _, iss := range issues {
+		if iss.Kind == "missing_ports" {
+			missing = true
+		}
+	}
+	if !missing {
+		t.Errorf("expected missing_ports, got: %+v", issues)
+	}
+}
+
+func TestPruneStale_PreservesStandaloneClones(t *testing.T) {
+	// Regression: gtl prune --stale used to flag every entry that wasn't in
+	// `git worktree list` of the current repo as stale. Standalone clones
+	// (Conductor workspaces) have their own .git directory and are not part
+	// of any parent repo's worktree list, so they got nuked. Now PruneStale
+	// recognizes them by ".git is a directory" and preserves them.
+	reg := newTestRegistry(t)
+	dir := filepath.Dir(reg.Path)
+
+	clone := filepath.Join(dir, "conductor-workspace")
+	mkClone(t, clone)
+
+	_ = reg.Allocate(Allocation{
+		"project": "clients", "branch": "feature/x", "worktree": clone, "port": float64(3022),
+	})
+
+	count, err := reg.PruneStale()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 0 {
+		t.Errorf("expected 0 prunes, got %d", count)
+	}
+	if reg.Find(clone) == nil {
+		t.Error("standalone clone entry got pruned — Conductor regression")
+	}
+}
+
+func TestPruneStale_RemovesMissingDirectory(t *testing.T) {
+	reg := newTestRegistry(t)
+	dir := filepath.Dir(reg.Path)
+
+	gone := filepath.Join(dir, "gone")
+	_ = reg.Allocate(Allocation{
+		"project": "g", "branch": "main", "worktree": gone, "port": float64(3022),
+	})
+
+	count, err := reg.PruneStale()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 prune for missing dir, got %d", count)
+	}
+}
+
+func TestBackup_CreatesCopy(t *testing.T) {
+	reg := newTestRegistry(t)
+	dir := filepath.Dir(reg.Path)
+	clone := filepath.Join(dir, "wt")
+	mkClone(t, clone)
+	_ = reg.Allocate(Allocation{"project": "p", "branch": "main", "worktree": clone, "port": float64(3010)})
+
+	path, err := reg.Backup("test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(path, ".bak-test") {
+		t.Errorf("expected .bak-test suffix, got %q", path)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("backup file not created: %v", err)
+	}
+}

--- a/internal/service/bounce_test.go
+++ b/internal/service/bounce_test.go
@@ -1,0 +1,337 @@
+package service
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// withFakeRunCmd replaces runCmd / runCmdOutput with capturing fakes for the
+// duration of a test. The returned slice records every (name, args) call in
+// order.
+func withFakeRunCmd(t *testing.T, runErr map[string]error) *[]string {
+	t.Helper()
+	var calls []string
+
+	origRun := runCmd
+	origOut := runCmdOutput
+	t.Cleanup(func() {
+		runCmd = origRun
+		runCmdOutput = origOut
+	})
+
+	runCmd = func(name string, args ...string) error {
+		joined := name + " " + strings.Join(args, " ")
+		calls = append(calls, joined)
+		for prefix, err := range runErr {
+			if strings.HasPrefix(joined, prefix) {
+				return err
+			}
+		}
+		return nil
+	}
+	runCmdOutput = func(name string, args ...string) ([]byte, error) {
+		return nil, nil
+	}
+	return &calls
+}
+
+// withFakeClock replaces nowFn / sleepFn so wait loops complete without real
+// time passing. Each sleep advances the simulated clock.
+func withFakeClock(t *testing.T) *time.Time {
+	t.Helper()
+	now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	origNow := nowFn
+	origSleep := sleepFn
+	t.Cleanup(func() {
+		nowFn = origNow
+		sleepFn = origSleep
+	})
+	nowFn = func() time.Time { return now }
+	sleepFn = func(d time.Duration) { now = now.Add(d) }
+	return &now
+}
+
+// withTempVersionFile points RouterVersionFile() at a temp directory so tests
+// can write the version file without touching the real ConfigDir.
+func withTempVersionFile(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	t.Setenv("GTL_HOME", dir)
+	// On macOS, ConfigDir uses ~/Library/Application Support — override
+	// HOME so it lands in the temp dir.
+	t.Setenv("HOME", dir)
+	path := RouterVersionFile()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	return path
+}
+
+func TestBounce_LaunchAgent_Kickstart_Success(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only")
+	}
+	versionPath := withTempVersionFile(t)
+	withFakeClock(t)
+
+	// Pre-populate version file with a known mtime, set to "before" the
+	// fake clock so any later write counts as fresh.
+	if err := os.WriteFile(versionPath, []byte("0.39.2"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	past := nowFn().Add(-time.Hour)
+	_ = os.Chtimes(versionPath, past, past)
+
+	calls := withFakeRunCmd(t, nil)
+
+	// Simulate the router writing a fresh version file mid-bounce: when
+	// kickstart is called, advance the file's mtime to the current
+	// simulated clock.
+	origRun := runCmd
+	runCmd = func(name string, args ...string) error {
+		err := origRun(name, args...)
+		if err == nil && len(args) > 0 && args[0] == "kickstart" {
+			t := nowFn().Add(50 * time.Millisecond)
+			_ = os.Chtimes(versionPath, t, t)
+		}
+		return err
+	}
+
+	if err := Bounce(2 * time.Second); err != nil {
+		t.Fatalf("Bounce: %v", err)
+	}
+
+	// First call should be `launchctl print` (probe), then `kickstart -k`.
+	if len(*calls) < 2 {
+		t.Fatalf("expected at least 2 launchctl calls, got %d: %v", len(*calls), *calls)
+	}
+	if !strings.Contains((*calls)[0], "launchctl print") {
+		t.Errorf("first call should be print, got %q", (*calls)[0])
+	}
+	found := false
+	for _, c := range *calls {
+		if strings.Contains(c, "launchctl kickstart -k") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected a kickstart -k call, got: %v", *calls)
+	}
+}
+
+func TestBounce_LaunchAgent_FallsBackToBootstrap_WhenNotLoaded(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only")
+	}
+	versionPath := withTempVersionFile(t)
+	withFakeClock(t)
+
+	// Plist file must exist for bootstrap to proceed.
+	plistDir := filepath.Dir(PlistPath())
+	if err := os.MkdirAll(plistDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(PlistPath(), []byte("<plist/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// `launchctl print` returns error → not loaded; bootstrap path runs.
+	calls := withFakeRunCmd(t, map[string]error{
+		"launchctl print": errors.New("service not loaded"),
+	})
+
+	// Have bootstrap "succeed" and write the version file.
+	origRun := runCmd
+	runCmd = func(name string, args ...string) error {
+		if err := origRun(name, args...); err != nil {
+			return err
+		}
+		if len(args) > 0 && args[0] == "bootstrap" {
+			t := nowFn().Add(50 * time.Millisecond)
+			_ = os.WriteFile(versionPath, []byte("9.9.9"), 0o644)
+			_ = os.Chtimes(versionPath, t, t)
+		}
+		return nil
+	}
+
+	if err := Bounce(2 * time.Second); err != nil {
+		t.Fatalf("Bounce: %v", err)
+	}
+
+	wantSeq := []string{"launchctl print", "launchctl bootout", "launchctl bootstrap"}
+	for i, want := range wantSeq {
+		if i >= len(*calls) || !strings.Contains((*calls)[i], want) {
+			t.Fatalf("call %d: want prefix %q, got %v", i, want, *calls)
+		}
+	}
+	// Ensure no kickstart call happened.
+	for _, c := range *calls {
+		if strings.Contains(c, "kickstart") {
+			t.Errorf("did not expect kickstart in fallback path, got: %v", *calls)
+		}
+	}
+}
+
+func TestBounce_LaunchAgent_Times_Out_When_Version_Not_Updated(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only")
+	}
+	withTempVersionFile(t)
+	withFakeClock(t)
+	withFakeRunCmd(t, nil) // print + kickstart both succeed; nothing writes version file
+
+	err := Bounce(500 * time.Millisecond)
+	if err == nil {
+		t.Fatal("expected timeout error, got nil")
+	}
+	if !strings.Contains(err.Error(), "did not record a new version") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestBounce_LaunchAgent_Surfaces_Kickstart_Failure(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only")
+	}
+	withTempVersionFile(t)
+	withFakeClock(t)
+	withFakeRunCmd(t, map[string]error{
+		"launchctl kickstart": errors.New("Could not find service"),
+	})
+
+	err := Bounce(2 * time.Second)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "kickstart") {
+		t.Errorf("expected error to mention kickstart, got %v", err)
+	}
+}
+
+func TestBounce_Systemd_RestartUnit(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only")
+	}
+	versionPath := withTempVersionFile(t)
+	withFakeClock(t)
+
+	calls := withFakeRunCmd(t, nil)
+	origRun := runCmd
+	runCmd = func(name string, args ...string) error {
+		err := origRun(name, args...)
+		if err == nil && len(args) > 1 && args[1] == "restart" {
+			t := nowFn().Add(50 * time.Millisecond)
+			_ = os.WriteFile(versionPath, []byte("9.9.9"), 0o644)
+			_ = os.Chtimes(versionPath, t, t)
+		}
+		return err
+	}
+
+	if err := Bounce(2 * time.Second); err != nil {
+		t.Fatalf("Bounce: %v", err)
+	}
+	if len(*calls) == 0 || !strings.Contains((*calls)[0], "systemctl --user restart") {
+		t.Errorf("expected systemctl restart, got %v", *calls)
+	}
+}
+
+func TestReload_LaunchAgent_BootoutThenBootstrap(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only")
+	}
+	versionPath := withTempVersionFile(t)
+	withFakeClock(t)
+
+	// Plist must exist.
+	if err := os.MkdirAll(filepath.Dir(PlistPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(PlistPath(), []byte("<plist/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := withFakeRunCmd(t, nil)
+	origRun := runCmd
+	runCmd = func(name string, args ...string) error {
+		err := origRun(name, args...)
+		if err == nil && len(args) > 0 && args[0] == "bootstrap" {
+			t := nowFn().Add(50 * time.Millisecond)
+			_ = os.WriteFile(versionPath, []byte("9.9.9"), 0o644)
+			_ = os.Chtimes(versionPath, t, t)
+		}
+		return err
+	}
+
+	if err := Reload(2 * time.Second); err != nil {
+		t.Fatalf("Reload: %v", err)
+	}
+	if len(*calls) < 2 {
+		t.Fatalf("expected at least 2 calls (bootout, bootstrap), got %d", len(*calls))
+	}
+	if !strings.Contains((*calls)[0], "bootout") {
+		t.Errorf("first call should be bootout, got %q", (*calls)[0])
+	}
+	if !strings.Contains((*calls)[1], "bootstrap") {
+		t.Errorf("second call should be bootstrap, got %q", (*calls)[1])
+	}
+}
+
+func TestReload_LaunchAgent_FailsWhenPlistMissing(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only")
+	}
+	withTempVersionFile(t)
+	withFakeClock(t)
+	// Do NOT create the plist.
+	withFakeRunCmd(t, nil)
+
+	err := Reload(time.Second)
+	if err == nil {
+		t.Fatal("expected error when plist is missing")
+	}
+	if !strings.Contains(err.Error(), "plist not found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestRunningPIDDarwin_ParsesLaunchctlOutput(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only")
+	}
+	origOut := runCmdOutput
+	t.Cleanup(func() { runCmdOutput = origOut })
+	runCmdOutput = func(name string, args ...string) ([]byte, error) {
+		return []byte(`gui/501/dev.treeline.router = {
+	active count = 1
+	on demand = false
+	pid = 81129
+	state = running
+}`), nil
+	}
+
+	if got := RunningPID(); got != 81129 {
+		t.Errorf("RunningPID() = %d, want 81129", got)
+	}
+}
+
+func TestRunningPIDDarwin_ZeroOnError(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only")
+	}
+	origOut := runCmdOutput
+	t.Cleanup(func() { runCmdOutput = origOut })
+	runCmdOutput = func(name string, args ...string) ([]byte, error) {
+		return nil, fmt.Errorf("not loaded")
+	}
+	if got := RunningPID(); got != 0 {
+		t.Errorf("RunningPID() = %d, want 0", got)
+	}
+}

--- a/internal/service/health.go
+++ b/internal/service/health.go
@@ -339,7 +339,7 @@ func httpProbe(url string, timeout time.Duration) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	_, _ = io.Copy(io.Discard, resp.Body)
 	return resp.StatusCode, nil
 }

--- a/internal/service/health.go
+++ b/internal/service/health.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -19,14 +21,22 @@ type HealthCheck struct {
 	Fix    string `json:"fix,omitempty"`
 }
 
+type processInfo struct {
+	Name string
+	PID  int
+}
+
 type healthDeps struct {
 	isRunning               func() bool
 	installedBinaryPath     func() string
 	runningRouterVersion    func() string
+	runningPID              func() int
 	isPortForwardConfigured func() bool
+	checkPortForward        func(routerPort int) PortForwardStatus
 	dialTimeout             func(network, address string, timeout time.Duration) (net.Conn, error)
+	httpProbe               func(url string, timeout time.Duration) (int, error)
 	executable              func() (string, error)
-	processOnPort           func(port int) string
+	processOnPort           func(port int) processInfo
 }
 
 func defaultHealthDeps() healthDeps {
@@ -34,8 +44,11 @@ func defaultHealthDeps() healthDeps {
 		isRunning:               IsRunning,
 		installedBinaryPath:     InstalledBinaryPath,
 		runningRouterVersion:    RunningRouterVersion,
+		runningPID:              RunningPID,
 		isPortForwardConfigured: IsPortForwardConfigured,
+		checkPortForward:        CheckPortForward,
 		dialTimeout:             net.DialTimeout,
+		httpProbe:               httpProbe,
 		executable:              os.Executable,
 		processOnPort:           processOnPort,
 	}
@@ -53,6 +66,7 @@ func checkHealthWith(d healthDeps, routerPort int, cliVersion string) []HealthCh
 	checks = append(checks, checkBinaryMatch(d))
 	checks = append(checks, checkRouterVersion(d, cliVersion))
 	checks = append(checks, checkRouterListening(d, routerPort))
+	checks = append(checks, checkRouterResponding(d, routerPort))
 	checks = append(checks, checkPortForward(d, routerPort))
 
 	return checks
@@ -149,8 +163,8 @@ func checkRouterListening(d healthDeps, port int) HealthCheck {
 			return HealthCheck{
 				Name:   "router_port",
 				Status: "error",
-			Detail: fmt.Sprintf("service registered but port %d not listening", port),
-			Fix:    "gtl serve install",
+				Detail: fmt.Sprintf("service registered but port %d not listening", port),
+				Fix:    "gtl serve restart",
 			}
 		}
 		return HealthCheck{
@@ -162,25 +176,89 @@ func checkRouterListening(d healthDeps, port int) HealthCheck {
 	}
 	_ = conn.Close()
 
-	proc := d.processOnPort(port)
-	if proc != "" && !strings.Contains(proc, "gtl") {
+	// Compare the listener's PID with the PID launchd/systemd has registered
+	// for our service. If they match, this is our router — full stop.
+	// If they differ, something else holds the port (or our service crashed
+	// and a stale process is squatting). The previous check substring-
+	// matched the process name against "gtl", which produced false alarms
+	// when the binary was named "git-treeline" — fixed.
+	listener := d.processOnPort(port)
+	registered := d.runningPID()
+	if listener.Name == "" {
+		// Couldn't read from lsof; fall back to "ok" since we did dial.
+		return HealthCheck{
+			Name:   "router_port",
+			Status: "ok",
+			Detail: fmt.Sprintf("listening on %d", port),
+		}
+	}
+	if registered > 0 && listener.PID == registered {
+		return HealthCheck{
+			Name:   "router_port",
+			Status: "ok",
+			Detail: fmt.Sprintf("listening on %d (pid %d)", port, listener.PID),
+		}
+	}
+	if registered > 0 && listener.PID != registered {
 		return HealthCheck{
 			Name:   "router_port",
 			Status: "warn",
-			Detail: fmt.Sprintf("port %d occupied by: %s", port, proc),
-			Fix:    "kill the rogue process, then gtl serve install",
+			Detail: fmt.Sprintf("port %d occupied by %s (pid %d), but launchd has %d for our service",
+				port, listener.Name, listener.PID, registered),
+			Fix: "gtl serve restart",
 		}
 	}
-
+	// registered == 0 means we couldn't read launchd's PID — fall back to a
+	// loose name check rather than crying wolf.
+	if !looksLikeRouter(listener.Name) {
+		return HealthCheck{
+			Name:   "router_port",
+			Status: "warn",
+			Detail: fmt.Sprintf("port %d occupied by %s (pid %d) — does not look like our router", port, listener.Name, listener.PID),
+			Fix:    "investigate the process, then 'gtl serve install'",
+		}
+	}
 	return HealthCheck{
 		Name:   "router_port",
 		Status: "ok",
-		Detail: fmt.Sprintf("listening on %d", port),
+		Detail: fmt.Sprintf("listening on %d (pid %d)", port, listener.PID),
+	}
+}
+
+// checkRouterResponding does an end-to-end liveness probe: a real HTTP
+// request to the router's health endpoint. A listening socket is necessary
+// but not sufficient — the router could be deadlocked or panicking on
+// every request. Treats any 2xx/3xx/4xx as alive (the router answered).
+// 5xx or transport error → warn.
+func checkRouterResponding(d healthDeps, port int) HealthCheck {
+	url := fmt.Sprintf("http://127.0.0.1:%d/_treeline/health", port)
+	status, err := d.httpProbe(url, 2*time.Second)
+	if err != nil {
+		return HealthCheck{
+			Name:   "router_responding",
+			Status: "warn",
+			Detail: fmt.Sprintf("liveness probe failed: %v", err),
+			Fix:    "gtl serve restart",
+		}
+	}
+	if status >= 500 {
+		return HealthCheck{
+			Name:   "router_responding",
+			Status: "warn",
+			Detail: fmt.Sprintf("router answered with %d", status),
+			Fix:    "gtl serve restart",
+		}
+	}
+	return HealthCheck{
+		Name:   "router_responding",
+		Status: "ok",
+		Detail: fmt.Sprintf("HTTP %d from /_treeline/health", status),
 	}
 }
 
 func checkPortForward(d healthDeps, routerPort int) HealthCheck {
-	if !d.isPortForwardConfigured() {
+	st := d.checkPortForward(routerPort)
+	if !st.ConfiguredOnDisk {
 		return HealthCheck{
 			Name:   "port_forwarding",
 			Status: "warn",
@@ -188,51 +266,80 @@ func checkPortForward(d healthDeps, routerPort int) HealthCheck {
 			Fix:    "gtl serve install",
 		}
 	}
-
+	if !st.LoadedInKernel {
+		return HealthCheck{
+			Name:   "port_forwarding",
+			Status: "error",
+			Detail: st.Detail,
+			Fix:    "gtl serve reload-pf",
+		}
+	}
+	// Rules are loaded — verify port 443 actually accepts connections.
 	conn, err := d.dialTimeout("tcp", "127.0.0.1:443", 2*time.Second)
 	if err != nil {
 		return HealthCheck{
 			Name:   "port_forwarding",
 			Status: "error",
-			Detail: "configured in pf.conf but port 443 not reachable — rules may need reload",
-			Fix:    "gtl serve install",
+			Detail: "rule loaded but port 443 not reachable",
+			Fix:    "gtl serve reload-pf",
 		}
 	}
 	_ = conn.Close()
-
 	return HealthCheck{
 		Name:   "port_forwarding",
 		Status: "ok",
-		Detail: fmt.Sprintf("443 → %d", routerPort),
+		Detail: fmt.Sprintf("443 → %d (loaded in kernel)", routerPort),
 	}
 }
 
-// processOnPort returns a description of the process listening on the given
-// TCP port, or "" if it can't be determined.
-func processOnPort(port int) string {
+// looksLikeRouter is used as a soft fallback when we couldn't read launchd's
+// PID (e.g. on Linux when the test environment lacks systemctl). Treats any
+// process name containing "gtl", "git-treeline", or "treeline" as plausibly
+// ours. The previous code only matched "gtl", which produced false alarms
+// for the "git-treeline" binary.
+func looksLikeRouter(name string) bool {
+	lower := strings.ToLower(name)
+	return strings.Contains(lower, "gtl") ||
+		strings.Contains(lower, "git-treeline") ||
+		strings.Contains(lower, "treeline")
+}
+
+// processOnPort returns name + PID of the process listening on the given
+// TCP port, or zero processInfo if it can't be determined.
+func processOnPort(port int) processInfo {
 	if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
-		return ""
+		return processInfo{}
 	}
 	out, err := exec.Command("lsof", "-i", fmt.Sprintf("TCP:%d", port),
 		"-sTCP:LISTEN", "-n", "-P", "-F", "cn").Output()
 	if err != nil {
-		return ""
+		return processInfo{}
 	}
 
-	var name, pid string
+	var info processInfo
 	for _, line := range strings.Split(string(out), "\n") {
 		if strings.HasPrefix(line, "c") {
-			name = line[1:]
+			info.Name = line[1:]
 		}
 		if strings.HasPrefix(line, "p") {
-			pid = line[1:]
+			var pid int
+			if _, err := fmt.Sscanf(line[1:], "%d", &pid); err == nil {
+				info.PID = pid
+			}
 		}
 	}
-	if name == "" {
-		return ""
+	return info
+}
+
+// httpProbe is the default HTTP liveness implementation. Returns the HTTP
+// status code, or an error if the request couldn't complete.
+func httpProbe(url string, timeout time.Duration) (int, error) {
+	client := &http.Client{Timeout: timeout}
+	resp, err := client.Get(url)
+	if err != nil {
+		return 0, err
 	}
-	if pid != "" {
-		return fmt.Sprintf("%s (pid %s)", name, pid)
-	}
-	return name
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	return resp.StatusCode, nil
 }

--- a/internal/service/health_test.go
+++ b/internal/service/health_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"fmt"
 	"net"
+	"strings"
 	"testing"
 	"time"
 )
@@ -20,15 +21,38 @@ func fakeDial(succeed bool) func(string, string, time.Duration) (net.Conn, error
 	}
 }
 
+func fakeHTTP(status int, err error) func(string, time.Duration) (int, error) {
+	return func(_ string, _ time.Duration) (int, error) {
+		return status, err
+	}
+}
+
+func fakePF(configuredOnDisk, loadedInKernel, pfEnabled bool, detail string) func(int) PortForwardStatus {
+	return func(int) PortForwardStatus {
+		return PortForwardStatus{
+			ConfiguredOnDisk: configuredOnDisk,
+			LoadedInKernel:   loadedInKernel,
+			PfEnabled:        pfEnabled,
+			Detail:           detail,
+		}
+	}
+}
+
+// allHealthy returns a healthDeps where every probe reports the happy path.
+// Listener PID matches launchd's recorded PID; pf rules are loaded; the
+// router answers the liveness probe with 200.
 func allHealthy() healthDeps {
 	return healthDeps{
 		isRunning:               func() bool { return true },
 		installedBinaryPath:     func() string { return "/usr/local/bin/gtl" },
 		runningRouterVersion:    func() string { return "1.0.0" },
+		runningPID:              func() int { return 1234 },
 		isPortForwardConfigured: func() bool { return true },
+		checkPortForward:        fakePF(true, true, true, ""),
 		dialTimeout:             fakeDial(true),
+		httpProbe:               fakeHTTP(200, nil),
 		executable:              func() (string, error) { return "/usr/local/bin/gtl", nil },
-		processOnPort:           func(int) string { return "gtl (pid 1234)" },
+		processOnPort:           func(int) processInfo { return processInfo{Name: "git-treeline", PID: 1234} },
 	}
 }
 
@@ -37,8 +61,8 @@ func allHealthy() healthDeps {
 func TestCheckHealthWith_AllHealthy(t *testing.T) {
 	checks := checkHealthWith(allHealthy(), 8443, "1.0.0")
 
-	if len(checks) != 5 {
-		t.Fatalf("expected 5 checks, got %d", len(checks))
+	if len(checks) != 6 {
+		t.Fatalf("expected 6 checks, got %d", len(checks))
 	}
 	for _, c := range checks {
 		if c.Status != "ok" {
@@ -52,20 +76,24 @@ func TestCheckHealthWith_AllBroken(t *testing.T) {
 		isRunning:               func() bool { return false },
 		installedBinaryPath:     func() string { return "" },
 		runningRouterVersion:    func() string { return "" },
+		runningPID:              func() int { return 0 },
 		isPortForwardConfigured: func() bool { return false },
+		checkPortForward:        fakePF(false, false, false, "not configured"),
 		dialTimeout:             fakeDial(false),
+		httpProbe:               fakeHTTP(0, fmt.Errorf("connection refused")),
 		executable:              func() (string, error) { return "/usr/local/bin/gtl", nil },
-		processOnPort:           func(int) string { return "" },
+		processOnPort:           func(int) processInfo { return processInfo{} },
 	}
 
 	checks := checkHealthWith(d, 8443, "1.0.0")
 
 	expected := map[string]string{
-		"service":         "error",
-		"binary":          "warn",
-		"router_version":  "warn",
-		"router_port":     "error",
-		"port_forwarding": "warn",
+		"service":           "error",
+		"binary":            "warn",
+		"router_version":    "warn",
+		"router_port":       "error",
+		"router_responding": "warn",
+		"port_forwarding":   "warn",
 	}
 	for _, c := range checks {
 		want, ok := expected[c.Name]
@@ -174,11 +202,14 @@ func TestCheckRouterVersion_NoVersionFile(t *testing.T) {
 
 // --- checkRouterListening ---
 
-func TestCheckRouterListening_Ok(t *testing.T) {
+func TestCheckRouterListening_Ok_PIDMatches(t *testing.T) {
 	d := allHealthy()
 	c := checkRouterListening(d, 8443)
 	if c.Status != "ok" {
-		t.Errorf("expected ok, got %s", c.Status)
+		t.Errorf("expected ok, got %s (%s)", c.Status, c.Detail)
+	}
+	if !strings.Contains(c.Detail, "pid 1234") {
+		t.Errorf("expected detail to include the listener pid, got %q", c.Detail)
 	}
 }
 
@@ -188,9 +219,6 @@ func TestCheckRouterListening_NotListening_ServiceRunning(t *testing.T) {
 	c := checkRouterListening(d, 8443)
 	if c.Status != "error" {
 		t.Errorf("expected error, got %s", c.Status)
-	}
-	if c.Detail != "service registered but port 8443 not listening" {
-		t.Errorf("unexpected detail: %s", c.Detail)
 	}
 }
 
@@ -202,17 +230,92 @@ func TestCheckRouterListening_NotListening_ServiceStopped(t *testing.T) {
 	if c.Status != "error" {
 		t.Errorf("expected error, got %s", c.Status)
 	}
-	if c.Detail != "port 8443 not listening" {
-		t.Errorf("unexpected detail: %s", c.Detail)
+}
+
+// Regression: previously the rogue check substring-matched the process name
+// against "gtl"; the binary is named "git-treeline" which does NOT contain
+// "gtl" as a substring, so the legitimate router got flagged as rogue.
+// With PID-compare, when the listener PID matches launchd's recorded PID,
+// it's our router regardless of the name.
+func TestCheckRouterListening_GitTreelineNotRogue(t *testing.T) {
+	d := allHealthy()
+	d.processOnPort = func(int) processInfo { return processInfo{Name: "git-treeline", PID: 1234} }
+	d.runningPID = func() int { return 1234 }
+
+	c := checkRouterListening(d, 8443)
+	if c.Status != "ok" {
+		t.Errorf("expected ok for matching PID, got %s (%s)", c.Status, c.Detail)
 	}
 }
 
-func TestCheckRouterListening_RogueProcess(t *testing.T) {
+func TestCheckRouterListening_PIDMismatch_Warns(t *testing.T) {
 	d := allHealthy()
-	d.processOnPort = func(int) string { return "nginx (pid 5678)" }
+	d.processOnPort = func(int) processInfo { return processInfo{Name: "nginx", PID: 5678} }
+	d.runningPID = func() int { return 1234 }
+
 	c := checkRouterListening(d, 8443)
 	if c.Status != "warn" {
-		t.Errorf("expected warn for rogue process, got %s", c.Status)
+		t.Errorf("expected warn for PID mismatch, got %s", c.Status)
+	}
+	if !strings.Contains(c.Detail, "5678") || !strings.Contains(c.Detail, "1234") {
+		t.Errorf("expected detail to mention both PIDs, got %q", c.Detail)
+	}
+	if c.Fix != "gtl serve restart" {
+		t.Errorf("expected fix to be 'gtl serve restart', got %q", c.Fix)
+	}
+}
+
+func TestCheckRouterListening_FallbackWhenLaunchdPIDUnknown(t *testing.T) {
+	// runningPID returns 0 → couldn't read launchd → fall back to a soft
+	// name check. Both "gtl" and "git-treeline" should pass.
+	for _, name := range []string{"gtl", "git-treeline"} {
+		d := allHealthy()
+		d.runningPID = func() int { return 0 }
+		d.processOnPort = func(int) processInfo { return processInfo{Name: name, PID: 9999} }
+		c := checkRouterListening(d, 8443)
+		if c.Status != "ok" {
+			t.Errorf("name=%q: expected ok, got %s (%s)", name, c.Status, c.Detail)
+		}
+	}
+
+	// Something genuinely foreign should still warn.
+	d := allHealthy()
+	d.runningPID = func() int { return 0 }
+	d.processOnPort = func(int) processInfo { return processInfo{Name: "nginx", PID: 9999} }
+	c := checkRouterListening(d, 8443)
+	if c.Status != "warn" {
+		t.Errorf("expected warn for unknown listener with unknown launchd PID, got %s", c.Status)
+	}
+}
+
+// --- checkRouterResponding ---
+
+func TestCheckRouterResponding_2xx(t *testing.T) {
+	d := allHealthy()
+	c := checkRouterResponding(d, 8443)
+	if c.Status != "ok" {
+		t.Errorf("expected ok, got %s (%s)", c.Status, c.Detail)
+	}
+}
+
+func TestCheckRouterResponding_5xx(t *testing.T) {
+	d := allHealthy()
+	d.httpProbe = fakeHTTP(503, nil)
+	c := checkRouterResponding(d, 8443)
+	if c.Status != "warn" {
+		t.Errorf("expected warn for 5xx, got %s", c.Status)
+	}
+}
+
+func TestCheckRouterResponding_TransportError(t *testing.T) {
+	d := allHealthy()
+	d.httpProbe = fakeHTTP(0, fmt.Errorf("connection refused"))
+	c := checkRouterResponding(d, 8443)
+	if c.Status != "warn" {
+		t.Errorf("expected warn for transport error, got %s", c.Status)
+	}
+	if c.Fix != "gtl serve restart" {
+		t.Errorf("expected fix to suggest restart, got %q", c.Fix)
 	}
 }
 
@@ -222,20 +325,35 @@ func TestCheckPortForward_Ok(t *testing.T) {
 	d := allHealthy()
 	c := checkPortForward(d, 8443)
 	if c.Status != "ok" {
-		t.Errorf("expected ok, got %s", c.Status)
+		t.Errorf("expected ok, got %s (%s)", c.Status, c.Detail)
 	}
 }
 
 func TestCheckPortForward_NotConfigured(t *testing.T) {
 	d := allHealthy()
-	d.isPortForwardConfigured = func() bool { return false }
+	d.checkPortForward = fakePF(false, false, false, "")
 	c := checkPortForward(d, 8443)
 	if c.Status != "warn" {
 		t.Errorf("expected warn, got %s", c.Status)
 	}
 }
 
-func TestCheckPortForward_ConfiguredButUnreachable(t *testing.T) {
+func TestCheckPortForward_ConfiguredOnDiskButNotInKernel(t *testing.T) {
+	// This is the exact failure mode the user hit: pf.conf has the
+	// rule but `pfctl -s nat` doesn't, so traffic to :443 doesn't reach
+	// the router.
+	d := allHealthy()
+	d.checkPortForward = fakePF(true, false, true, "rule not loaded in kernel — pf.conf has it but `pfctl -s nat` doesn't show port 8443 (run 'gtl serve reload-pf')")
+	c := checkPortForward(d, 8443)
+	if c.Status != "error" {
+		t.Errorf("expected error, got %s", c.Status)
+	}
+	if c.Fix != "gtl serve reload-pf" {
+		t.Errorf("expected fix to be 'gtl serve reload-pf', got %q", c.Fix)
+	}
+}
+
+func TestCheckPortForward_RuleLoadedButPort443Unreachable(t *testing.T) {
 	d := allHealthy()
 	d.dialTimeout = func(_, addr string, _ time.Duration) (net.Conn, error) {
 		if addr == "127.0.0.1:443" {
@@ -246,5 +364,8 @@ func TestCheckPortForward_ConfiguredButUnreachable(t *testing.T) {
 	c := checkPortForward(d, 8443)
 	if c.Status != "error" {
 		t.Errorf("expected error, got %s", c.Status)
+	}
+	if c.Fix != "gtl serve reload-pf" {
+		t.Errorf("expected fix to suggest reload-pf, got %q", c.Fix)
 	}
 }

--- a/internal/service/portforward.go
+++ b/internal/service/portforward.go
@@ -47,7 +47,10 @@ func UninstallPortForward() error {
 	}
 }
 
-// IsPortForwardConfigured checks whether the port 443 redirect is in place.
+// IsPortForwardConfigured checks whether the port 443 redirect is in place
+// on disk (pf.conf or iptables rules saved). Note: this can return true when
+// the rules are not actually loaded into the kernel — see PortForwardActive
+// for an authoritative check.
 func IsPortForwardConfigured() bool {
 	switch runtime.GOOS {
 	case "darwin":
@@ -60,6 +63,134 @@ func IsPortForwardConfigured() bool {
 		return isLinuxPortForwardConfigured()
 	default:
 		return false
+	}
+}
+
+// PortForwardStatus reports whether the port-forwarding rules are not just
+// configured on disk but actually loaded in the kernel right now. This is
+// what determines whether traffic to :443 will reach the router.
+type PortForwardStatus struct {
+	// ConfiguredOnDisk is true when pf.conf (macOS) or saved iptables rules
+	// (Linux) reference our redirect.
+	ConfiguredOnDisk bool
+	// LoadedInKernel is true when the running ruleset includes our redirect.
+	// On macOS this requires both pf to be enabled AND our rdr rule to be
+	// in the active anchor.
+	LoadedInKernel bool
+	// PfEnabled (macOS only) is true when `pfctl -s info` reports pf is
+	// enabled. Meaningless on Linux.
+	PfEnabled bool
+	// Detail is a one-line human-readable summary, or "" when everything is
+	// healthy.
+	Detail string
+}
+
+// CheckPortForward queries the running kernel state of our port-forwarding
+// rules. Requires sudo on macOS for full accuracy; without sudo, falls back
+// to the on-disk check and returns LoadedInKernel = false (unknown).
+//
+// routerPort is the port the rdr should forward to; used to detect a rule
+// that exists but points to the wrong port.
+func CheckPortForward(routerPort int) PortForwardStatus {
+	switch runtime.GOOS {
+	case "darwin":
+		return checkPortForwardDarwin(routerPort)
+	case "linux":
+		return checkPortForwardLinux(routerPort)
+	default:
+		return PortForwardStatus{}
+	}
+}
+
+func checkPortForwardDarwin(routerPort int) PortForwardStatus {
+	st := PortForwardStatus{ConfiguredOnDisk: IsPortForwardConfigured()}
+
+	// pfctl -s info reports the daemon's enabled/disabled state. This call
+	// does not require sudo on macOS.
+	if out, err := runCmdOutput("/sbin/pfctl", "-s", "info"); err == nil {
+		for _, line := range strings.Split(string(out), "\n") {
+			if strings.HasPrefix(strings.TrimSpace(line), "Status: Enabled") {
+				st.PfEnabled = true
+				break
+			}
+		}
+	}
+
+	// pfctl -a treeline -s nat lists the rules in our anchor. Without sudo
+	// macOS sometimes refuses; in that case we fall back to the main NAT
+	// ruleset (`pfctl -s nat`), which can also reference our anchor via a
+	// `rdr-anchor` line.
+	wantSubstr := fmt.Sprintf("port %d", routerPort)
+	if out, err := runCmdOutput("/sbin/pfctl", "-a", pfAnchorName(), "-s", "nat"); err == nil {
+		if strings.Contains(string(out), wantSubstr) {
+			st.LoadedInKernel = true
+		}
+	}
+	if !st.LoadedInKernel {
+		if out, err := runCmdOutput("/sbin/pfctl", "-s", "nat"); err == nil {
+			body := string(out)
+			if strings.Contains(body, wantSubstr) {
+				st.LoadedInKernel = true
+			}
+		}
+	}
+
+	switch {
+	case !st.ConfiguredOnDisk:
+		st.Detail = "not configured (run 'gtl serve install')"
+	case !st.PfEnabled:
+		st.Detail = "pf disabled — rules will not apply (run 'gtl serve reload-pf')"
+	case !st.LoadedInKernel:
+		st.Detail = fmt.Sprintf("rule not loaded in kernel — pf.conf has it but `pfctl -s nat` doesn't show port %d (run 'gtl serve reload-pf')", routerPort)
+	}
+	return st
+}
+
+func checkPortForwardLinux(routerPort int) PortForwardStatus {
+	st := PortForwardStatus{ConfiguredOnDisk: IsPortForwardConfigured()}
+	out, err := runCmdOutput("/sbin/iptables", "-t", "nat", "-L", "OUTPUT", "-n")
+	if err != nil {
+		if !st.ConfiguredOnDisk {
+			st.Detail = "not configured"
+		} else {
+			st.Detail = "could not read iptables (need root or CAP_NET_ADMIN)"
+		}
+		return st
+	}
+	body := string(out)
+	if strings.Contains(body, "git-treeline") &&
+		strings.Contains(body, fmt.Sprintf("ports %d", routerPort)) {
+		st.LoadedInKernel = true
+	}
+	if !st.LoadedInKernel && st.ConfiguredOnDisk {
+		st.Detail = "iptables rule missing in current ruleset (run 'gtl serve reload-pf')"
+	}
+	return st
+}
+
+// ReloadPortForward re-applies the port-forwarding rules from disk into the
+// running kernel ruleset. Useful after a reboot/network change wiped them
+// without changing pf.conf or iptables-save state.
+//
+// macOS requires sudo. Linux uses the same mechanism as install (currently
+// re-running iptables rules); we delegate to the same install path because
+// it is idempotent.
+func ReloadPortForward() error {
+	switch runtime.GOOS {
+	case "darwin":
+		return reloadPf()
+	case "linux":
+		// Linux installs iptables rules directly; reapplying them is the
+		// only "reload" available. The install function already short-
+		// circuits when rules are present, but we want it to reapply
+		// unconditionally — the linux install path is idempotent so we
+		// just call it again.
+		// We don't have the routerPort here, so the caller should use
+		// InstallPortForward(routerPort) instead. ReloadPortForward is
+		// macOS-focused; on Linux we return a hint.
+		return fmt.Errorf("on Linux, run 'gtl serve install' to reapply iptables rules")
+	default:
+		return fmt.Errorf("port forwarding not supported on %s", runtime.GOOS)
 	}
 }
 

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -13,9 +13,33 @@ import (
 	"runtime"
 	"strings"
 	"text/template"
+	"time"
 
 	"github.com/git-treeline/cli/internal/platform"
 )
+
+// runCmd executes a command and returns its error. Overridable for tests so
+// service-management code can be exercised without touching launchctl/systemctl.
+var runCmd = func(name string, args ...string) error {
+	return exec.Command(name, args...).Run()
+}
+
+// runCmdOutput executes a command and returns combined stdout+stderr.
+// Overridable for tests.
+var runCmdOutput = func(name string, args ...string) ([]byte, error) {
+	return exec.Command(name, args...).CombinedOutput()
+}
+
+// nowFn / sleepFn are overridable so bounce-verification can be tested
+// without real time passing.
+var (
+	nowFn   = time.Now
+	sleepFn = time.Sleep
+)
+
+// DefaultBounceTimeout is the default deadline for verifying that a bounced
+// router has come back up (i.e. written its version file).
+const DefaultBounceTimeout = 5 * time.Second
 
 // StableExecutablePath returns a path suitable for embedding in a service
 // definition (launchd plist, systemd unit). On Homebrew installs,
@@ -102,14 +126,190 @@ func Uninstall() error {
 func IsRunning() bool {
 	switch runtime.GOOS {
 	case "darwin":
-		out, err := exec.Command("launchctl", "list", LaunchLabel()).CombinedOutput()
+		out, err := runCmdOutput("launchctl", "list", LaunchLabel())
 		return err == nil && len(out) > 0
 	case "linux":
-		err := exec.Command("systemctl", "--user", "is-active", "--quiet", SystemdUnit()).Run()
+		err := runCmd("systemctl", "--user", "is-active", "--quiet", SystemdUnit())
 		return err == nil
 	default:
 		return false
 	}
+}
+
+// RunningPID returns the PID of the running service process, or 0 if it
+// cannot be determined. On macOS, parses `launchctl print` output for the
+// authoritative PID launchd has registered for our label. On Linux, reads
+// the MainPID from `systemctl --user show`.
+func RunningPID() int {
+	switch runtime.GOOS {
+	case "darwin":
+		return runningPIDDarwin()
+	case "linux":
+		return runningPIDLinux()
+	default:
+		return 0
+	}
+}
+
+func runningPIDDarwin() int {
+	out, err := runCmdOutput("launchctl", "print", launchTarget())
+	if err != nil {
+		return 0
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		// Format: "pid = 12345"
+		if !strings.HasPrefix(line, "pid") {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) >= 3 && fields[0] == "pid" && fields[1] == "=" {
+			var pid int
+			if _, err := fmt.Sscanf(fields[2], "%d", &pid); err == nil {
+				return pid
+			}
+		}
+	}
+	return 0
+}
+
+func runningPIDLinux() int {
+	out, err := runCmdOutput("systemctl", "--user", "show", "--property=MainPID", "--value", SystemdUnit())
+	if err != nil {
+		return 0
+	}
+	var pid int
+	if _, err := fmt.Sscanf(strings.TrimSpace(string(out)), "%d", &pid); err == nil {
+		return pid
+	}
+	return 0
+}
+
+// launchTarget returns the launchd domain target for our service,
+// e.g. "gui/501/dev.treeline.router". Used for kickstart, print, bootout.
+func launchTarget() string {
+	return fmt.Sprintf("gui/%d/%s", os.Getuid(), LaunchLabel())
+}
+
+// launchDomain returns just the user domain, e.g. "gui/501". Used for
+// `launchctl bootstrap <domain> <plist>`.
+func launchDomain() string {
+	return fmt.Sprintf("gui/%d", os.Getuid())
+}
+
+// Bounce restarts the running router service so it picks up changes that
+// don't require a new service definition (e.g. the `gtl` binary on disk has
+// been upgraded by Homebrew, but the launchd-managed process is still the
+// old build). On macOS this is `launchctl kickstart -k`; on Linux it is
+// `systemctl --user restart`.
+//
+// Bounce verifies the restart by waiting for the router to write a fresh
+// `router.version` file. Returns an error if no new write is observed
+// within `wait`.
+//
+// Use Reload (not Bounce) when the service definition itself changed.
+func Bounce(wait time.Duration) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return bounceLaunchAgent(wait)
+	case "linux":
+		return bounceSystemd(wait)
+	default:
+		return fmt.Errorf("bounce not supported on %s", runtime.GOOS)
+	}
+}
+
+// Reload tears down the existing service registration and re-registers it
+// from the on-disk service definition. Use this after writing a new plist
+// or systemd unit so launchd/systemd actually pick up the changes.
+//
+// On macOS that's `launchctl bootout` followed by `launchctl bootstrap`.
+// On Linux that's `systemctl --user daemon-reload` followed by `restart`.
+func Reload(wait time.Duration) error {
+	switch runtime.GOOS {
+	case "darwin":
+		return reloadLaunchAgent(wait)
+	case "linux":
+		return reloadSystemd(wait)
+	default:
+		return fmt.Errorf("reload not supported on %s", runtime.GOOS)
+	}
+}
+
+// versionFileMtime returns the mtime of the running router's version file,
+// or the zero time if the file doesn't exist.
+func versionFileMtime() time.Time {
+	info, err := os.Stat(RouterVersionFile())
+	if err != nil {
+		return time.Time{}
+	}
+	return info.ModTime()
+}
+
+// waitForFreshVersion polls until the router.version file has been
+// (re)written after `before`, or until `wait` elapses.
+func waitForFreshVersion(before time.Time, wait time.Duration) error {
+	deadline := nowFn().Add(wait)
+	for {
+		if mt := versionFileMtime(); !mt.IsZero() && mt.After(before) {
+			return nil
+		}
+		if !nowFn().Before(deadline) {
+			break
+		}
+		sleepFn(100 * time.Millisecond)
+	}
+	return fmt.Errorf("router did not record a new version within %s — check logs at %s", wait, logDir())
+}
+
+func bounceLaunchAgent(wait time.Duration) error {
+	target := launchTarget()
+	before := versionFileMtime()
+	// If the agent isn't loaded yet (e.g. fresh install), kickstart will
+	// fail. Fall back to bootstrap so first-time callers don't hit a wall.
+	if err := runCmd("launchctl", "print", target); err != nil {
+		return reloadLaunchAgent(wait)
+	}
+	if err := runCmd("launchctl", "kickstart", "-k", target); err != nil {
+		return fmt.Errorf("launchctl kickstart: %w", err)
+	}
+	return waitForFreshVersion(before, wait)
+}
+
+func reloadLaunchAgent(wait time.Duration) error {
+	plist := PlistPath()
+	if _, err := os.Stat(plist); err != nil {
+		return fmt.Errorf("plist not found at %s — run 'gtl serve install' first", plist)
+	}
+	target := launchTarget()
+	before := versionFileMtime()
+	// bootout removes the existing registration. Errors are swallowed
+	// because it returns non-zero when the service isn't currently
+	// loaded — that's fine, we're about to bootstrap.
+	_ = runCmd("launchctl", "bootout", target)
+	if err := runCmd("launchctl", "bootstrap", launchDomain(), plist); err != nil {
+		return fmt.Errorf("launchctl bootstrap %s: %w", plist, err)
+	}
+	return waitForFreshVersion(before, wait)
+}
+
+func bounceSystemd(wait time.Duration) error {
+	before := versionFileMtime()
+	if err := runCmd("systemctl", "--user", "restart", SystemdUnit()); err != nil {
+		return fmt.Errorf("systemctl restart: %w", err)
+	}
+	return waitForFreshVersion(before, wait)
+}
+
+func reloadSystemd(wait time.Duration) error {
+	before := versionFileMtime()
+	if err := runCmd("systemctl", "--user", "daemon-reload"); err != nil {
+		return fmt.Errorf("systemctl daemon-reload: %w", err)
+	}
+	if err := runCmd("systemctl", "--user", "restart", SystemdUnit()); err != nil {
+		return fmt.Errorf("systemctl restart: %w", err)
+	}
+	return waitForFreshVersion(before, wait)
 }
 
 // RouterVersionFile returns the path to the file where the running router
@@ -201,16 +401,16 @@ func installLaunchAgent(gtlPath string, _ int) (string, error) {
 		return "", err
 	}
 
-	_ = exec.Command("launchctl", "unload", path).Run()
-	if err := exec.Command("launchctl", "load", path).Run(); err != nil {
-		return path, fmt.Errorf("wrote plist but failed to load: %w", err)
+	if err := Reload(DefaultBounceTimeout); err != nil {
+		return path, fmt.Errorf("wrote plist but service did not come up: %w", err)
 	}
 	return path, nil
 }
 
 func uninstallLaunchAgent() error {
 	path := PlistPath()
-	_ = exec.Command("launchctl", "unload", path).Run()
+	// Best-effort bootout — non-zero exit when not loaded is fine.
+	_ = runCmd("launchctl", "bootout", launchTarget())
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return err
 	}
@@ -315,23 +515,25 @@ func installSystemd(gtlPath string, _ int) (string, error) {
 		return "", err
 	}
 
-	_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
-	if err := exec.Command("systemctl", "--user", "enable", "--now", SystemdUnit()).Run(); err != nil {
+	if err := runCmd("systemctl", "--user", "daemon-reload"); err != nil {
+		return path, fmt.Errorf("wrote unit but daemon-reload failed: %w", err)
+	}
+	if err := runCmd("systemctl", "--user", "enable", "--now", SystemdUnit()); err != nil {
 		return path, fmt.Errorf("wrote unit but failed to enable: %w", err)
 	}
-	if err := exec.Command("systemctl", "--user", "restart", SystemdUnit()).Run(); err != nil {
-		return path, fmt.Errorf("wrote unit but failed to restart: %w", err)
+	if err := Reload(DefaultBounceTimeout); err != nil {
+		return path, fmt.Errorf("wrote unit but service did not come up: %w", err)
 	}
 	return path, nil
 }
 
 func uninstallSystemd() error {
-	_ = exec.Command("systemctl", "--user", "disable", "--now", SystemdUnit()).Run()
+	_ = runCmd("systemctl", "--user", "disable", "--now", SystemdUnit())
 	path := UnitPath()
 	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
+	_ = runCmd("systemctl", "--user", "daemon-reload")
 	return nil
 }
 

--- a/scripts/smoke/doctor-serve-overhaul.sh
+++ b/scripts/smoke/doctor-serve-overhaul.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Smoke test for the doctor/serve overhaul branch.
+#
+# Run AFTER `go install ./...` (or after `brew upgrade git-treeline`) on a
+# real macOS machine with the router previously installed via
+# `gtl serve install`. Each step prints what it's verifying and pauses so
+# you can eyeball the output.
+#
+# Not run in CI — these tests intentionally touch launchctl and pf.
+
+set -euo pipefail
+
+step() { printf "\n\033[1;34m▸ %s\033[0m\n" "$*"; }
+pause() { read -r -p "  Press enter to continue, or Ctrl-C to abort..." _; }
+
+step "1. gtl serve restart should kickstart the router (no sudo, fast)"
+gtl serve restart
+pause
+
+step "2. gtl serve status should show the new pid and version"
+gtl serve status | head -20
+pause
+
+step "3. gtl doctor should NOT flag the running router as a 'rogue process'"
+echo "  (regression check: previously substring-matched 'gtl' against 'git-treeline')"
+gtl doctor | grep -A2 "Router port" || true
+pause
+
+step "4. gtl doctor's Request flow section should call out the FIRST failure"
+echo "  Stop the dev server in another terminal first if you want to see this fail."
+gtl doctor | sed -n '/Request flow/,$p'
+pause
+
+step "5. gtl serve reload-pf reloads pf rules without rewriting the plist"
+gtl serve reload-pf
+pause
+
+step "6. gtl registry validate (read-only) reports issues, exit 0 when clean"
+gtl registry validate || echo "  exit \$? = $?"
+pause
+
+step "7. gtl reallocate (dry-run by default) on the current dir"
+gtl reallocate
+pause
+
+step "8. PersistentPreRun stale warning"
+echo "  Forge a stale router.version to confirm the warning fires:"
+VERSION_FILE="$(gtl config path 2>/dev/null | sed 's|config.json|router.version|')"
+ORIG="$(cat "$VERSION_FILE" 2>/dev/null || echo "")"
+echo "  saved: $ORIG"
+echo "0.0.0" > "$VERSION_FILE"
+echo "  ↓ should print a warning before any output:"
+gtl status 2>&1 | head -5 || true
+echo "$ORIG" > "$VERSION_FILE"
+pause
+
+step "9. doctor --fix dry-runs the remediation (read-only when nothing to fix)"
+gtl doctor --fix | sed -n '/Auto-fix/,$p'
+
+echo
+echo "Smoke checks complete."


### PR DESCRIPTION
## Summary

Fixes a stack of issues exposed when a hard reboot dropped pf rules and a `brew upgrade` left the router running an older build. The user ran \`gtl serve install\` and nothing changed; the doctor flagged the legitimate router as a "rogue process"; \`gtl prune --stale\` then helpfully deleted 21 legitimate Conductor workspaces from the registry. Each problem in this branch is one of those incidents.

Phases land as separate commits on this branch — see \`git log feature/doctor-serve-overhaul\` — but ship together as v0.40.0.

### What's fixed

- **\`gtl serve restart\`** — fast bounce via \`launchctl kickstart -k\` (or \`systemctl --user restart\`). No sudo. Replaces the silent \`launchctl unload\`/\`load\` pair that was the root cause of "ran serve install and nothing changed."
- **\`gtl serve reload-pf\`** — targeted pf reload after a reboot, no full \`serve install\` needed.
- **Doctor now actually verifies things.** PID compare against \`launchctl print\`, real HTTP liveness probe (\`/_treeline/health\`), kernel-level pf check (\`pfctl -s nat\`).
- **Doctor: Request flow** — new section walks app→router→pf→CA and surfaces the first failure as the actionable diagnosis.
- **Doctor: app-not-listening prints \`commands.start\`** as the fix.
- **\`gtl doctor --fix\`** auto-runs the remediations doctor was already hinting at.
- **\`gtl reallocate\`** — bulk re-runs setup. Defaults to dry-run.
- **\`gtl registry validate\` / \`repair\` / \`forget\`** — read-only audit, safe auto-repair (with backup), single-entry removal.
- **\`gtl prune --stale\` stops nuking Conductor clones.** Distinguishes worktrees (.git is a file) from standalone clones (.git is a dir) and only applies the worktree-list check to actual worktrees.
- **Every \`gtl <cmd>\` warns when the running router is stale**, suppressed for self-repairing commands and via \`GTL_NO_STALE_WARN=1\`.

### What's deferred (follow-ups, captured in PR)

- **pf reboot survival via a LaunchDaemon.** Cleanly implementing this needs a sudo install path and a privileged reload helper — bigger than this branch should carry. \`gtl serve reload-pf\` is the one-liner recovery in the meantime.
- **Brew \`post_install\` hook** to auto-run \`gtl serve restart\` after upgrade. Requires changes in the separate \`git-treeline/homebrew-tap\` repo, not this one.

## Test plan

### Automated (CI runs all of this)

- [x] \`go test ./...\` passes
- [x] \`go vet ./...\` clean
- [x] New unit tests cover: kickstart bounce + reload, version-file mtime polling, RunningPID parsing, doctor PID compare (regression: \"git-treeline\" not flagged), doctor pf kernel checks, evaluateRequestFlow priority order, autoFix planner dedup, registry Validate (orphans, duplicate ports, duplicate branches, missing ports), \`PruneStale\` standalone-clone preservation, reallocate scanning at Conductor depth, \`shouldWarnStaleRouter\` suppression matrix.

### Manual (run on a real macOS machine before merge)

- [ ] \`bash scripts/smoke/doctor-serve-overhaul.sh\` — guided 9-step verification touching launchctl + pf for real
- [ ] After install: \`gtl serve restart\` returns in <2s and \`gtl serve status\` shows the new PID
- [ ] After install: visit a working \`*.prt.dev\` URL, confirm the router answers
- [ ] After install: kill pf rules manually (\`sudo pfctl -F all\`), \`gtl serve reload-pf\` brings them back
- [ ] After install: doctor against a worktree whose dev server is stopped → Request flow surfaces \`commands.start\` as the fix
- [ ] \`gtl registry validate\` reports nothing on a healthy registry; reports orphan after \`rm -rf\` of a workspace dir

## Phasing on this branch

1. \`d5dcfde\` — kickstart bounce + serve restart, doctor PID compare and liveness probe
2. \`30a4557\` — doctor ordered request-flow diagnosis + commands.start as fix
3. \`f0fa84b\` — registry validate / repair / reallocate / forget; fix prune --stale
4. \`703cb51\` — root-level stale-router warning
5. \`81e662c\` — doctor --fix
6. \`54891e5\` — CHANGELOG + smoke script