### PR TITLE
Fix dashed project names breaking DB clones; add gtl rename

### DIFF
--- a/cmd/init_cmd.go
+++ b/cmd/init_cmd.go
@@ -55,7 +55,7 @@ var initCmd = &cobra.Command{
 		detection.MergeTarget = worktree.DetectDefaultBranch(cwd)
 		project := initProject
 		if project == "" {
-			project = defaultProjectName(cwd, detection)
+			project = defaultProjectName(cwd)
 		}
 
 		templateDB := initTemplateDB
@@ -168,37 +168,11 @@ func defaultTemplateDB(project string, det *detect.Result) string {
 	if det != nil && det.DBTemplate != "" {
 		return det.DBTemplate
 	}
-	dbProject := databaseIdentifierName(project)
+	dbProject := config.SanitizeIdentifier(project)
 	if det != nil && det.Framework == "phoenix" {
 		return dbProject + "_dev"
 	}
 	return dbProject + "_development"
-}
-
-func databaseIdentifierName(name string) string {
-	var b strings.Builder
-	lastUnderscore := false
-	for _, r := range name {
-		valid := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_'
-		if valid {
-			b.WriteRune(r)
-			lastUnderscore = r == '_'
-			continue
-		}
-		if !lastUnderscore {
-			b.WriteByte('_')
-			lastUnderscore = true
-		}
-	}
-	result := strings.Trim(b.String(), "_")
-	if result == "" {
-		return "app"
-	}
-	first := result[0]
-	if (first >= 'a' && first <= 'z') || (first >= 'A' && first <= 'Z') || first == '_' {
-		return result
-	}
-	return "db_" + result
 }
 
 func openInEditor(path string) {
@@ -223,7 +197,7 @@ func runInitForNew(mainRepo string, det *detect.Result) error {
 		return nil
 	}
 
-	project := defaultProjectName(mainRepo, det)
+	project := defaultProjectName(mainRepo)
 	det.MergeTarget = worktree.DetectDefaultBranch(mainRepo)
 	templateDB := defaultTemplateDB(project, det)
 
@@ -241,9 +215,13 @@ func runInitForNew(mainRepo string, det *detect.Result) error {
 	return nil
 }
 
-func defaultProjectName(root string, det *detect.Result) string {
-	if det != nil && det.ProjectName != "" {
-		return det.ProjectName
+// defaultProjectName derives a project name from the git remote first,
+// then falls back to the directory basename. The result is sanitized to a
+// valid identifier so it's safe to use in databases, redis prefixes, and
+// router keys without further escaping.
+func defaultProjectName(root string) string {
+	if name := worktree.RepoNameFromRemote(root); name != "" {
+		return config.SanitizeIdentifier(name)
 	}
-	return filepath.Base(root)
+	return config.SanitizeIdentifier(filepath.Base(root))
 }

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/git-treeline/cli/internal/config"
+	"github.com/git-treeline/cli/internal/confirm"
+	"github.com/git-treeline/cli/internal/database"
+	"github.com/git-treeline/cli/internal/registry"
+	"github.com/git-treeline/cli/internal/setup"
+	"github.com/git-treeline/cli/internal/style"
+	"github.com/git-treeline/cli/internal/worktree"
+	"github.com/spf13/cobra"
+)
+
+var renameYes bool
+
+func init() {
+	renameCmd.Flags().BoolVarP(&renameYes, "yes", "y", false, "Skip confirmation prompt")
+	rootCmd.AddCommand(renameCmd)
+}
+
+var renameCmd = &cobra.Command{
+	Use:   "rename <new-name>",
+	Short: "Rename the project, migrating registry, port reservations, and databases",
+	Long: `Renames the project across .treeline.yml, the global registry, and
+user-config keys (port reservations, editor overrides). Worktree databases
+under the old name are dropped, then re-cloned from the template under the
+new name. Existing worktrees keep their port reservations where possible.
+
+Project names must match [a-zA-Z_][a-zA-Z0-9_]* — same rule as Postgres
+identifiers, since the project name flows into databases, redis prefixes,
+and router keys.`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		newName := args[0]
+		if !config.IsValidIdentifier(newName) {
+			return cliErr(cmd, &CliError{
+				Message: fmt.Sprintf("invalid project name %q", newName),
+				Hint: fmt.Sprintf("Project names must match [a-zA-Z_][a-zA-Z0-9_]* (no dashes, dots, spaces).\n"+
+					"  Try: gtl rename %s", config.SanitizeIdentifier(newName)),
+			})
+		}
+
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("getting working directory: %w", err)
+		}
+		mainRepo := worktree.DetectMainRepo(cwd)
+		pc := config.LoadProjectConfig(mainRepo)
+		if !pc.Exists() {
+			return cliErr(cmd, &CliError{
+				Message: fmt.Sprintf("no %s found at %s", config.ProjectConfigFile, mainRepo),
+				Hint:    "Run gtl rename inside a treeline project (the main repo or any worktree).",
+			})
+		}
+
+		oldName := pc.Project()
+		if oldName == newName {
+			fmt.Printf("Project is already named %q. Nothing to do.\n", newName)
+			return nil
+		}
+
+		uc := config.LoadUserConfig("")
+		reg := registry.New("")
+		entries := reg.FindByProject(oldName)
+
+		fmt.Printf("Renaming project: %s → %s\n", oldName, newName)
+		if len(entries) > 0 {
+			fmt.Println()
+			fmt.Printf("This drops and re-clones databases for %d worktree(s):\n", len(entries))
+			for _, e := range entries {
+				wt := registry.GetString(e, "worktree")
+				db := registry.GetString(e, "database")
+				if db != "" {
+					fmt.Printf("  - %s  (drops %s)\n", wt, db)
+				} else {
+					fmt.Printf("  - %s\n", wt)
+				}
+			}
+		}
+		fmt.Println()
+
+		if !renameYes {
+			if !confirm.Prompt(fmt.Sprintf("Proceed with rename to %q?", newName), false, nil) {
+				fmt.Println("Aborted.")
+				return nil
+			}
+		}
+
+		if err := pc.SetProject(newName); err != nil {
+			return fmt.Errorf("rewriting %s: %w", config.ProjectConfigFile, err)
+		}
+		fmt.Println(style.Actionf("Updated %s", config.ProjectConfigFile))
+
+		if migrated := uc.MigrateProjectKeys(oldName, newName); migrated > 0 {
+			if err := uc.Save(); err != nil {
+				return fmt.Errorf("saving user config: %w", err)
+			}
+			fmt.Println(style.Actionf("Migrated %d user-config key(s)", migrated))
+		}
+
+		dropDatabases(pc.DatabaseAdapter(), entries)
+
+		var paths []string
+		for _, e := range entries {
+			wt := registry.GetString(e, "worktree")
+			if wt == "" {
+				continue
+			}
+			if _, err := reg.Release(wt); err != nil {
+				fmt.Fprintf(os.Stderr, "  warning: failed to release %s: %v\n", wt, err)
+			}
+			if info, statErr := os.Stat(wt); statErr == nil && info.IsDir() {
+				paths = append(paths, wt)
+			}
+		}
+
+		successes := 0
+		var failures []string
+		if len(paths) > 0 {
+			fmt.Println()
+			fmt.Println("Reallocating worktrees under new project name...")
+		}
+		for _, p := range paths {
+			fmt.Printf("\n→ %s\n", p)
+			s := setup.New(p, "", uc)
+			if _, err := s.Run(); err != nil {
+				fmt.Fprintf(os.Stderr, "  ✗ %v\n", err)
+				failures = append(failures, p)
+				continue
+			}
+			successes++
+		}
+
+		fmt.Println()
+		fmt.Printf("Rename complete: %d worktree(s) reallocated", successes)
+		if len(failures) > 0 {
+			fmt.Printf(", %d failed", len(failures))
+		}
+		fmt.Println(".")
+		if len(failures) > 0 {
+			return fmt.Errorf("%d reallocation(s) failed", len(failures))
+		}
+		return nil
+	},
+}
+
+// dropDatabases drops every database name listed in the registry entries,
+// using the configured adapter. Errors are reported but don't abort the
+// rename — the worktree re-allocation step will surface any real problem.
+func dropDatabases(adapterName string, entries []registry.Allocation) {
+	if len(entries) == 0 {
+		return
+	}
+	adapter, err := database.ForAdapter(adapterName)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "  warning: %v\n", err)
+		return
+	}
+	for _, e := range entries {
+		dbName := registry.GetString(e, "database")
+		if dbName == "" {
+			continue
+		}
+		exists, err := adapter.Exists(dbName)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: checking %s: %v\n", dbName, err)
+			continue
+		}
+		if !exists {
+			continue
+		}
+		fmt.Printf("==> Dropping %s\n", dbName)
+		if err := adapter.Drop(dbName); err != nil {
+			fmt.Fprintf(os.Stderr, "  warning: dropping %s: %v\n", dbName, err)
+		}
+	}
+}

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -422,21 +422,27 @@ func (al *Allocator) nextAvailableRedisDB() int {
 var sanitizeRe = regexp.MustCompile(`[^a-zA-Z0-9_]`)
 var collapseRe = regexp.MustCompile(`_+`)
 
+// sanitizeIdentifier converts an arbitrary string into a database/redis-safe
+// identifier: only [a-zA-Z0-9_], no leading/trailing underscores, no runs.
+func sanitizeIdentifier(s string) string {
+	s = sanitizeRe.ReplaceAllString(s, "_")
+	s = collapseRe.ReplaceAllString(s, "_")
+	return strings.Trim(s, "_")
+}
+
 func (al *Allocator) buildDatabaseName(worktreeName string) string {
 	template := al.ProjectConfig.DatabaseTemplate()
 	if template == "" {
 		return ""
 	}
 
-	sanitized := sanitizeRe.ReplaceAllString(worktreeName, "_")
-	sanitized = collapseRe.ReplaceAllString(sanitized, "_")
-	sanitized = strings.Trim(sanitized, "_")
-
-	return strings.NewReplacer(
+	name := strings.NewReplacer(
 		"{template}", template,
-		"{worktree}", sanitized,
+		"{worktree}", sanitizeIdentifier(worktreeName),
 		"{project}", al.ProjectConfig.Project(),
 	).Replace(al.ProjectConfig.DatabasePattern())
+
+	return sanitizeIdentifier(name)
 }
 
 func intsToAny(ints []int) []any {

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -179,6 +179,63 @@ func TestAllocate_DatabaseName(t *testing.T) {
 	}
 }
 
+func TestBuildDatabaseName_SanitizesFullResult(t *testing.T) {
+	cases := []struct {
+		name, project, template, pattern, worktreeName, want string
+	}{
+		{
+			name:         "dashed_project_in_pattern",
+			project:      "fitter-app",
+			template:     "fitter_app_development",
+			pattern:      "{project}_{worktree}",
+			worktreeName: "feature/x",
+			want:         "fitter_app_feature_x",
+		},
+		{
+			name:         "dashed_template_value",
+			project:      "fitter",
+			template:     "fitter-dev",
+			pattern:      "{template}_{worktree}",
+			worktreeName: "feature_x",
+			want:         "fitter_dev_feature_x",
+		},
+		{
+			name:         "default_pattern_dashed_worktree",
+			project:      "fitter",
+			template:     "fitter_development",
+			pattern:      "{template}_{worktree}",
+			worktreeName: "feature-branch",
+			want:         "fitter_development_feature_branch",
+		},
+		{
+			name:         "leading_and_trailing_dashes_collapse",
+			project:      "fitter",
+			template:     "-weird-",
+			pattern:      "{template}_{worktree}",
+			worktreeName: "x",
+			want:         "weird_x",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			yamlExtra := ""
+			al, _ := testAllocator(t, 1, yamlExtra)
+			al.ProjectConfig.Data["project"] = c.project
+			al.ProjectConfig.Data["database"] = map[string]any{
+				"adapter":  "postgresql",
+				"template": c.template,
+				"pattern":  c.pattern,
+			}
+			got := al.buildDatabaseName(c.worktreeName)
+			if got != c.want {
+				t.Errorf("buildDatabaseName(%q) with project=%q template=%q pattern=%q\n  got:  %q\n  want: %q",
+					c.worktreeName, c.project, c.template, c.pattern, got, c.want)
+			}
+		})
+	}
+}
+
 func TestAllocate_RedisPrefix(t *testing.T) {
 	al, _ := testAllocator(t, 1, "")
 	alloc, err := al.Allocate("/wt/my-branch", "my-branch", false)

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -98,14 +98,14 @@ func (pc *ProjectConfig) Project() string {
 func (pc *ProjectConfig) Validate() error {
 	if v, ok := pc.Data["project"].(string); ok && v != "" {
 		if !IsValidIdentifier(v) {
-			return fmt.Errorf("project name %q in %s contains invalid characters; must match [a-zA-Z_][a-zA-Z0-9_]*\n  Run `gtl rename %s` to fix.",
+			return fmt.Errorf("project name %q in %s contains invalid characters; must match [a-zA-Z_][a-zA-Z0-9_]* (run `gtl rename %s` to fix)",
 				v, ProjectConfigFile, SanitizeIdentifier(v))
 		}
 	}
 	if t := pc.DatabaseTemplate(); t != "" {
 		adapter := pc.DatabaseAdapter()
 		if (adapter == "postgresql" || adapter == "mysql") && !IsValidIdentifier(t) {
-			return fmt.Errorf("database.template %q in %s is not a valid %s identifier; must match [a-zA-Z_][a-zA-Z0-9_]*\n  Suggested: %s",
+			return fmt.Errorf("database.template %q in %s is not a valid %s identifier; must match [a-zA-Z_][a-zA-Z0-9_]* (suggested: %s)",
 				t, ProjectConfigFile, adapter, SanitizeIdentifier(t))
 		}
 	}

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -4,12 +4,53 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
 )
 
 const ProjectConfigFile = ".treeline.yml"
+
+// identifierRe matches a valid SQL/redis-safe identifier: letter or underscore
+// to start, then alphanumerics and underscores. The same rule applies to
+// project names and database template names because they propagate into both.
+var identifierRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// IsValidIdentifier reports whether s is a safe project / database identifier.
+func IsValidIdentifier(s string) bool {
+	return identifierRe.MatchString(s)
+}
+
+// SanitizeIdentifier converts an arbitrary string into a valid identifier by
+// replacing runs of non-identifier characters with `_`, trimming leading and
+// trailing underscores, and prefixing with `db_` when the result would start
+// with a digit. Returns "app" for inputs that contain no usable characters.
+func SanitizeIdentifier(s string) string {
+	var b strings.Builder
+	lastUnderscore := false
+	for _, r := range s {
+		valid := (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_'
+		if valid {
+			b.WriteRune(r)
+			lastUnderscore = r == '_'
+			continue
+		}
+		if !lastUnderscore && b.Len() > 0 {
+			b.WriteByte('_')
+			lastUnderscore = true
+		}
+	}
+	result := strings.Trim(b.String(), "_")
+	if result == "" {
+		return "app"
+	}
+	first := result[0]
+	if (first >= '0' && first <= '9') {
+		return "db_" + result
+	}
+	return result
+}
 
 var ProjectDefaults = map[string]any{
 	"port_count": 1,
@@ -47,7 +88,28 @@ func (pc *ProjectConfig) Project() string {
 	if v, ok := pc.Data["project"].(string); ok && v != "" {
 		return v
 	}
-	return filepath.Base(pc.ProjectRoot)
+	return SanitizeIdentifier(filepath.Base(pc.ProjectRoot))
+}
+
+// Validate checks that the loaded config has identifier-safe values for fields
+// that propagate into databases, redis prefixes, and router keys. Returns nil
+// when the config is safe to use, otherwise an error naming the offending
+// field with a suggested replacement.
+func (pc *ProjectConfig) Validate() error {
+	if v, ok := pc.Data["project"].(string); ok && v != "" {
+		if !IsValidIdentifier(v) {
+			return fmt.Errorf("project name %q in %s contains invalid characters; must match [a-zA-Z_][a-zA-Z0-9_]*\n  Run `gtl rename %s` to fix.",
+				v, ProjectConfigFile, SanitizeIdentifier(v))
+		}
+	}
+	if t := pc.DatabaseTemplate(); t != "" {
+		adapter := pc.DatabaseAdapter()
+		if (adapter == "postgresql" || adapter == "mysql") && !IsValidIdentifier(t) {
+			return fmt.Errorf("database.template %q in %s is not a valid %s identifier; must match [a-zA-Z_][a-zA-Z0-9_]*\n  Suggested: %s",
+				t, ProjectConfigFile, adapter, SanitizeIdentifier(t))
+		}
+	}
+	return nil
 }
 
 func (pc *ProjectConfig) PortsNeeded() int {

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -61,8 +61,9 @@ func TestProjectConfig_Defaults(t *testing.T) {
 	if pc.EnvFileTarget() != ".env.local" {
 		t.Errorf("expected .env.local, got %s", pc.EnvFileTarget())
 	}
-	if pc.Project() != filepath.Base(dir) {
-		t.Errorf("expected %s, got %s", filepath.Base(dir), pc.Project())
+	want := SanitizeIdentifier(filepath.Base(dir))
+	if pc.Project() != want {
+		t.Errorf("expected %s, got %s", want, pc.Project())
 	}
 }
 
@@ -812,5 +813,105 @@ func TestRewriteEnvFileBlock_PreservesRestOfFile(t *testing.T) {
 	}
 	if !strings.Contains(got, "project: myapp") {
 		t.Errorf("expected project preserved, got:\n%s", got)
+	}
+}
+
+func TestIsValidIdentifier(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"fitter", true},
+		{"fitter_app", true},
+		{"_underscore_lead", true},
+		{"app1", true},
+		{"My_App_2", true},
+		{"", false},
+		{"my-app", false},
+		{"1leading_digit", false},
+		{"with space", false},
+		{"semi;colon", false},
+		{"dot.value", false},
+	}
+	for _, c := range cases {
+		if got := IsValidIdentifier(c.in); got != c.want {
+			t.Errorf("IsValidIdentifier(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestSanitizeIdentifier(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"fitter", "fitter"},
+		{"fitter-app", "fitter_app"},
+		{"my--app", "my_app"},
+		{"--leading-and-trailing--", "leading_and_trailing"},
+		{"with space", "with_space"},
+		{"1leading", "db_1leading"},
+		{"123", "db_123"},
+		{"", "app"},
+		{"---", "app"},
+	}
+	for _, c := range cases {
+		if got := SanitizeIdentifier(c.in); got != c.want {
+			t.Errorf("SanitizeIdentifier(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestProjectConfig_Validate(t *testing.T) {
+	cases := []struct {
+		name    string
+		yml     string
+		wantErr string // substring; "" means no error
+	}{
+		{
+			name:    "valid",
+			yml:     "project: fitter\ndatabase:\n  adapter: postgresql\n  template: fitter_development\n",
+			wantErr: "",
+		},
+		{
+			name:    "dashed_project",
+			yml:     "project: fitter-app\ndatabase:\n  adapter: postgresql\n  template: fitter_development\n",
+			wantErr: "project name",
+		},
+		{
+			name:    "dashed_template",
+			yml:     "project: fitter\ndatabase:\n  adapter: postgresql\n  template: fitter-development\n",
+			wantErr: "database.template",
+		},
+		{
+			name:    "no_project_set_dir_basename_used",
+			yml:     "database:\n  adapter: postgresql\n  template: fitter_development\n",
+			wantErr: "",
+		},
+		{
+			name:    "sqlite_template_can_have_dashes",
+			yml:     "project: fitter\ndatabase:\n  adapter: sqlite\n  template: ./db/dev-fitter.sqlite3\n",
+			wantErr: "",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			dir := t.TempDir()
+			_ = os.WriteFile(filepath.Join(dir, ProjectConfigFile), []byte(c.yml), 0o644)
+			pc := LoadProjectConfig(dir)
+			err := pc.Validate()
+			if c.wantErr == "" {
+				if err != nil {
+					t.Errorf("expected no error, got: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Errorf("expected error containing %q, got nil", c.wantErr)
+				return
+			}
+			if !strings.Contains(err.Error(), c.wantErr) {
+				t.Errorf("expected error containing %q, got: %v", c.wantErr, err)
+			}
+		})
 	}
 }

--- a/internal/config/user.go
+++ b/internal/config/user.go
@@ -348,6 +348,44 @@ func (uc *UserConfig) resolveEditorOverride(key, project, branch string) string 
 	return ""
 }
 
+// MigrateProjectKeys rewrites every config map key that's exactly oldName or
+// is prefixed with "oldName/" so it uses newName instead. Targets the maps
+// where project names appear as keys: port.reservations, editor.themes,
+// editor.colors. Returns the number of keys rewritten. Caller must Save().
+func (uc *UserConfig) MigrateProjectKeys(oldName, newName string) int {
+	if oldName == "" || newName == "" || oldName == newName {
+		return 0
+	}
+	targets := [][]string{
+		{"port", "reservations"},
+		{"editor", "themes"},
+		{"editor", "colors"},
+	}
+	total := 0
+	for _, path := range targets {
+		raw, ok := Dig(uc.Data, path...).(map[string]any)
+		if !ok {
+			continue
+		}
+		for key, val := range raw {
+			rewritten := ""
+			switch {
+			case key == oldName:
+				rewritten = newName
+			case strings.HasPrefix(key, oldName+"/"):
+				rewritten = newName + key[len(oldName):]
+			}
+			if rewritten == "" {
+				continue
+			}
+			delete(raw, key)
+			raw[rewritten] = val
+			total++
+		}
+	}
+	return total
+}
+
 func (uc *UserConfig) Get(dottedKey string) any {
 	keys := splitDotted(dottedKey)
 	return Dig(uc.Data, keys...)

--- a/internal/config/user_test.go
+++ b/internal/config/user_test.go
@@ -789,6 +789,76 @@ func TestUserConfig_SaveFilePermissions(t *testing.T) {
 	}
 }
 
+func TestMigrateProjectKeys(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.json")
+	uc := &UserConfig{
+		Path: path,
+		Data: map[string]any{
+			"port": map[string]any{
+				"reservations": map[string]any{
+					"fitter":         float64(3000),
+					"fitter/main":    float64(3000),
+					"fitter/staging": float64(3010),
+					"other":          float64(3100),
+				},
+			},
+			"editor": map[string]any{
+				"themes": map[string]any{
+					"fitter":      "Solarized",
+					"fitter/main": "Dark",
+				},
+				"colors": map[string]any{
+					"other": "blue",
+				},
+			},
+		},
+	}
+
+	migrated := uc.MigrateProjectKeys("fitter", "fitter_app")
+	if migrated != 5 {
+		t.Errorf("migrated = %d, want 5 (3 reservations + 2 themes)", migrated)
+	}
+
+	res := uc.PortReservations()
+	if res["fitter_app"] != 3000 || res["fitter_app/main"] != 3000 || res["fitter_app/staging"] != 3010 {
+		t.Errorf("port reservations not migrated: %#v", res)
+	}
+	if _, has := res["fitter"]; has {
+		t.Error("old fitter port reservation still present")
+	}
+	if res["other"] != 3100 {
+		t.Error("unrelated reservation lost")
+	}
+
+	themes, _ := Dig(uc.Data, "editor", "themes").(map[string]any)
+	if themes["fitter_app"] != "Solarized" || themes["fitter_app/main"] != "Dark" {
+		t.Errorf("themes not migrated: %#v", themes)
+	}
+	if _, has := themes["fitter"]; has {
+		t.Error("old fitter theme still present")
+	}
+
+	colors, _ := Dig(uc.Data, "editor", "colors").(map[string]any)
+	if colors["other"] != "blue" {
+		t.Error("unrelated editor color lost")
+	}
+}
+
+func TestMigrateProjectKeys_NoOpWhenSame(t *testing.T) {
+	uc := &UserConfig{Data: map[string]any{
+		"port": map[string]any{
+			"reservations": map[string]any{"fitter": float64(3000)},
+		},
+	}}
+	if got := uc.MigrateProjectKeys("fitter", "fitter"); got != 0 {
+		t.Errorf("expected 0 migrations for same name, got %d", got)
+	}
+	if got := uc.MigrateProjectKeys("", "anything"); got != 0 {
+		t.Errorf("expected 0 migrations for empty old name, got %d", got)
+	}
+}
+
 func TestUserConfig_InitFilePermissions(t *testing.T) {
 	dir := t.TempDir()
 	sub := filepath.Join(dir, "gtl-data")

--- a/internal/detect/detect.go
+++ b/internal/detect/detect.go
@@ -14,13 +14,14 @@ import (
 // Result contains the detection findings for a project directory.
 // All fields are populated by Detect() based on filesystem analysis.
 type Result struct {
-	Framework      string // "nextjs", "vite", "rails", "phoenix", "node", "django", "python", "rust", "go", "unknown"
-	ProjectName    string // framework-specific project/app name, when detected
-	HasPrisma      bool
-	HasJSBundler   bool   // jsbundling-rails/cssbundling-rails or multi-process Procfile.dev
-	HasDotenv      bool   // project has dotenv or equivalent wired up
-	DBAdapter      string // "postgresql", "sqlite", ""
-	DBTemplate     string // static development database name, when detected
+	Framework         string // "nextjs", "vite", "rails", "phoenix", "node", "django", "python", "rust", "go", "unknown"
+	HasPrisma         bool
+	HasJSBundler      bool   // jsbundling-rails/cssbundling-rails or multi-process Procfile.dev
+	HasDotenv         bool   // project has dotenv or equivalent wired up
+	DBAdapter         string // "postgresql", "sqlite", ""
+	DBTemplate        string // static development database name, when detected
+	DBTemplateInvalid string // raw value from database.yml that was rejected as a non-identifier
+
 	HasRedis       bool
 	HasEnvFile     bool     // true if any env file exists on disk
 	EnvFile        string   // best candidate: ".env.local", ".env.development", ".env", etc.
@@ -34,7 +35,6 @@ func Detect(root string) *Result {
 	r := &Result{Framework: "unknown"}
 
 	r.detectFramework(root)
-	r.detectProjectName(root)
 	r.detectPrisma(root)
 	r.detectJSBundler(root)
 	r.detectDotenv(root)
@@ -94,79 +94,6 @@ func (r *Result) detectFramework(root string) {
 	}
 }
 
-func (r *Result) detectProjectName(root string) {
-	if r.Framework != "rails" {
-		return
-	}
-	appRB := filepath.Join(root, "config", "application.rb")
-	if f, err := os.Open(appRB); err == nil {
-		defer func() { _ = f.Close() }()
-		r.ProjectName = parseRailsApplicationModule(f)
-	}
-}
-
-func parseRailsApplicationModule(f *os.File) string {
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if beforeComment, _, ok := strings.Cut(line, "#"); ok {
-			line = beforeComment
-		}
-		fields := strings.Fields(strings.TrimSpace(line))
-		if len(fields) < 2 || fields[0] != "module" {
-			continue
-		}
-		name := strings.Trim(fields[1], `"'`)
-		if name == "" {
-			continue
-		}
-		if project := rubyModuleToProjectName(name); project != "" {
-			return project
-		}
-	}
-	return ""
-}
-
-func rubyModuleToProjectName(name string) string {
-	name = strings.ReplaceAll(name, "::", "_")
-	var b strings.Builder
-	var prev rune
-	for i, r := range name {
-		if !isASCIIAlphaNum(r) {
-			if b.Len() > 0 && prev != '_' {
-				b.WriteByte('_')
-				prev = '_'
-			}
-			continue
-		}
-		if isUpper(r) {
-			if i > 0 && prev != '_' && (isLower(prev) || isDigit(prev)) {
-				b.WriteByte('_')
-			}
-			r += 'a' - 'A'
-		}
-		b.WriteRune(r)
-		prev = r
-	}
-	return strings.Trim(b.String(), "_")
-}
-
-func isASCIIAlphaNum(r rune) bool {
-	return isLower(r) || isUpper(r) || isDigit(r)
-}
-
-func isLower(r rune) bool {
-	return r >= 'a' && r <= 'z'
-}
-
-func isUpper(r rune) bool {
-	return r >= 'A' && r <= 'Z'
-}
-
-func isDigit(r rune) bool {
-	return r >= '0' && r <= '9'
-}
-
 func (r *Result) detectDatabase(root string) {
 	dbYml := filepath.Join(root, "config", "database.yml")
 	if f, err := os.Open(dbYml); err == nil {
@@ -180,8 +107,12 @@ func (r *Result) detectDatabase(root string) {
 		case strings.Contains(adapter, "mysql"):
 			r.DBAdapter = "mysql"
 		}
-		if r.DBAdapter == "postgresql" && isDatabaseIdentifier(database) {
-			r.DBTemplate = database
+		if r.DBAdapter == "postgresql" && database != "" {
+			if isDatabaseIdentifier(database) {
+				r.DBTemplate = database
+			} else {
+				r.DBTemplateInvalid = database
+			}
 		}
 		return
 	}

--- a/internal/detect/detect_test.go
+++ b/internal/detect/detect_test.go
@@ -102,19 +102,19 @@ test:
 	}
 }
 
-func TestDetect_RailsProjectNameFromApplicationModule(t *testing.T) {
-	dir := setup(t, "Gemfile", "config/application.rb")
-	_ = os.WriteFile(filepath.Join(dir, "config/application.rb"), []byte(`require_relative "boot"
-
-module HonoluluV1
-  class Application < Rails::Application
-  end
-end
+func TestDetect_Rails_PostgreSQLInvalidTemplate(t *testing.T) {
+	dir := setup(t, "Gemfile", "config/application.rb", "config/database.yml")
+	_ = os.WriteFile(filepath.Join(dir, "config/database.yml"), []byte(`development:
+  adapter: postgresql
+  database: my-app_development
 `), 0o644)
 
 	r := Detect(dir)
-	if r.ProjectName != "honolulu_v1" {
-		t.Errorf("expected ProjectName honolulu_v1, got %q", r.ProjectName)
+	if r.DBTemplate != "" {
+		t.Errorf("expected DBTemplate empty for invalid identifier, got %q", r.DBTemplate)
+	}
+	if r.DBTemplateInvalid != "my-app_development" {
+		t.Errorf("expected DBTemplateInvalid=my-app_development, got %q", r.DBTemplateInvalid)
 	}
 }
 

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -84,6 +84,9 @@ func New(worktreePath string, mainRepo string, uc *config.UserConfig) *Setup {
 }
 
 func (s *Setup) Run() (*allocator.Allocation, error) {
+	if err := s.ProjectConfig.Validate(); err != nil {
+		return nil, err
+	}
 	if pruned, err := s.Registry.Prune(); err == nil && pruned > 0 {
 		s.log("Reclaimed %d stale allocation(s)", pruned)
 	}

--- a/internal/templates/diagnostics.go
+++ b/internal/templates/diagnostics.go
@@ -19,8 +19,22 @@ func Diagnose(det *detect.Result) []Diagnostic {
 	diags = append(diags, diagnoseEnvLoading(det)...)
 	diags = append(diags, diagnosePortWiring(det)...)
 	diags = append(diags, diagnoseUmbrella(det)...)
+	diags = append(diags, diagnoseInvalidDBTemplate(det)...)
 
 	return diags
+}
+
+func diagnoseInvalidDBTemplate(det *detect.Result) []Diagnostic {
+	if det.DBTemplateInvalid == "" {
+		return nil
+	}
+	return []Diagnostic{{
+		Level: "warn",
+		Message: fmt.Sprintf("config/database.yml has development.database = %q, which isn't a valid Postgres identifier (dashes/quotes/etc).\n"+
+			"  Treeline left database.template empty in .treeline.yml. Fix it manually before running gtl setup,\n"+
+			"  or rename the database in Postgres + database.yml so they match.",
+			det.DBTemplateInvalid),
+	}}
 }
 
 func diagnoseUmbrella(det *detect.Result) []Diagnostic {

--- a/internal/templates/diagnostics_test.go
+++ b/internal/templates/diagnostics_test.go
@@ -113,6 +113,24 @@ func TestDiagnose_WithEnvFile(t *testing.T) {
 	}
 }
 
+func TestDiagnose_InvalidDBTemplate(t *testing.T) {
+	det := &detect.Result{
+		Framework:         "rails",
+		DBAdapter:         "postgresql",
+		DBTemplateInvalid: "my-app_development",
+	}
+	diags := Diagnose(det)
+	found := false
+	for _, d := range diags {
+		if d.Level == "warn" && contains(d.Message, "my-app_development") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected warn diagnostic mentioning invalid template, got %#v", diags)
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && searchString(s, substr)
 }

--- a/internal/worktree/worktree.go
+++ b/internal/worktree/worktree.go
@@ -61,6 +61,37 @@ func DetectRepoRoot(path string) string {
 	return root
 }
 
+// RepoNameFromRemote returns the repo basename from the `origin` remote URL
+// (e.g. "fitter" from "git@github.com:acme/fitter.git" or
+// "https://gitlab.com/group/sub/fitter"). Returns "" when there's no origin
+// remote or the URL can't be parsed.
+func RepoNameFromRemote(repoPath string) string {
+	url := gitOutput(repoPath, "remote", "get-url", "origin")
+	return parseRepoNameFromURL(url)
+}
+
+func parseRepoNameFromURL(url string) string {
+	url = strings.TrimSpace(url)
+	if url == "" {
+		return ""
+	}
+	// Strip the host/userinfo prefix. For scheme URLs this trims "https://host"
+	// or "ssh://git@host"; for scp-style "git@host:path" it trims "git@host".
+	if i := strings.Index(url, "://"); i >= 0 {
+		url = url[i+3:]
+		if j := strings.Index(url, "/"); j >= 0 {
+			url = url[j+1:]
+		}
+	} else if i := strings.Index(url, ":"); i >= 0 {
+		url = url[i+1:]
+	}
+	url = strings.TrimRight(url, "/")
+	if i := strings.LastIndex(url, "/"); i >= 0 {
+		url = url[i+1:]
+	}
+	return strings.TrimSuffix(url, ".git")
+}
+
 // Create adds a git worktree at path. If newBranch is true, it creates a new
 // branch from base. Otherwise it checks out an existing branch.
 func Create(path, branch string, newBranch bool, base string) error {

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -705,3 +705,47 @@ func TestFetch_NonexistentBranch(t *testing.T) {
 		t.Error("expected error for non-existent branch")
 	}
 }
+
+func TestParseRepoNameFromURL(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"git@github.com:acme/fitter.git", "fitter"},
+		{"git@github.com:acme/fitter", "fitter"},
+		{"https://github.com/acme/fitter.git", "fitter"},
+		{"https://github.com/acme/fitter", "fitter"},
+		{"ssh://git@github.com/acme/fitter.git", "fitter"},
+		{"https://gitlab.com/group/sub/fitter.git", "fitter"},
+		{"https://gitlab.com/group/sub/fitter/", "fitter"},
+		{"file:///srv/git/fitter.git", "fitter"},
+		{"/srv/git/fitter.git", "fitter"},
+		{"fitter", "fitter"},
+		{"", ""},
+		{"   ", ""},
+	}
+	for _, c := range cases {
+		got := parseRepoNameFromURL(c.in)
+		if got != c.want {
+			t.Errorf("parseRepoNameFromURL(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestRepoNameFromRemote(t *testing.T) {
+	skipIfNoGit(t)
+	repo := initTestRepo(t)
+	run(t, repo, "git", "remote", "add", "origin", "git@github.com:acme/fitter-app.git")
+
+	got := RepoNameFromRemote(repo)
+	if got != "fitter-app" {
+		t.Errorf("RepoNameFromRemote = %q, want %q", got, "fitter-app")
+	}
+}
+
+func TestRepoNameFromRemote_NoOrigin(t *testing.T) {
+	skipIfNoGit(t)
+	repo := initTestRepo(t)
+	if got := RepoNameFromRemote(repo); got != "" {
+		t.Errorf("RepoNameFromRemote without origin = %q, want empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

A dash in a project name (or `database.template`) leaks into Postgres clone targets via `{project}` / `{template}` substitution in the database pattern, producing identifiers Postgres rejects (`createdb: error: ... ERROR: syntax error at or near "-"`). This branch fixes the immediate bug, eliminates the source of the bad name in `gtl init`, and adds a `gtl rename` command for cleaning up an existing project that was already misnamed.

### What changed

- **`buildDatabaseName` sanitizes the full post-substitution result**, not just `{worktree}`. Dashes anywhere in the pattern are converted before the name reaches Postgres.
- **`gtl init` derives the project name from `git remote get-url origin`** (basename, `.git` stripped) instead of the directory name or the Rails `application.rb` module. The result is run through `config.SanitizeIdentifier` so a `fitter-app` repo always lands as `fitter_app` in `.treeline.yml`. The Rails module detection (and dead helpers) are removed — repo name is the right anchor since it's stable across rebrands.
- **`ProjectConfig.Validate` enforces `[a-zA-Z_][a-zA-Z0-9_]*`** for `project` and `database.template`, called from `setup.Run` before allocation. Existing configs that were already misnamed get a clear error pointing at `gtl rename <suggested>`.
- **Rails `database.yml` detection no longer silently drops** a non-identifier database name — it's captured as `DBTemplateInvalid` and surfaced as a warn diagnostic in `gtl init`.
- **New `gtl rename <new-name>`** — single command that rewrites `.treeline.yml`, migrates user-config keys (port reservations, editor themes/colors, including the `project/branch` variants), drops the old databases, and re-runs `setup.Run()` for each worktree so it comes back up under the new name with a freshly cloned DB. Confirms with the user before destructive work; `-y` to skip.

### Test plan

- [x] `go test ./...` (clean)
- [x] `go vet ./...` (clean)
- [x] Smoke: `gtl rename my-bad-name` rejects the dashed name with a `Try: gtl rename my_bad_name` hint
- [x] Smoke: `gtl init` in a fresh repo with `origin = git@github.com:acme/fitter-app.git` writes `project: fitter_app` to `.treeline.yml`
- [ ] Manual end-to-end on a real Rails project: rename a project with active worktrees, confirm port reservations migrate, old DBs drop, new DBs clone

### Notes

- Tests added for: git-remote URL parsing across SSH/HTTPS/scp/GitLab subgroup forms; `buildDatabaseName` with dashed templates and projects (4 cases); `IsValidIdentifier`/`SanitizeIdentifier`; `ProjectConfig.Validate` (5 cases); `MigrateProjectKeys` end-to-end; `DBTemplateInvalid` detection; `diagnoseInvalidDBTemplate`.
- The dead Rails-only `detectProjectName` / `parseRailsApplicationModule` / `rubyModuleToProjectName` helpers and their tests are deleted (introduced in #32).