### PR TITLE
0.40.1: pf reboot survival, brew post_install, serve status truthful

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -35,6 +35,12 @@ brews:
 
       generate_completions_from_executable(bin/"git-treeline", "completion")
       generate_completions_from_executable(bin/"git-treeline", "completion", base_name: "gtl")
+    post_install: |
+      # If the user previously installed the HTTPS router service, bounce it
+      # so the launchd-managed process picks up the new gtl binary. The
+      # --if-installed flag makes this a no-op for users who never ran
+      # 'gtl serve install', so first-time brew installs stay quiet.
+      system bin/"gtl", "serve", "restart", "--if-installed"
     caveats: |
       Get started:
         cd your-project && gtl install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.40.1]
+
+- **pf rules now survive a reboot.** `gtl serve install` ships a small LaunchDaemon at `/Library/LaunchDaemons/dev.treeline.pfreload.plist` that re-runs `pfctl -ef /etc/pf.conf` at boot. Apple's own pf service loads the rules but does NOT enable pf — without our daemon, the redirect from :443 to the router silently broke after every reboot until the user manually ran `sudo pfctl -ef`. The daemon invokes Apple's signed `/sbin/pfctl` directly (no Treeline binary in the boot path → no notarization or code-signing concerns). `gtl serve uninstall` removes it cleanly.
+- **`gtl doctor` warns when the boot-time pf reloader is missing**, so users upgrading from v0.40.0 see exactly what to run (`gtl serve install`) to get the new daemon.
+- **`gtl serve restart --if-installed`** — tooling-friendly variant that no-ops with exit 0 when the router service has not been installed for the current user.
+- **Brew `post_install` auto-bounces the router on `brew upgrade`.** Wired via the `.goreleaser.yml` `brews.post_install` directive: after the new binary lands at `/opt/homebrew/bin/gtl`, brew runs `gtl serve restart --if-installed`. Users who installed serve get the new code running immediately; first-time installers stay quiet (the `--if-installed` no-op).
+- **`gtl serve status` uses the same kernel-aware port-forwarding check as the doctor.** Previously it read `pf.conf` on disk and lied "active" while pf was actually disabled — the bug that masked the post-reboot outage. Distinguishes "we read pf state and it's disabled" from "we couldn't read pf state without sudo," so we never silently report a false "pf disabled" alarm on macOS Sequoia.
+
 ## [0.40.0]
 
 - **Doctor & serve overhaul** — fixes a stack of issues exposed when a hard reboot dropped pf rules and a `brew upgrade` left the router running an older build. Most-impactful changes:

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -439,6 +439,7 @@ func doctorServe() {
 		"router_port":       "Router port",
 		"router_responding": "Router responding",
 		"port_forwarding":   "Port forwarding",
+		"pf_reload_daemon":  "pf reboot survival",
 	}
 
 	checks := service.CheckHealth(port, Version)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -238,6 +238,16 @@ func runServeInstall(uc *config.UserConfig) error {
 		fmt.Fprintln(os.Stderr, style.Warnf("port forwarding skipped: %v", err))
 		fmt.Fprintln(os.Stderr, style.Dimf("  URLs will require a port number: https://{branch}.%s:%d", domain, port))
 		fmt.Println()
+	} else {
+		// macOS resets pf state on reboot — without our LaunchDaemon, the
+		// rdr rule is on disk but pf is disabled until the user manually
+		// runs `gtl serve reload-pf`. The daemon makes the redirect
+		// survive reboots without intervention. macOS-only; no-op on Linux.
+		if err := service.InstallPfReloadDaemon(); err != nil {
+			fmt.Fprintln(os.Stderr, style.Warnf("boot-time pf reloader install skipped: %v", err))
+			fmt.Fprintln(os.Stderr, style.Dimf("  After reboot, run 'gtl serve reload-pf' manually."))
+			fmt.Println()
+		}
 	}
 
 	if _, err := service.Install(gtlPath, port); err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -179,6 +179,14 @@ var serveUninstallCmd = &cobra.Command{
 			}
 		}
 
+		if service.IsPfReloadDaemonInstalled() {
+			if err := service.UninstallPfReloadDaemon(); err != nil {
+				fmt.Fprintln(os.Stderr, style.Warnf("could not remove boot-time pf reloader: %v", err))
+			} else {
+				fmt.Println("Boot-time pf reloader removed.")
+			}
+		}
+
 		if err := proxy.UntrustCA(); err != nil {
 			fmt.Fprintln(os.Stderr, style.Warnf("could not remove CA trust: %v", err))
 		} else {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -38,6 +38,7 @@ func init() {
 	serveCmd.AddCommand(serveInstallCmd)
 	serveCmd.AddCommand(serveUninstallCmd)
 	serveRestartCmd.Flags().BoolVar(&serveRestartReloadPF, "pf", false, "Also reload pf rules (port forwarding)")
+	serveRestartCmd.Flags().BoolVar(&serveRestartIfInstalled, "if-installed", false, "No-op if the router service is not installed for this user")
 	serveCmd.AddCommand(serveRestartCmd)
 	serveCmd.AddCommand(serveReloadPFCmd)
 	serveCmd.AddCommand(serveStatusCmd)
@@ -50,7 +51,10 @@ func init() {
 	rootCmd.AddCommand(serveCmd)
 }
 
-var serveRestartReloadPF bool
+var (
+	serveRestartReloadPF   bool
+	serveRestartIfInstalled bool
+)
 
 var serveRestartCmd = &cobra.Command{
 	Use:   "restart",
@@ -60,12 +64,25 @@ upgrade of the gtl binary. Cheaper and faster than 'gtl serve install' —
 no sudo, no plist rewrite, no pf reload.
 
 Pass --pf to also reload port-forwarding rules (useful after a reboot
-that dropped them).`,
+that dropped them).
+
+Pass --if-installed to no-op when the router service has not been
+installed for the current user (intended for tooling integrations like
+the Homebrew post_install hook — bouncing something that doesn't exist
+should not be an error).`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if runtime.GOOS != "darwin" && runtime.GOOS != "linux" {
+			if serveRestartIfInstalled {
+				// Tooling-friendly no-op on unsupported platforms.
+				return nil
+			}
 			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("gtl serve restart requires macOS or Linux (detected %s).", runtime.GOOS),
 			})
+		}
+		if serveRestartIfInstalled && !service.IsInstalled() {
+			fmt.Println(style.Dimf("Router service not installed for this user — skipping restart."))
+			return nil
 		}
 		fmt.Println(style.Actionf("Restarting router service..."))
 		if err := service.Bounce(service.DefaultBounceTimeout); err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -183,7 +183,7 @@ var serveStatusCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		uc := config.LoadUserConfig("")
 		port := uc.RouterPort()
-		portFwd := service.IsPortForwardConfigured()
+		pfStatus := service.CheckPortForward(port)
 		caInstalled := proxy.IsCAInstalled()
 
 		if service.IsRunning() {
@@ -199,11 +199,7 @@ var serveStatusCmd = &cobra.Command{
 			fmt.Println("CA: not installed (run 'gtl serve install')")
 		}
 
-		if portFwd {
-			fmt.Println("Port forwarding: active (443 → router)")
-		} else {
-			fmt.Println("Port forwarding: not configured")
-		}
+		fmt.Println(formatPortForwardStatus(pfStatus, port))
 
 		domain := uc.RouterDomain()
 		reg := registry.New("")
@@ -229,7 +225,7 @@ var serveStatusCmd = &cobra.Command{
 
 		fmt.Printf("\nRoutes (%d):\n", len(routes))
 		for _, key := range sortedRouteKeys(routes) {
-			if portFwd {
+			if pfStatus.ConfiguredOnDisk {
 				fmt.Printf("  %s://%s.%s → :%d\n", scheme, key, domain, routes[key])
 			} else {
 				fmt.Printf("  %s://%s.%s:%d → :%d\n", scheme, key, domain, port, routes[key])
@@ -294,6 +290,32 @@ func projectAliases(reg *registry.Registry) proxy.AliasSource {
 			}
 		}
 		return merged
+	}
+}
+
+// formatPortForwardStatus returns the single-line "Port forwarding: ..."
+// string used by `gtl serve status`. Distinct from the doctor's check —
+// status is for at-a-glance reading, doctor is for diagnosis. Both pull
+// from the same kernel-level CheckPortForward.
+//
+// Important: never report "pf disabled" or "rule missing" unless we
+// actually read the relevant state. Without sudo on modern macOS, both
+// `pfctl -s info` and `pfctl -s nat` may error — silently treating those
+// failures as "disabled/missing" is the bug this helper exists to avoid.
+func formatPortForwardStatus(st service.PortForwardStatus, routerPort int) string {
+	switch {
+	case !st.ConfiguredOnDisk:
+		return "Port forwarding: not configured"
+	case st.PfStateKnown && !st.PfEnabled:
+		return "Port forwarding: ⚠ configured but pf is disabled (run 'gtl serve reload-pf')"
+	case !st.PfStateKnown && !st.KernelStateKnown:
+		return fmt.Sprintf("Port forwarding: configured (443 → %d, run with sudo or 'gtl doctor' for kernel-state verification)", routerPort)
+	case !st.KernelStateKnown:
+		return fmt.Sprintf("Port forwarding: configured (443 → %d, kernel ruleset not readable without sudo)", routerPort)
+	case !st.LoadedInKernel:
+		return "Port forwarding: ⚠ pf.conf has the rule but the kernel ruleset doesn't (run 'gtl serve reload-pf')"
+	default:
+		return fmt.Sprintf("Port forwarding: active (443 → %d)", routerPort)
 	}
 }
 

--- a/cmd/serve_test.go
+++ b/cmd/serve_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/git-treeline/cli/internal/service"
+)
+
+func TestFormatPortForwardStatus_NotConfigured(t *testing.T) {
+	got := formatPortForwardStatus(service.PortForwardStatus{}, 3001)
+	if !strings.Contains(got, "not configured") {
+		t.Errorf("got %q", got)
+	}
+}
+
+func TestFormatPortForwardStatus_PfDisabled(t *testing.T) {
+	got := formatPortForwardStatus(service.PortForwardStatus{
+		ConfiguredOnDisk: true,
+		PfStateKnown:     true,
+		PfEnabled:        false,
+	}, 3001)
+	if !strings.Contains(got, "pf is disabled") {
+		t.Errorf("expected pf-disabled message, got %q", got)
+	}
+	if !strings.Contains(got, "reload-pf") {
+		t.Errorf("expected reload-pf hint, got %q", got)
+	}
+}
+
+// The exact scenario observed on macOS Sequoia without sudo: neither
+// pfctl -s info nor pfctl -s nat returns useful output. Status must NOT
+// claim pf is disabled — that is just as misleading as the previous
+// "Port forwarding: active" lie.
+func TestFormatPortForwardStatus_PfStateUnknown(t *testing.T) {
+	got := formatPortForwardStatus(service.PortForwardStatus{
+		ConfiguredOnDisk: true,
+		PfStateKnown:     false,
+		KernelStateKnown: false,
+	}, 3001)
+	if strings.Contains(got, "disabled") {
+		t.Errorf("must not claim pf disabled when state unknown, got %q", got)
+	}
+	if !strings.Contains(got, "sudo") {
+		t.Errorf("expected sudo note, got %q", got)
+	}
+}
+
+func TestFormatPortForwardStatus_KernelUnknown_NoFalseAlarm(t *testing.T) {
+	// pfctl -s info worked (PfStateKnown) but the per-anchor query needs
+	// sudo. Status should NOT scream that the rule is missing.
+	got := formatPortForwardStatus(service.PortForwardStatus{
+		ConfiguredOnDisk: true,
+		PfStateKnown:     true,
+		PfEnabled:        true,
+		KernelStateKnown: false,
+	}, 3001)
+	if strings.Contains(got, "⚠") || strings.Contains(got, "missing") {
+		t.Errorf("kernel-unknown should not warn-flag, got %q", got)
+	}
+	if !strings.Contains(got, "not readable without sudo") {
+		t.Errorf("expected sudo note in detail, got %q", got)
+	}
+}
+
+func TestFormatPortForwardStatus_RuleMissingFromKernel(t *testing.T) {
+	got := formatPortForwardStatus(service.PortForwardStatus{
+		ConfiguredOnDisk: true,
+		PfStateKnown:     true,
+		PfEnabled:        true,
+		KernelStateKnown: true,
+		LoadedInKernel:   false,
+	}, 3001)
+	if !strings.Contains(got, "⚠") {
+		t.Errorf("expected warning marker, got %q", got)
+	}
+	if !strings.Contains(got, "reload-pf") {
+		t.Errorf("expected reload-pf hint, got %q", got)
+	}
+}
+
+func TestFormatPortForwardStatus_Active(t *testing.T) {
+	got := formatPortForwardStatus(service.PortForwardStatus{
+		ConfiguredOnDisk: true,
+		PfStateKnown:     true,
+		PfEnabled:        true,
+		KernelStateKnown: true,
+		LoadedInKernel:   true,
+	}, 3001)
+	if !strings.Contains(got, "active (443 → 3001)") {
+		t.Errorf("expected active message, got %q", got)
+	}
+	if strings.Contains(got, "⚠") {
+		t.Errorf("active should not warn, got %q", got)
+	}
+}

--- a/internal/service/bounce_test.go
+++ b/internal/service/bounce_test.go
@@ -322,6 +322,27 @@ func TestRunningPIDDarwin_ParsesLaunchctlOutput(t *testing.T) {
 	}
 }
 
+func TestIsInstalled_DarwinReturnsTrueWhenPlistExists(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only")
+	}
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	if IsInstalled() {
+		t.Fatal("expected IsInstalled=false with no plist")
+	}
+	plist := PlistPath()
+	if err := os.MkdirAll(filepath.Dir(plist), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(plist, []byte("<plist/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !IsInstalled() {
+		t.Fatal("expected IsInstalled=true once plist exists")
+	}
+}
+
 func TestRunningPIDDarwin_ZeroOnError(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("darwin-only")

--- a/internal/service/health.go
+++ b/internal/service/health.go
@@ -27,30 +27,34 @@ type processInfo struct {
 }
 
 type healthDeps struct {
-	isRunning               func() bool
-	installedBinaryPath     func() string
-	runningRouterVersion    func() string
-	runningPID              func() int
-	isPortForwardConfigured func() bool
-	checkPortForward        func(routerPort int) PortForwardStatus
-	dialTimeout             func(network, address string, timeout time.Duration) (net.Conn, error)
-	httpProbe               func(url string, timeout time.Duration) (int, error)
-	executable              func() (string, error)
-	processOnPort           func(port int) processInfo
+	isRunning                  func() bool
+	installedBinaryPath        func() string
+	runningRouterVersion       func() string
+	runningPID                 func() int
+	isPortForwardConfigured    func() bool
+	checkPortForward           func(routerPort int) PortForwardStatus
+	dialTimeout                func(network, address string, timeout time.Duration) (net.Conn, error)
+	httpProbe                  func(url string, timeout time.Duration) (int, error)
+	executable                 func() (string, error)
+	processOnPort              func(port int) processInfo
+	isPfReloadDaemonInstalled  func() bool
+	pfReloadDaemonSupported    bool
 }
 
 func defaultHealthDeps() healthDeps {
 	return healthDeps{
-		isRunning:               IsRunning,
-		installedBinaryPath:     InstalledBinaryPath,
-		runningRouterVersion:    RunningRouterVersion,
-		runningPID:              RunningPID,
-		isPortForwardConfigured: IsPortForwardConfigured,
-		checkPortForward:        CheckPortForward,
-		dialTimeout:             net.DialTimeout,
-		httpProbe:               httpProbe,
-		executable:              os.Executable,
-		processOnPort:           processOnPort,
+		isRunning:                  IsRunning,
+		installedBinaryPath:        InstalledBinaryPath,
+		runningRouterVersion:       RunningRouterVersion,
+		runningPID:                 RunningPID,
+		isPortForwardConfigured:    IsPortForwardConfigured,
+		checkPortForward:           CheckPortForward,
+		dialTimeout:                net.DialTimeout,
+		httpProbe:                  httpProbe,
+		executable:                 os.Executable,
+		processOnPort:              processOnPort,
+		isPfReloadDaemonInstalled:  IsPfReloadDaemonInstalled,
+		pfReloadDaemonSupported:    runtime.GOOS == "darwin",
 	}
 }
 
@@ -68,8 +72,39 @@ func checkHealthWith(d healthDeps, routerPort int, cliVersion string) []HealthCh
 	checks = append(checks, checkRouterListening(d, routerPort))
 	checks = append(checks, checkRouterResponding(d, routerPort))
 	checks = append(checks, checkPortForward(d, routerPort))
+	if d.pfReloadDaemonSupported {
+		checks = append(checks, checkPfReloadDaemon(d))
+	}
 
 	return checks
+}
+
+// checkPfReloadDaemon flags the absence of the boot-time pf reloader when
+// port forwarding is otherwise configured. Without the daemon, pf rules
+// drop on every reboot and the user has to manually run
+// `gtl serve reload-pf`. macOS-only.
+func checkPfReloadDaemon(d healthDeps) HealthCheck {
+	if !d.isPortForwardConfigured() {
+		// No pf rules to keep alive across reboots — daemon is irrelevant.
+		return HealthCheck{
+			Name:   "pf_reload_daemon",
+			Status: "ok",
+			Detail: "n/a (port forwarding not configured)",
+		}
+	}
+	if !d.isPfReloadDaemonInstalled() {
+		return HealthCheck{
+			Name:   "pf_reload_daemon",
+			Status: "warn",
+			Detail: "missing — pf rules will drop on reboot",
+			Fix:    "gtl serve install",
+		}
+	}
+	return HealthCheck{
+		Name:   "pf_reload_daemon",
+		Status: "ok",
+		Detail: "installed (pf rules survive reboot)",
+	}
 }
 
 func checkServiceRegistered(d healthDeps) HealthCheck {

--- a/internal/service/health.go
+++ b/internal/service/health.go
@@ -266,7 +266,11 @@ func checkPortForward(d healthDeps, routerPort int) HealthCheck {
 			Fix:    "gtl serve install",
 		}
 	}
-	if !st.LoadedInKernel {
+	// pf disabled is a definite failure — rules can't apply. The "couldn't
+	// even read pf state" case falls through to a port 443 dial below as
+	// the authoritative signal. Linux ignores PfStateKnown (it's macOS-
+	// specific) but its branch sets KernelStateKnown=true on success.
+	if st.PfStateKnown && !st.PfEnabled {
 		return HealthCheck{
 			Name:   "port_forwarding",
 			Status: "error",
@@ -274,17 +278,33 @@ func checkPortForward(d healthDeps, routerPort int) HealthCheck {
 			Fix:    "gtl serve reload-pf",
 		}
 	}
-	// Rules are loaded — verify port 443 actually accepts connections.
+	// We know pf is enabled (or its state is unknown) — verify port 443
+	// actually accepts connections. This dial is the most reliable signal
+	// when we couldn't read the kernel ruleset without sudo.
 	conn, err := d.dialTimeout("tcp", "127.0.0.1:443", 2*time.Second)
 	if err != nil {
+		// Port 443 not reachable. If we read the kernel ruleset and it
+		// didn't show our rule, the diagnosis is "rule missing"; otherwise
+		// it's "loaded but unreachable" — both fix with reload-pf.
+		detail := "rule loaded but port 443 not reachable"
+		if st.KernelStateKnown && !st.LoadedInKernel {
+			detail = st.Detail
+		}
 		return HealthCheck{
 			Name:   "port_forwarding",
 			Status: "error",
-			Detail: "rule loaded but port 443 not reachable",
+			Detail: detail,
 			Fix:    "gtl serve reload-pf",
 		}
 	}
 	_ = conn.Close()
+	if !st.KernelStateKnown {
+		return HealthCheck{
+			Name:   "port_forwarding",
+			Status: "ok",
+			Detail: fmt.Sprintf("443 → %d (kernel state not readable without sudo, but the port answers)", routerPort),
+		}
+	}
 	return HealthCheck{
 		Name:   "port_forwarding",
 		Status: "ok",

--- a/internal/service/health_test.go
+++ b/internal/service/health_test.go
@@ -68,16 +68,18 @@ func fakePFAll(configuredOnDisk, loadedInKernel, pfEnabled, pfStateKnown, kernel
 // router answers the liveness probe with 200.
 func allHealthy() healthDeps {
 	return healthDeps{
-		isRunning:               func() bool { return true },
-		installedBinaryPath:     func() string { return "/usr/local/bin/gtl" },
-		runningRouterVersion:    func() string { return "1.0.0" },
-		runningPID:              func() int { return 1234 },
-		isPortForwardConfigured: func() bool { return true },
-		checkPortForward:        fakePF(true, true, true, ""),
-		dialTimeout:             fakeDial(true),
-		httpProbe:               fakeHTTP(200, nil),
-		executable:              func() (string, error) { return "/usr/local/bin/gtl", nil },
-		processOnPort:           func(int) processInfo { return processInfo{Name: "git-treeline", PID: 1234} },
+		isRunning:                  func() bool { return true },
+		installedBinaryPath:        func() string { return "/usr/local/bin/gtl" },
+		runningRouterVersion:       func() string { return "1.0.0" },
+		runningPID:                 func() int { return 1234 },
+		isPortForwardConfigured:    func() bool { return true },
+		checkPortForward:           fakePF(true, true, true, ""),
+		dialTimeout:                fakeDial(true),
+		httpProbe:                  fakeHTTP(200, nil),
+		executable:                 func() (string, error) { return "/usr/local/bin/gtl", nil },
+		processOnPort:              func(int) processInfo { return processInfo{Name: "git-treeline", PID: 1234} },
+		isPfReloadDaemonInstalled:  func() bool { return true },
+		pfReloadDaemonSupported:    true,
 	}
 }
 
@@ -86,8 +88,8 @@ func allHealthy() healthDeps {
 func TestCheckHealthWith_AllHealthy(t *testing.T) {
 	checks := checkHealthWith(allHealthy(), 8443, "1.0.0")
 
-	if len(checks) != 6 {
-		t.Fatalf("expected 6 checks, got %d", len(checks))
+	if len(checks) != 7 {
+		t.Fatalf("expected 7 checks, got %d", len(checks))
 	}
 	for _, c := range checks {
 		if c.Status != "ok" {
@@ -96,18 +98,31 @@ func TestCheckHealthWith_AllHealthy(t *testing.T) {
 	}
 }
 
+func TestCheckHealthWith_NoPfReloadDaemonOnLinux(t *testing.T) {
+	d := allHealthy()
+	d.pfReloadDaemonSupported = false
+	checks := checkHealthWith(d, 8443, "1.0.0")
+	for _, c := range checks {
+		if c.Name == "pf_reload_daemon" {
+			t.Errorf("pf_reload_daemon check should not run on non-darwin, got %+v", c)
+		}
+	}
+}
+
 func TestCheckHealthWith_AllBroken(t *testing.T) {
 	d := healthDeps{
-		isRunning:               func() bool { return false },
-		installedBinaryPath:     func() string { return "" },
-		runningRouterVersion:    func() string { return "" },
-		runningPID:              func() int { return 0 },
-		isPortForwardConfigured: func() bool { return false },
-		checkPortForward:        fakePF(false, false, false, "not configured"),
-		dialTimeout:             fakeDial(false),
-		httpProbe:               fakeHTTP(0, fmt.Errorf("connection refused")),
-		executable:              func() (string, error) { return "/usr/local/bin/gtl", nil },
-		processOnPort:           func(int) processInfo { return processInfo{} },
+		isRunning:                  func() bool { return false },
+		installedBinaryPath:        func() string { return "" },
+		runningRouterVersion:       func() string { return "" },
+		runningPID:                 func() int { return 0 },
+		isPortForwardConfigured:    func() bool { return false },
+		checkPortForward:           fakePF(false, false, false, "not configured"),
+		dialTimeout:                fakeDial(false),
+		httpProbe:                  fakeHTTP(0, fmt.Errorf("connection refused")),
+		executable:                 func() (string, error) { return "/usr/local/bin/gtl", nil },
+		processOnPort:              func(int) processInfo { return processInfo{} },
+		isPfReloadDaemonInstalled:  func() bool { return false },
+		pfReloadDaemonSupported:    true,
 	}
 
 	checks := checkHealthWith(d, 8443, "1.0.0")
@@ -119,6 +134,7 @@ func TestCheckHealthWith_AllBroken(t *testing.T) {
 		"router_port":       "error",
 		"router_responding": "warn",
 		"port_forwarding":   "warn",
+		"pf_reload_daemon":  "ok", // pf not configured → daemon is n/a
 	}
 	for _, c := range checks {
 		want, ok := expected[c.Name]
@@ -446,6 +462,42 @@ func TestCheckPortForward_KernelStateUnknown_DialFails(t *testing.T) {
 	}
 	if c.Fix != "gtl serve reload-pf" {
 		t.Errorf("expected fix to be 'gtl serve reload-pf', got %q", c.Fix)
+	}
+}
+
+// --- checkPfReloadDaemon ---
+
+func TestCheckPfReloadDaemon_OkWhenInstalled(t *testing.T) {
+	d := allHealthy()
+	c := checkPfReloadDaemon(d)
+	if c.Status != "ok" {
+		t.Errorf("expected ok, got %s (%s)", c.Status, c.Detail)
+	}
+}
+
+func TestCheckPfReloadDaemon_WarnWhenPfConfiguredButDaemonMissing(t *testing.T) {
+	// The exact upgrade path: user has pf rules from v0.40.0 but the
+	// daemon was added in v0.40.1. They need to re-run gtl serve install.
+	d := allHealthy()
+	d.isPfReloadDaemonInstalled = func() bool { return false }
+	c := checkPfReloadDaemon(d)
+	if c.Status != "warn" {
+		t.Errorf("expected warn, got %s", c.Status)
+	}
+	if c.Fix != "gtl serve install" {
+		t.Errorf("expected serve install fix, got %q", c.Fix)
+	}
+}
+
+func TestCheckPfReloadDaemon_OkWhenPfNotConfigured(t *testing.T) {
+	// User chose not to install port forwarding. The daemon would be
+	// pointless — don't nag them about it.
+	d := allHealthy()
+	d.isPortForwardConfigured = func() bool { return false }
+	d.isPfReloadDaemonInstalled = func() bool { return false }
+	c := checkPfReloadDaemon(d)
+	if c.Status != "ok" {
+		t.Errorf("expected ok (n/a), got %s", c.Status)
 	}
 }
 

--- a/internal/service/health_test.go
+++ b/internal/service/health_test.go
@@ -28,11 +28,36 @@ func fakeHTTP(status int, err error) func(string, time.Duration) (int, error) {
 }
 
 func fakePF(configuredOnDisk, loadedInKernel, pfEnabled bool, detail string) func(int) PortForwardStatus {
+	// kernelStateKnown defaults to true for legacy callers — most existing
+	// tests want "we read the kernel and saw [or didn't see] the rule." Use
+	// fakePFKernelUnknown for the without-sudo path.
+	return fakePFFull(configuredOnDisk, loadedInKernel, pfEnabled, true, detail)
+}
+
+func fakePFKernelUnknown(configuredOnDisk, pfEnabled bool, detail string) func(int) PortForwardStatus {
+	// PfStateKnown=true (we read pf state) but KernelStateKnown=false (we
+	// couldn't list rules without sudo).
+	return fakePFAll(configuredOnDisk, false, pfEnabled, true, false, detail)
+}
+
+func fakePFFull(configuredOnDisk, loadedInKernel, pfEnabled, kernelStateKnown bool, detail string) func(int) PortForwardStatus {
+	// PfStateKnown defaults to true here — most tests set pfEnabled
+	// definitively. fakePFPfUnknown is the helper for the without-sudo case.
+	return fakePFAll(configuredOnDisk, loadedInKernel, pfEnabled, true, kernelStateKnown, detail)
+}
+
+func fakePFPfUnknown(configuredOnDisk bool, detail string) func(int) PortForwardStatus {
+	return fakePFAll(configuredOnDisk, false, false, false, false, detail)
+}
+
+func fakePFAll(configuredOnDisk, loadedInKernel, pfEnabled, pfStateKnown, kernelStateKnown bool, detail string) func(int) PortForwardStatus {
 	return func(int) PortForwardStatus {
 		return PortForwardStatus{
 			ConfiguredOnDisk: configuredOnDisk,
 			LoadedInKernel:   loadedInKernel,
 			PfEnabled:        pfEnabled,
+			PfStateKnown:     pfStateKnown,
+			KernelStateKnown: kernelStateKnown,
 			Detail:           detail,
 		}
 	}
@@ -341,9 +366,80 @@ func TestCheckPortForward_NotConfigured(t *testing.T) {
 func TestCheckPortForward_ConfiguredOnDiskButNotInKernel(t *testing.T) {
 	// This is the exact failure mode the user hit: pf.conf has the
 	// rule but `pfctl -s nat` doesn't, so traffic to :443 doesn't reach
-	// the router.
+	// the router. We also need port 443 to be unreachable for the
+	// kernel-says-no path to dominate (otherwise the dial succeeds and
+	// we treat the system as healthy).
 	d := allHealthy()
 	d.checkPortForward = fakePF(true, false, true, "rule not loaded in kernel — pf.conf has it but `pfctl -s nat` doesn't show port 8443 (run 'gtl serve reload-pf')")
+	d.dialTimeout = func(_, addr string, _ time.Duration) (net.Conn, error) {
+		if addr == "127.0.0.1:443" {
+			return nil, fmt.Errorf("connection refused")
+		}
+		return fakeConn{}, nil
+	}
+	c := checkPortForward(d, 8443)
+	if c.Status != "error" {
+		t.Errorf("expected error, got %s", c.Status)
+	}
+	if c.Fix != "gtl serve reload-pf" {
+		t.Errorf("expected fix to be 'gtl serve reload-pf', got %q", c.Fix)
+	}
+}
+
+// When pfctl needs sudo and we can't read the kernel ruleset, we should
+// fall back to a port-443 dial as the authoritative signal. If the dial
+// succeeds, the system IS forwarding — report ok with a note that we
+// couldn't verify via pfctl.
+func TestCheckPortForward_KernelStateUnknown_DialSucceeds(t *testing.T) {
+	d := allHealthy()
+	d.checkPortForward = fakePFKernelUnknown(true, true, "kernel ruleset not readable without sudo — verify with 'sudo pfctl -s nat'")
+	c := checkPortForward(d, 8443)
+	if c.Status != "ok" {
+		t.Errorf("expected ok (dial succeeded), got %s (%s)", c.Status, c.Detail)
+	}
+	if !strings.Contains(c.Detail, "not readable without sudo") {
+		t.Errorf("expected sudo note in detail, got %q", c.Detail)
+	}
+}
+
+// Without sudo on modern macOS, both `pfctl -s info` and `pfctl -s nat`
+// can fail. We must NOT report "pf disabled" in that case — the dial is
+// the only authoritative signal.
+func TestCheckPortForward_PfStateUnknown_DialSucceedsIsHealthy(t *testing.T) {
+	d := allHealthy()
+	d.checkPortForward = fakePFPfUnknown(true, "pf state not readable without sudo")
+	c := checkPortForward(d, 8443)
+	if c.Status != "ok" {
+		t.Errorf("expected ok when dial succeeds, got %s (%s)", c.Status, c.Detail)
+	}
+}
+
+func TestCheckPortForward_PfStateUnknown_DialFailsErrors(t *testing.T) {
+	d := allHealthy()
+	d.checkPortForward = fakePFPfUnknown(true, "pf state not readable without sudo")
+	d.dialTimeout = func(_, addr string, _ time.Duration) (net.Conn, error) {
+		if addr == "127.0.0.1:443" {
+			return nil, fmt.Errorf("connection refused")
+		}
+		return fakeConn{}, nil
+	}
+	c := checkPortForward(d, 8443)
+	if c.Status != "error" {
+		t.Errorf("expected error when dial fails, got %s", c.Status)
+	}
+}
+
+// Same scenario but the dial fails: rules might really be missing.
+// Report error with the reload-pf fix.
+func TestCheckPortForward_KernelStateUnknown_DialFails(t *testing.T) {
+	d := allHealthy()
+	d.checkPortForward = fakePFKernelUnknown(true, true, "kernel ruleset not readable without sudo — verify with 'sudo pfctl -s nat'")
+	d.dialTimeout = func(_, addr string, _ time.Duration) (net.Conn, error) {
+		if addr == "127.0.0.1:443" {
+			return nil, fmt.Errorf("connection refused")
+		}
+		return fakeConn{}, nil
+	}
 	c := checkPortForward(d, 8443)
 	if c.Status != "error" {
 		t.Errorf("expected error, got %s", c.Status)

--- a/internal/service/pfdaemon.go
+++ b/internal/service/pfdaemon.go
@@ -1,0 +1,143 @@
+package service
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+)
+
+// PfReloadDaemonLabel is the launchd label for our boot-time pf reloader.
+// Lives in /Library/LaunchDaemons (system-level, runs as root). The daemon
+// exists solely so pf rules survive a reboot — macOS loads pf.conf at boot
+// via Apple's own LaunchDaemon but does NOT enable pf. Our daemon re-runs
+// `pfctl -ef /etc/pf.conf` to enable pf and load our rdr rule.
+//
+// The daemon invokes Apple's signed /sbin/pfctl directly — it does NOT
+// reference our gtl binary, so no notarization or code-signing concerns
+// apply. The plist itself is a static config file.
+const PfReloadDaemonLabel = "dev.treeline.pfreload"
+
+// PfReloadDaemonPath returns the on-disk plist path. macOS-only; on
+// other platforms returns "" since we don't ship this daemon there.
+func PfReloadDaemonPath() string {
+	if runtime.GOOS != "darwin" {
+		return ""
+	}
+	return "/Library/LaunchDaemons/" + PfReloadDaemonLabel + ".plist"
+}
+
+// pfReloadDaemonPlist is the static plist body. No template params —
+// /sbin/pfctl is part of the OS, /etc/pf.conf is where our rdr rule
+// already lives.
+const pfReloadDaemonPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>dev.treeline.pfreload</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/sbin/pfctl</string>
+        <string>-ef</string>
+        <string>/etc/pf.conf</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardErrorPath</key>
+    <string>/var/log/dev.treeline.pfreload.err</string>
+    <key>StandardOutPath</key>
+    <string>/var/log/dev.treeline.pfreload.out</string>
+</dict>
+</plist>
+`
+
+// IsPfReloadDaemonInstalled reports whether our LaunchDaemon plist exists
+// on disk. Read-only; no sudo needed.
+func IsPfReloadDaemonInstalled() bool {
+	path := PfReloadDaemonPath()
+	if path == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// InstallPfReloadDaemon writes the LaunchDaemon plist to
+// /Library/LaunchDaemons and bootstraps it so it runs at every boot.
+// Requires sudo. Idempotent — safe to call when already installed.
+//
+// macOS-only. On other platforms returns nil (no-op) since iptables on
+// Linux distros generally persist their own rules via netfilter-persistent
+// or iptables-save and don't need a separate boot service.
+func InstallPfReloadDaemon() error {
+	if runtime.GOOS != "darwin" {
+		return nil
+	}
+
+	tmp, err := os.CreateTemp("", "treeline-pfreload-*.plist")
+	if err != nil {
+		return fmt.Errorf("creating temp plist: %w", err)
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	if _, err := tmp.WriteString(pfReloadDaemonPlist); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	target := PfReloadDaemonPath()
+	// One sudo session: copy plist, set ownership and perms, then
+	// (re)bootstrap. bootout is best-effort — non-zero when not loaded.
+	script := fmt.Sprintf(
+		"/bin/cp '%s' '%s' && "+
+			"/usr/sbin/chown root:wheel '%s' && "+
+			"/bin/chmod 644 '%s' && "+
+			"/bin/launchctl bootout system/%s 2>/dev/null; "+
+			"/bin/launchctl bootstrap system '%s'",
+		tmp.Name(), target,
+		target,
+		target,
+		PfReloadDaemonLabel,
+		target,
+	)
+	cmd := exec.Command("sudo", "-p",
+		"\nEnter your password to install the boot-time pf reloader: ",
+		"sh", "-c", script)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("pf-reload daemon install failed: %w", err)
+	}
+	return nil
+}
+
+// UninstallPfReloadDaemon removes the LaunchDaemon. Symmetric with install
+// — requires sudo. Idempotent.
+func UninstallPfReloadDaemon() error {
+	if runtime.GOOS != "darwin" {
+		return nil
+	}
+	if !IsPfReloadDaemonInstalled() {
+		return nil
+	}
+	target := PfReloadDaemonPath()
+	script := fmt.Sprintf(
+		"/bin/launchctl bootout system/%s 2>/dev/null; "+
+			"/bin/rm -f '%s'",
+		PfReloadDaemonLabel,
+		target,
+	)
+	cmd := exec.Command("sudo", "-p",
+		"\nEnter your password to remove the boot-time pf reloader: ",
+		"sh", "-c", script)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("pf-reload daemon uninstall failed: %w", err)
+	}
+	return nil
+}

--- a/internal/service/portforward.go
+++ b/internal/service/portforward.go
@@ -77,9 +77,19 @@ type PortForwardStatus struct {
 	// On macOS this requires both pf to be enabled AND our rdr rule to be
 	// in the active anchor.
 	LoadedInKernel bool
-	// PfEnabled (macOS only) is true when `pfctl -s info` reports pf is
-	// enabled. Meaningless on Linux.
+	// PfEnabled (macOS only) reports the running pf status. Meaningful only
+	// when PfStateKnown is true. Meaningless on Linux.
 	PfEnabled bool
+	// PfStateKnown (macOS only) is true when `pfctl -s info` succeeded —
+	// without it, callers must not interpret PfEnabled=false as proof that
+	// pf is actually disabled. On modern macOS, `pfctl -s info` may
+	// require sudo; without it, returns an error.
+	PfStateKnown bool
+	// KernelStateKnown is true when we successfully queried the kernel rule
+	// list. On macOS, `pfctl -s nat` (and per-anchor variants) typically
+	// require sudo — if our calls fail with permission errors, this is
+	// false, and LoadedInKernel should not be trusted as authoritative.
+	KernelStateKnown bool
 	// Detail is a one-line human-readable summary, or "" when everything is
 	// healthy.
 	Detail string
@@ -106,30 +116,40 @@ func checkPortForwardDarwin(routerPort int) PortForwardStatus {
 	st := PortForwardStatus{ConfiguredOnDisk: IsPortForwardConfigured()}
 
 	// pfctl -s info reports the daemon's enabled/disabled state. This call
-	// does not require sudo on macOS.
+	// MAY require sudo on modern macOS — when it fails we record
+	// PfStateKnown=false so callers don't misread the missing answer as
+	// "pf is disabled."
 	if out, err := runCmdOutput("/sbin/pfctl", "-s", "info"); err == nil {
 		for _, line := range strings.Split(string(out), "\n") {
-			if strings.HasPrefix(strings.TrimSpace(line), "Status: Enabled") {
+			trimmed := strings.TrimSpace(line)
+			if strings.HasPrefix(trimmed, "Status: Enabled") {
 				st.PfEnabled = true
+				st.PfStateKnown = true
+				break
+			}
+			if strings.HasPrefix(trimmed, "Status: Disabled") {
+				st.PfEnabled = false
+				st.PfStateKnown = true
 				break
 			}
 		}
 	}
 
-	// pfctl -a treeline -s nat lists the rules in our anchor. Without sudo
-	// macOS sometimes refuses; in that case we fall back to the main NAT
-	// ruleset (`pfctl -s nat`), which can also reference our anchor via a
-	// `rdr-anchor` line.
+	// pfctl -a treeline -s nat lists the rules in our anchor. Both this and
+	// the main `pfctl -s nat` typically require sudo on modern macOS, so we
+	// track whether either query actually succeeded — if neither does we
+	// can't prove or disprove "loaded in kernel."
 	wantSubstr := fmt.Sprintf("port %d", routerPort)
 	if out, err := runCmdOutput("/sbin/pfctl", "-a", pfAnchorName(), "-s", "nat"); err == nil {
+		st.KernelStateKnown = true
 		if strings.Contains(string(out), wantSubstr) {
 			st.LoadedInKernel = true
 		}
 	}
 	if !st.LoadedInKernel {
 		if out, err := runCmdOutput("/sbin/pfctl", "-s", "nat"); err == nil {
-			body := string(out)
-			if strings.Contains(body, wantSubstr) {
+			st.KernelStateKnown = true
+			if strings.Contains(string(out), wantSubstr) {
 				st.LoadedInKernel = true
 			}
 		}
@@ -138,8 +158,12 @@ func checkPortForwardDarwin(routerPort int) PortForwardStatus {
 	switch {
 	case !st.ConfiguredOnDisk:
 		st.Detail = "not configured (run 'gtl serve install')"
-	case !st.PfEnabled:
+	case st.PfStateKnown && !st.PfEnabled:
 		st.Detail = "pf disabled — rules will not apply (run 'gtl serve reload-pf')"
+	case !st.PfStateKnown && !st.KernelStateKnown:
+		st.Detail = "pf state not readable without sudo — verify with 'sudo pfctl -s info'"
+	case !st.KernelStateKnown:
+		st.Detail = "kernel ruleset not readable without sudo — verify with 'sudo pfctl -s nat'"
 	case !st.LoadedInKernel:
 		st.Detail = fmt.Sprintf("rule not loaded in kernel — pf.conf has it but `pfctl -s nat` doesn't show port %d (run 'gtl serve reload-pf')", routerPort)
 	}
@@ -157,6 +181,7 @@ func checkPortForwardLinux(routerPort int) PortForwardStatus {
 		}
 		return st
 	}
+	st.KernelStateKnown = true
 	body := string(out)
 	if strings.Contains(body, "git-treeline") &&
 		strings.Contains(body, fmt.Sprintf("ports %d", routerPort)) {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -122,6 +122,24 @@ func Uninstall() error {
 	}
 }
 
+// IsInstalled reports whether the service definition exists on disk for the
+// current user, regardless of whether it's currently running. Used by
+// `gtl serve restart --if-installed` so tooling integrations (Homebrew
+// post_install) can safely be a no-op on machines where the user never
+// installed the router.
+func IsInstalled() bool {
+	switch runtime.GOOS {
+	case "darwin":
+		_, err := os.Stat(PlistPath())
+		return err == nil
+	case "linux":
+		_, err := os.Stat(UnitPath())
+		return err == nil
+	default:
+		return false
+	}
+}
+
 // IsRunning checks if the service is currently active.
 func IsRunning() bool {
 	switch runtime.GOOS {


### PR DESCRIPTION
## Summary

The three follow-ups from PR #42's notes, shipped together:

1. **pf reboot survival** — new LaunchDaemon at \`/Library/LaunchDaemons/dev.treeline.pfreload.plist\` re-runs \`pfctl -ef /etc/pf.conf\` at boot. Apple's own pf service loads rules but doesn't enable pf, so the redirect dies on every reboot in 0.40.0. The daemon invokes Apple's signed \`/sbin/pfctl\` directly — no Treeline binary in the boot path, no signing/notarization concerns.
2. **Brew \`post_install\` hook** — after \`brew upgrade git-treeline\`, runs \`gtl serve restart --if-installed\` so the launchd-managed router picks up the new binary automatically. New \`--if-installed\` flag makes it a quiet no-op for users who never installed serve.
3. **\`gtl serve status\` uses the kernel-level pf check** — same as the doctor. Previously read \`pf.conf\` on disk and said "active" while pf was actually disabled (the lie that masked the post-reboot outage). Also fixed a related false-alarm: on macOS Sequoia without sudo, \`pfctl -s info\` errors out; the old code silently treated that as "pf disabled," producing contradictory messages between status and doctor. New \`PfStateKnown\` field disambiguates.

## What's NOT in this PR

- LaunchDaemon Linux equivalent. iptables on most distros persists rules via netfilter-persistent — no separate boot service needed. Skip is intentional.
- Smoke verification of the actual reboot. Only the user can do that. The unit + read-only smoke proves the daemon writes/loads correctly; only a reboot proves pf rules survive.

## Phasing

Three commits on this branch, each tested green individually:

1. \`e0261dc\` — \`serve status\` & doctor: kernel-aware pf check without false alarms
2. \`be9ddc9\` — \`serve restart --if-installed\` + brew \`post_install\` hook
3. \`55b8c84\` — pf reboot-survival LaunchDaemon

## Test plan

### Automated (CI)
- [x] \`go test ./...\` passes
- [x] \`go vet ./...\` clean
- [x] \`golangci-lint run\` clean
- [x] New unit tests cover \`PfStateKnown\` matrix, \`IsInstalled\`, \`checkPfReloadDaemon\`, the new dial-fallback when neither pf state nor kernel rules can be read

### Manual (run on real macOS before merging)
- [ ] \`gtl serve restart --if-installed\` no-ops with exit 0 when no plist exists (verified locally: works)
- [ ] \`gtl serve install\` (after merge) writes \`/Library/LaunchDaemons/dev.treeline.pfreload.plist\`, sets ownership to root:wheel, and \`launchctl print system/dev.treeline.pfreload\` succeeds
- [ ] After the daemon installs, run \`sudo pfctl -d\` (disable pf), then **reboot the machine**. After login, \`sudo pfctl -s info\` should report \`Status: Enabled\` again — that's the daemon doing its job
- [ ] \`gtl serve uninstall\` cleanly removes the LaunchDaemon (\`launchctl print system/dev.treeline.pfreload\` returns "service not found")
- [ ] \`brew upgrade git-treeline\` triggers the post_install hook, which runs \`gtl serve restart --if-installed\` and bounces the router. Verifiable on the next release after this one ships