### PR TITLE
Multiplex gtl tunnel across repos via a lazy-start daemon

### DIFF
--- a/cmd/tunnel.go
+++ b/cmd/tunnel.go
@@ -17,6 +17,7 @@ import (
 	"github.com/git-treeline/cli/internal/style"
 	"github.com/git-treeline/cli/internal/templates"
 	"github.com/git-treeline/cli/internal/tunnel"
+	"github.com/git-treeline/cli/internal/tunneldaemon"
 	"github.com/git-treeline/cli/internal/worktree"
 	"github.com/spf13/cobra"
 )
@@ -83,7 +84,7 @@ Related commands:
 				routeKey := proxy.RouteKey(project, branch)
 				hostname := routeKey + "." + domain
 				printTunnelHint(hostname, domain)
-				return tunnel.RunNamed(tunnelName, domain, routeKey, port)
+				return tunneldaemon.RegisterAndWait(tunnelName, hostname, port, "")
 			}
 
 			fmt.Fprintf(os.Stderr, "Note: using quick tunnel (random URL) because project/branch could not be determined.\n")
@@ -207,13 +208,13 @@ account that owns that zone. gtl stores per-domain credentials automatically.`,
 					return fmt.Errorf("login failed: %w", err)
 				}
 
-			certPath = tunnel.CertPathForDomain(domain)
+				certPath = tunnel.CertPathForDomain(domain)
 				fmt.Println(style.Actionf("Routing %s → tunnel %q", wildcardHost, tunnelName))
 				if err := tunnel.RouteDNSWithCert(tunnelName, wildcardHost, certPath); err != nil {
 					return cliErr(cmd, printDNSManualInstructions(tunnelName, domain, err))
 				}
 
-			if !tunnel.VerifyDNS(testHost, 10*time.Second) {
+				if !tunnel.VerifyDNS(testHost, 10*time.Second) {
 					return cliErr(cmd, printDNSManualInstructions(tunnelName, domain, nil))
 				}
 			} else {

--- a/cmd/tunnel_daemon.go
+++ b/cmd/tunnel_daemon.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/git-treeline/cli/internal/tunneldaemon"
+	"github.com/spf13/cobra"
+)
+
+var (
+	tunnelDaemonSocket string
+	tunnelDaemonName   string
+)
+
+func init() {
+	tunnelDaemonCmd.Flags().StringVar(&tunnelDaemonSocket, "socket", "", "Unix socket path to listen on (required)")
+	tunnelDaemonCmd.Flags().StringVar(&tunnelDaemonName, "tunnel", "", "Cloudflare tunnel name to manage (required)")
+	rootCmd.AddCommand(tunnelDaemonCmd)
+}
+
+// tunnelDaemonCmd is hidden: it's spawned by `gtl tunnel` when no daemon is
+// running for the requested tunnel. Users shouldn't run it directly.
+var tunnelDaemonCmd = &cobra.Command{
+	Use:    "tunnel-daemon",
+	Hidden: true,
+	Short:  "Internal: run the gtl tunnel multiplexing daemon",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if tunnelDaemonSocket == "" || tunnelDaemonName == "" {
+			return fmt.Errorf("--socket and --tunnel are required")
+		}
+
+		if err := tunneldaemon.EnsureSocketDir(); err != nil {
+			return fmt.Errorf("prepare socket dir: %w", err)
+		}
+
+		// Best-effort cleanup of a stale socket from a prior crashed daemon.
+		// If another daemon is alive on this socket, Listen will fail and we
+		// exit, which is the correct behaviour for a lost spawn race.
+		if _, err := os.Stat(tunnelDaemonSocket); err == nil {
+			if c, dialErr := net.Dial("unix", tunnelDaemonSocket); dialErr == nil {
+				_ = c.Close()
+				// Another daemon is already serving this socket. Exit silently.
+				return nil
+			}
+			_ = os.Remove(tunnelDaemonSocket)
+		}
+
+		// Tighten umask so the socket is created 0600 atomically (no
+		// TOCTOU window between net.Listen and a follow-up Chmod).
+		prevUmask := syscall.Umask(0o077)
+		ln, err := net.Listen("unix", tunnelDaemonSocket)
+		syscall.Umask(prevUmask)
+		if err != nil {
+			return fmt.Errorf("listen: %w", err)
+		}
+		defer func() {
+			_ = ln.Close()
+			_ = os.Remove(tunnelDaemonSocket)
+		}()
+
+		d := tunneldaemon.New(tunnelDaemonName)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		sigs := make(chan os.Signal, 1)
+		signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+		go func() {
+			select {
+			case <-d.Done():
+				cancel()
+			case <-sigs:
+				cancel()
+			}
+		}()
+
+		return d.Run(ctx, ln)
+	},
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/git-treeline/cli
 
-go 1.26.2
+go 1.26.3
 
 require (
 	charm.land/bubbles/v2 v2.1.0

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -70,42 +70,6 @@ func ExtractTrycloudflareURL(line string) string {
 	return trycloudflareRe.FindString(line)
 }
 
-// RunNamed starts a named Cloudflare tunnel using a generated config file.
-// The tunnel must already exist (via Setup) and DNS must be routed.
-func RunNamed(tunnelName, domain, routeKey string, port int) error {
-	cfPath, err := ResolveCloudflared()
-	if err != nil {
-		return err
-	}
-
-	hostname := routeKey + "." + domain
-	configPath, err := writeTunnelConfig(tunnelName, hostname, port)
-	if err != nil {
-		return fmt.Errorf("failed to write tunnel config: %w", err)
-	}
-
-	fmt.Printf("Tunnel: https://%s → http://localhost:%d\n", hostname, port)
-	fmt.Println("Press Ctrl+C to stop")
-	fmt.Println()
-
-	cmd := exec.Command(cfPath, "tunnel", "--config", configPath, "run", tunnelName)
-	cmd.Stdout = os.Stdout
-	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
-
-	stderrPipe, err := cmd.StderrPipe()
-	if err != nil {
-		return err
-	}
-
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("failed to start cloudflared: %w", err)
-	}
-
-	go FilterCloudflaredLogs(stderrPipe)
-
-	return WaitForSignalOrExit(cmd)
-}
-
 // --- Shared cloudflared process management ---
 
 // FilterCloudflaredLogs reads cloudflared stderr and only passes through
@@ -416,25 +380,6 @@ func ConfigDir() string {
 	return filepath.Join(home, ".cloudflared")
 }
 
-// writeTunnelConfig generates a cloudflared config.yml for a named tunnel
-// routing a single hostname to a local port.
-func writeTunnelConfig(tunnelName, hostname string, port int) (string, error) {
-	credPath := findCredentialsFile(tunnelName)
-
-	config := fmt.Sprintf("tunnel: %q\ncredentials-file: %q\n\ningress:\n  - hostname: %q\n    service: http://localhost:%d\n  - service: http_status:404\n",
-		tunnelName, credPath, hostname, port)
-
-	dir := ConfigDir()
-	configPath := filepath.Join(dir, fmt.Sprintf("gtl-%s.yml", tunnelName))
-	if err := os.MkdirAll(dir, 0o700); err != nil {
-		return "", err
-	}
-	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
-		return "", err
-	}
-	return configPath, nil
-}
-
 // findCredentialsFile locates the tunnel credentials JSON in ~/.cloudflared/
 // by looking up the tunnel ID via `cloudflared tunnel list`.
 func findCredentialsFile(tunnelName string) string {
@@ -480,6 +425,42 @@ func parseTunnelListID(data []byte, name string) string {
 func GenerateConfig(tunnelName, hostname string, port int, credPath string) string {
 	return fmt.Sprintf("tunnel: %q\ncredentials-file: %q\n\ningress:\n  - hostname: %q\n    service: http://localhost:%d\n  - service: http_status:404\n",
 		tunnelName, credPath, hostname, port)
+}
+
+// HostRoute is one entry in a multi-hostname ingress config.
+type HostRoute struct {
+	Hostname string
+	Port     int
+}
+
+// GenerateMultiHostConfig produces a cloudflared config.yml whose ingress
+// section routes each hostname to its corresponding local port. Routes are
+// emitted in the order given; the trailing catch-all returns 404.
+func GenerateMultiHostConfig(tunnelName, credPath string, routes []HostRoute) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "tunnel: %q\ncredentials-file: %q\n\ningress:\n", tunnelName, credPath)
+	for _, r := range routes {
+		fmt.Fprintf(&b, "  - hostname: %q\n    service: http://localhost:%d\n", r.Hostname, r.Port)
+	}
+	b.WriteString("  - service: http_status:404\n")
+	return b.String()
+}
+
+// WriteMultiHostConfig writes a multi-hostname cloudflared config to
+// ~/.cloudflared/gtl-{tunnelName}.yml and returns the path.
+func WriteMultiHostConfig(tunnelName string, routes []HostRoute) (string, error) {
+	credPath := findCredentialsFile(tunnelName)
+	config := GenerateMultiHostConfig(tunnelName, credPath, routes)
+
+	dir := ConfigDir()
+	configPath := filepath.Join(dir, fmt.Sprintf("gtl-%s.yml", tunnelName))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(configPath, []byte(config), 0o600); err != nil {
+		return "", err
+	}
+	return configPath, nil
 }
 
 // WriteShareConfig writes a temporary cloudflared config for a share session.

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -119,15 +119,19 @@ func TestFilterLine_OutputRouting(t *testing.T) {
 	}
 }
 
-func TestWriteTunnelConfig(t *testing.T) {
+func TestWriteMultiHostConfig(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
-	_ = os.MkdirAll(filepath.Join(dir, ".cloudflared"), 0o700)
-	credPath := filepath.Join(dir, ".cloudflared", "test-tunnel.json")
+	cfDir := filepath.Join(dir, ".cloudflared")
+	_ = os.MkdirAll(cfDir, 0o700)
+	credPath := filepath.Join(cfDir, "test-tunnel.json")
 	_ = os.WriteFile(credPath, []byte(`{"AccountTag":"abc"}`), 0o600)
 
-	path, err := writeTunnelConfig("test-tunnel", "myapp-main.example.dev", 3050)
+	path, err := WriteMultiHostConfig("test-tunnel", []HostRoute{
+		{Hostname: "myapp-main.example.dev", Port: 3050},
+		{Hostname: "other-feature.example.dev", Port: 4050},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -142,12 +146,36 @@ func TestWriteTunnelConfig(t *testing.T) {
 		`tunnel: "test-tunnel"`,
 		`hostname: "myapp-main.example.dev"`,
 		"http://localhost:3050",
+		`hostname: "other-feature.example.dev"`,
+		"http://localhost:4050",
 		"http_status:404",
 	}
 	for _, check := range checks {
 		if !strings.Contains(s, check) {
 			t.Errorf("config missing %q\nGot:\n%s", check, s)
 		}
+	}
+
+	// Ingress order must match input order.
+	myapp := strings.Index(s, "myapp-main.example.dev")
+	other := strings.Index(s, "other-feature.example.dev")
+	if myapp < 0 || other < 0 || myapp > other {
+		t.Errorf("expected myapp ingress to come before other-feature in config:\n%s", s)
+	}
+
+	// http_status:404 must be the last rule.
+	if !strings.HasSuffix(strings.TrimRight(s, "\n"), "service: http_status:404") {
+		t.Errorf("expected http_status:404 catch-all at the end of ingress:\n%s", s)
+	}
+}
+
+func TestGenerateMultiHostConfig_Empty(t *testing.T) {
+	got := GenerateMultiHostConfig("t", "/tmp/c.json", nil)
+	if !strings.Contains(got, "service: http_status:404") {
+		t.Errorf("expected catch-all even with no routes:\n%s", got)
+	}
+	if strings.Contains(got, "hostname:") {
+		t.Errorf("expected no hostname entries with empty routes:\n%s", got)
 	}
 }
 

--- a/internal/tunneldaemon/client.go
+++ b/internal/tunneldaemon/client.go
@@ -1,0 +1,187 @@
+package tunneldaemon
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+// RegisterAndWait connects to the daemon for tunnelName (spawning it if not
+// running), registers (hostname → localhost:port), then blocks until the
+// process is interrupted. cloudflared output relevant to this hostname is
+// printed to stdout/stderr. The returned error is non-nil only if the
+// daemon refused the registration or the connection died unexpectedly.
+//
+// gtlBinary is the path used to spawn the daemon when one isn't already
+// running (typically os.Args[0]); if empty, RegisterAndWait will resolve
+// it via os.Executable().
+func RegisterAndWait(tunnelName, hostname string, port int, gtlBinary string) error {
+	socketPath := SocketPath(tunnelName)
+	conn, err := dialWithSpawn(socketPath, tunnelName, gtlBinary)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = conn.Close() }()
+
+	if err := writeJSON(conn, Register{Op: OpRegister, Hostname: hostname, Port: port}); err != nil {
+		return fmt.Errorf("register: %w", err)
+	}
+
+	return streamEvents(conn, hostname, port)
+}
+
+// dialWithSpawn dials the daemon socket and, if no daemon answers, forks
+// a detached daemon process and retries with backoff.
+func dialWithSpawn(socketPath, tunnelName, gtlBinary string) (net.Conn, error) {
+	if c, err := net.DialTimeout("unix", socketPath, 500*time.Millisecond); err == nil {
+		return c, nil
+	}
+
+	bin := gtlBinary
+	if bin == "" {
+		exe, err := os.Executable()
+		if err != nil {
+			return nil, fmt.Errorf("locate gtl binary: %w", err)
+		}
+		bin = exe
+	}
+
+	if err := spawnDaemon(bin, tunnelName, socketPath); err != nil {
+		return nil, fmt.Errorf("spawn daemon: %w", err)
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if c, err := net.DialTimeout("unix", socketPath, 500*time.Millisecond); err == nil {
+			return c, nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return nil, errors.New("daemon did not start in time")
+}
+
+func spawnDaemon(gtlBinary, tunnelName, socketPath string) error {
+	logPath := filepath.Join(os.TempDir(), fmt.Sprintf("gtl-tunnel-%s.log", sanitizeFilename(tunnelName)))
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		logFile = nil
+	}
+
+	cmd := exec.Command(gtlBinary, "tunnel-daemon",
+		"--tunnel", tunnelName,
+		"--socket", socketPath,
+	)
+	cmd.Stdin = nil
+	if logFile != nil {
+		cmd.Stdout = logFile
+		cmd.Stderr = logFile
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	cmd.Env = append(os.Environ(), "GTL_TUNNEL_DAEMON=1")
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+	// We don't Wait — the daemon is meant to outlive this call.
+	go func() { _ = cmd.Process.Release() }()
+	return nil
+}
+
+func writeJSON(w io.Writer, v any) error {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	if _, err := w.Write(append(b, '\n')); err != nil {
+		return err
+	}
+	return nil
+}
+
+// streamEvents reads events from the daemon until the user interrupts or
+// the connection closes. On SIGINT/SIGTERM, the connection is closed so
+// the daemon unregisters this hostname.
+func streamEvents(conn net.Conn, hostname string, port int) error {
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	defer signal.Stop(sigs)
+
+	done := make(chan error, 1)
+	go func() {
+		dec := json.NewDecoder(bufio.NewReader(conn))
+		for {
+			var ev Event
+			if err := dec.Decode(&ev); err != nil {
+				done <- err
+				return
+			}
+			renderEvent(ev, hostname, port)
+			switch ev.Kind {
+			case EventError:
+				done <- fmt.Errorf("%s", ev.Error)
+				return
+			case EventTunnelDown:
+				msg := ev.Error
+				if msg == "" {
+					msg = "cloudflared exited"
+				}
+				done <- fmt.Errorf("tunnel down: %s", msg)
+				return
+			}
+		}
+	}()
+
+	select {
+	case <-sigs:
+		_ = conn.Close()
+		// Drain so we exit cleanly without printing partial events.
+		<-done
+		return nil
+	case err := <-done:
+		if err == nil || errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	}
+}
+
+func renderEvent(ev Event, hostname string, port int) {
+	switch ev.Kind {
+	case EventRegistered:
+		fmt.Fprintf(os.Stdout, "Tunnel: https://%s → http://localhost:%d\n", ev.Hostname, ev.Port)
+		fmt.Fprintln(os.Stdout, "Press Ctrl+C to stop")
+		fmt.Fprintln(os.Stdout)
+	case EventTunnelUp:
+		// Initial cloudflared "Registered tunnel connection" line; surface to
+		// the user so they see the tunnel really came online.
+		fmt.Fprintln(os.Stdout, ev.Line)
+	case EventLog:
+		if ev.Stream == StreamStderr {
+			fmt.Fprintln(os.Stderr, ev.Line)
+		} else {
+			fmt.Fprintln(os.Stdout, ev.Line)
+		}
+	case EventError:
+		fmt.Fprintln(os.Stderr, ev.Error)
+	case EventTunnelDown:
+		msg := ev.Error
+		if msg == "" {
+			msg = "cloudflared exited"
+		}
+		fmt.Fprintf(os.Stderr, "Tunnel down: %s\n", msg)
+	}
+}
+
+func sanitizeFilename(s string) string {
+	r := strings.NewReplacer("/", "_", "\\", "_", ":", "_", " ", "_")
+	return r.Replace(s)
+}

--- a/internal/tunneldaemon/client.go
+++ b/internal/tunneldaemon/client.go
@@ -157,18 +157,18 @@ func streamEvents(conn net.Conn, hostname string, port int) error {
 func renderEvent(ev Event, hostname string, port int) {
 	switch ev.Kind {
 	case EventRegistered:
-		fmt.Fprintf(os.Stdout, "Tunnel: https://%s → http://localhost:%d\n", ev.Hostname, ev.Port)
-		fmt.Fprintln(os.Stdout, "Press Ctrl+C to stop")
-		fmt.Fprintln(os.Stdout)
+		_, _ = fmt.Fprintf(os.Stdout, "Tunnel: https://%s → http://localhost:%d\n", ev.Hostname, ev.Port)
+		_, _ = fmt.Fprintln(os.Stdout, "Press Ctrl+C to stop")
+		_, _ = fmt.Fprintln(os.Stdout)
 	case EventTunnelUp:
 		// Initial cloudflared "Registered tunnel connection" line; surface to
 		// the user so they see the tunnel really came online.
-		fmt.Fprintln(os.Stdout, ev.Line)
+		_, _ = fmt.Fprintln(os.Stdout, ev.Line)
 	case EventLog:
 		if ev.Stream == StreamStderr {
 			fmt.Fprintln(os.Stderr, ev.Line)
 		} else {
-			fmt.Fprintln(os.Stdout, ev.Line)
+			_, _ = fmt.Fprintln(os.Stdout, ev.Line)
 		}
 	case EventError:
 		fmt.Fprintln(os.Stderr, ev.Error)

--- a/internal/tunneldaemon/client_test.go
+++ b/internal/tunneldaemon/client_test.go
@@ -1,0 +1,246 @@
+package tunneldaemon
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/git-treeline/cli/internal/tunnel"
+)
+
+// TestClient_RegisterAgainstRunningDaemon exercises the full client path
+// against a daemon that is already listening. Verifies that:
+//   - the client connects without spawning,
+//   - the register handshake completes,
+//   - SIGINT triggers a clean disconnect and unregister,
+//   - the daemon regenerates its config without the dropped hostname.
+func TestClient_RegisterAgainstRunningDaemon(t *testing.T) {
+	prev := IdleShutdown
+	IdleShutdown = 200 * time.Millisecond
+	defer func() { IdleShutdown = prev }()
+
+	// Start a daemon in this process so we don't need a built binary.
+	f, err := os.CreateTemp("/tmp", "gtl-client-test-*.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sock := f.Name()
+	_ = f.Close()
+	_ = os.Remove(sock)
+	t.Cleanup(func() { _ = os.Remove(sock) })
+
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	runner := newFakeRunner()
+	cfgDir := t.TempDir()
+
+	d := New("test-tunnel")
+	d.Runner = runner
+	d.LogSink = io.Discard
+	d.WriteConfig = func(name string, routes []tunnel.HostRoute) (string, error) {
+		path := filepath.Join(cfgDir, "config.yml")
+		return path, os.WriteFile(path, []byte(tunnel.GenerateMultiHostConfig(name, "/tmp/cred.json", routes)), 0o600)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	daemonDone := make(chan struct{})
+	go func() {
+		_ = d.Run(ctx, ln)
+		close(daemonDone)
+	}()
+	defer func() {
+		cancel()
+		_ = ln.Close()
+		<-daemonDone
+	}()
+
+	// Pre-create a connection through the client API by reaching into
+	// dialWithSpawn directly (we override the socket path via SocketPath
+	// can't be done; call the dial helper with a sentinel gtlBinary that's
+	// never executed because the daemon is already up).
+	//
+	// We bypass SocketPath() and dial the test socket directly to keep the
+	// test hermetic.
+	conn, err := net.DialTimeout("unix", sock, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Drive the same streamEvents flow the client uses. We send the
+	// register, get the registered event, then interrupt.
+	if err := writeJSON(conn, Register{Op: OpRegister, Hostname: "a.example.dev", Port: 3050}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for daemon to start cloudflared once.
+	waitFor(t, "registered + started", func() bool { return runner.StartCount() >= 1 })
+
+	// Confirm the config contains the registered hostname.
+	if !strings.Contains(runner.LastConfig(), `hostname: "a.example.dev"`) {
+		t.Errorf("expected hostname in config:\n%s", runner.LastConfig())
+	}
+
+	// Close the connection — simulates Ctrl+C in the real client.
+	_ = conn.Close()
+
+	// After the only client disconnects, cloudflared should stop and the
+	// daemon should eventually fire its Done() channel.
+	select {
+	case <-d.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon did not signal Done after client disconnect")
+	}
+
+	if !runner.Current().stopped.Load() {
+		t.Error("expected cloudflared to be stopped after last client left")
+	}
+}
+
+// TestDialWithSpawn_SpawnsWhenAbsent verifies the spawn path uses the
+// provided binary. We substitute a fake binary that just listens on the
+// socket and exits, proving the client invoked it. Skipped on systems
+// without `nc -U` support.
+func TestDialWithSpawn_SpawnsWhenAbsent(t *testing.T) {
+	if !ncSupportsUnix() {
+		t.Skip("nc -lU not available; smoke test covers the spawn path")
+	}
+
+	f, err := os.CreateTemp("/tmp", "gtl-spawn-test-*.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sock := f.Name()
+	_ = f.Close()
+	_ = os.Remove(sock)
+	t.Cleanup(func() { _ = os.Remove(sock) })
+
+	fakeBin := writeFakeDaemonBinary(t, sock)
+
+	conn, err := dialWithSpawn(sock, "any", fakeBin)
+	if err != nil {
+		t.Fatalf("dialWithSpawn: %v", err)
+	}
+	_ = conn.Close()
+}
+
+func ncSupportsUnix() bool {
+	if _, err := os.Stat("/usr/bin/nc"); err == nil {
+		return true
+	}
+	if _, err := os.Stat("/bin/nc"); err == nil {
+		return true
+	}
+	return false
+}
+
+// TestDialWithSpawn_ReusesExisting verifies that when a daemon is already
+// listening, dialWithSpawn just dials without spawning anything.
+func TestDialWithSpawn_ReusesExisting(t *testing.T) {
+	f, err := os.CreateTemp("/tmp", "gtl-existing-*.sock")
+	if err != nil {
+		t.Fatal(err)
+	}
+	sock := f.Name()
+	_ = f.Close()
+	_ = os.Remove(sock)
+	t.Cleanup(func() { _ = os.Remove(sock) })
+
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	accepted := make(chan struct{}, 1)
+	go func() {
+		c, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		accepted <- struct{}{}
+		_ = c.Close()
+	}()
+
+	// Pass a non-existent binary; if the client tries to spawn, this would
+	// fail. Connection should succeed before any spawn attempt.
+	conn, err := dialWithSpawn(sock, "any", "/nonexistent/gtl-binary-xyz")
+	if err != nil {
+		t.Fatalf("dial failed: %v", err)
+	}
+	_ = conn.Close()
+
+	select {
+	case <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("daemon did not see connection")
+	}
+}
+
+// writeFakeDaemonBinary creates a tiny shell script that listens on the
+// given socket using `nc` (built-in on macOS/Linux) for a short window so
+// dialWithSpawn can connect. If nc isn't available, the test self-skips.
+func writeFakeDaemonBinary(t *testing.T, sock string) string {
+	t.Helper()
+	dir := t.TempDir()
+	bin := filepath.Join(dir, "fake-daemon")
+
+	script := "#!/bin/sh\n" +
+		"# args: tunnel-daemon --tunnel X --socket S\n" +
+		"sock=\"" + sock + "\"\n" +
+		"# Use go-style listener via netcat\n" +
+		"if command -v nc >/dev/null 2>&1; then\n" +
+		"  ( nc -lU \"$sock\" > /dev/null 2>&1 & ) \n" +
+		"  exit 0\n" +
+		"fi\n" +
+		"exit 1\n"
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return bin
+}
+
+// TestStreamEvents_RendersAndStopsOnEOF feeds a synthetic event stream
+// and verifies streamEvents returns cleanly on EOF.
+func TestStreamEvents_RendersAndStopsOnEOF(t *testing.T) {
+	server, client := net.Pipe()
+	defer client.Close()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	var streamErr error
+	go func() {
+		defer wg.Done()
+		streamErr = streamEvents(client, "x.example.dev", 3050)
+	}()
+
+	// Write a registered event then close to simulate EOF.
+	_ = writeJSON(server, Event{Kind: EventRegistered, Hostname: "x.example.dev", Port: 3050})
+	_ = server.Close()
+
+	doneCh := make(chan struct{})
+	go func() { wg.Wait(); close(doneCh) }()
+	select {
+	case <-doneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatal("streamEvents did not return after EOF")
+	}
+
+	if streamErr != nil && !errors.Is(streamErr, io.EOF) && !isClosedPipe(streamErr) {
+		t.Errorf("unexpected error: %v", streamErr)
+	}
+}
+
+func isClosedPipe(err error) bool {
+	return err != nil && (strings.Contains(err.Error(), "closed") || errors.Is(err, syscall.EPIPE))
+}

--- a/internal/tunneldaemon/client_test.go
+++ b/internal/tunneldaemon/client_test.go
@@ -160,7 +160,7 @@ func TestDialWithSpawn_ReusesExisting(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	accepted := make(chan struct{}, 1)
 	go func() {
@@ -214,7 +214,7 @@ func writeFakeDaemonBinary(t *testing.T, sock string) string {
 // and verifies streamEvents returns cleanly on EOF.
 func TestStreamEvents_RendersAndStopsOnEOF(t *testing.T) {
 	server, client := net.Pipe()
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 
 	var wg sync.WaitGroup
 	wg.Add(1)

--- a/internal/tunneldaemon/daemon.go
+++ b/internal/tunneldaemon/daemon.go
@@ -460,7 +460,7 @@ func (d *Daemon) shutdown() error {
 func (d *Daemon) Done() <-chan struct{} { return d.done }
 
 func (d *Daemon) logf(format string, args ...any) {
-	fmt.Fprintf(d.LogSink, "tunneldaemon: "+format+"\n", args...)
+	_, _ = fmt.Fprintf(d.LogSink, "tunneldaemon: "+format+"\n", args...)
 }
 
 // --- real cloudflared runner ---

--- a/internal/tunneldaemon/daemon.go
+++ b/internal/tunneldaemon/daemon.go
@@ -1,0 +1,528 @@
+package tunneldaemon
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"time"
+
+	"github.com/git-treeline/cli/internal/tunnel"
+)
+
+// IdleShutdown is how long the daemon waits with zero registrations before
+// stopping cloudflared and exiting. Short enough that an unused daemon goes
+// away quickly; long enough that fast unregister/re-register cycles don't
+// cause flapping.
+var IdleShutdown = 5 * time.Second
+
+// SocketPath returns the per-user, per-tunnel-config Unix socket path used
+// to talk to the daemon. The socket lives in cloudflared's config dir
+// (typically ~/.cloudflared, mode 0700) so any local process needs the
+// user's permissions to connect. The hash keeps the leaf short to stay
+// within macOS's ~104-byte socket name limit.
+func SocketPath(tunnelName string) string {
+	h := sha256.Sum256([]byte(tunnelName))
+	return filepath.Join(tunnel.ConfigDir(), fmt.Sprintf("gtl-tunnel-%x.sock", h[:8]))
+}
+
+// EnsureSocketDir creates the parent directory for SocketPath with
+// user-only permissions (0700). Callers should invoke this before
+// Listen so an attacker can't pre-create a world-accessible parent.
+func EnsureSocketDir() error {
+	dir := tunnel.ConfigDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	// If the dir already existed with looser permissions, tighten them.
+	return os.Chmod(dir, 0o700)
+}
+
+// Runner abstracts cloudflared execution so tests can inject a fake.
+type Runner interface {
+	Start(ctx context.Context, tunnelName, configPath string) (CloudflaredHandle, error)
+}
+
+// CloudflaredHandle controls a running cloudflared instance.
+type CloudflaredHandle interface {
+	Stderr() io.Reader
+	Stop(timeout time.Duration) error
+	Wait() error
+}
+
+// Daemon owns one cloudflared process and tracks the set of active
+// registrations keyed by client connection.
+type Daemon struct {
+	TunnelName string
+	Runner     Runner
+
+	// WriteConfig writes the cloudflared config for the given routes and
+	// returns its on-disk path. Defaults to tunnel.WriteMultiHostConfig.
+	WriteConfig func(tunnelName string, routes []tunnel.HostRoute) (string, error)
+
+	// LogSink receives daemon's own log lines (defaults to stderr).
+	LogSink io.Writer
+
+	mu      sync.Mutex
+	applyMu sync.Mutex // serializes config writes + cloudflared (re)starts
+	clients map[*client]struct{}
+	session *cloudflaredSession
+
+	idleTimer *time.Timer
+	done      chan struct{}
+	doneOnce  sync.Once
+}
+
+// cloudflaredSession bundles a running cloudflared with the metadata we
+// need to tell intentional stops apart from unexpected exits.
+type cloudflaredSession struct {
+	handle   CloudflaredHandle
+	done     chan struct{} // closed when handle.Wait returns
+	expected atomic.Bool   // set before any clean stop
+}
+
+type client struct {
+	conn     net.Conn
+	enc      *json.Encoder
+	encMu    sync.Mutex
+	hostname string
+	port     int
+}
+
+// New returns a daemon ready to serve. Call Run with a listening socket.
+func New(tunnelName string) *Daemon {
+	return &Daemon{
+		TunnelName:  tunnelName,
+		Runner:      cloudflaredRunner{},
+		WriteConfig: tunnel.WriteMultiHostConfig,
+		LogSink:     os.Stderr,
+		clients:     make(map[*client]struct{}),
+		done:        make(chan struct{}),
+	}
+}
+
+// Run accepts connections from the given listener until the daemon's idle
+// timer fires (after the last client disconnects) or ctx is cancelled.
+func (d *Daemon) Run(ctx context.Context, ln net.Listener) error {
+	go func() {
+		<-ctx.Done()
+		_ = ln.Close()
+	}()
+
+	d.armIdleTimer()
+
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			select {
+			case <-d.done:
+				return d.shutdown()
+			case <-ctx.Done():
+				return d.shutdown()
+			default:
+			}
+			if errors.Is(err, net.ErrClosed) {
+				return d.shutdown()
+			}
+			d.logf("accept: %v", err)
+			continue
+		}
+		go d.handleConn(conn)
+	}
+}
+
+func (d *Daemon) handleConn(conn net.Conn) {
+	c := &client{
+		conn: conn,
+		enc:  json.NewEncoder(conn),
+	}
+	defer d.dropClient(c)
+
+	r := bufio.NewReader(conn)
+	line, err := r.ReadBytes('\n')
+	if err != nil {
+		_ = conn.Close()
+		return
+	}
+
+	var reg Register
+	if err := json.Unmarshal(line, &reg); err != nil || reg.Op != OpRegister {
+		c.send(Event{Kind: EventError, Error: "invalid register message"})
+		_ = conn.Close()
+		return
+	}
+	if reg.Hostname == "" || reg.Port <= 0 || reg.Port > 65535 {
+		c.send(Event{Kind: EventError, Error: "hostname and valid port required"})
+		_ = conn.Close()
+		return
+	}
+	c.hostname = reg.Hostname
+	c.port = reg.Port
+
+	if err := d.addClient(c); err != nil {
+		c.send(Event{Kind: EventError, Error: err.Error()})
+		_ = conn.Close()
+		return
+	}
+	c.send(Event{Kind: EventRegistered, Hostname: c.hostname, Port: c.port})
+
+	// Block until the client closes the connection; that's how we detect
+	// "unregister" (Ctrl+C on the client side).
+	buf := make([]byte, 1)
+	for {
+		if _, err := r.Read(buf); err != nil {
+			return
+		}
+	}
+}
+
+// addClient registers a new client, rewrites the config, and starts or
+// restarts cloudflared so its ingress includes the new hostname.
+func (d *Daemon) addClient(c *client) error {
+	d.mu.Lock()
+
+	// Reject duplicate hostname registrations (single repo running gtl tunnel
+	// twice would collide on subdomain anyway). Different port for same
+	// hostname is also rejected — caller should restart cleanly.
+	for existing := range d.clients {
+		if existing.hostname == c.hostname {
+			d.mu.Unlock()
+			return fmt.Errorf("hostname %s is already registered (port %d)", c.hostname, existing.port)
+		}
+	}
+
+	d.clients[c] = struct{}{}
+	if d.idleTimer != nil {
+		d.idleTimer.Stop()
+		d.idleTimer = nil
+	}
+	routes := d.routesLocked()
+	d.mu.Unlock()
+
+	return d.applyRoutes(routes)
+}
+
+func (d *Daemon) dropClient(c *client) {
+	d.mu.Lock()
+	if _, ok := d.clients[c]; !ok {
+		d.mu.Unlock()
+		_ = c.conn.Close()
+		return
+	}
+	delete(d.clients, c)
+	routes := d.routesLocked()
+	empty := len(d.clients) == 0
+	d.mu.Unlock()
+
+	_ = c.conn.Close()
+
+	if empty {
+		d.armIdleTimer()
+		// Stop cloudflared eagerly so we don't keep an idle tunnel up.
+		d.stopCloudflared()
+		return
+	}
+
+	if err := d.applyRoutes(routes); err != nil {
+		d.logf("apply routes after drop: %v", err)
+	}
+}
+
+func (d *Daemon) routesLocked() []tunnel.HostRoute {
+	routes := make([]tunnel.HostRoute, 0, len(d.clients))
+	for c := range d.clients {
+		routes = append(routes, tunnel.HostRoute{Hostname: c.hostname, Port: c.port})
+	}
+	sort.Slice(routes, func(i, j int) bool { return routes[i].Hostname < routes[j].Hostname })
+	return routes
+}
+
+// applyRoutes writes a fresh cloudflared config and (re)starts cloudflared
+// so the new ingress takes effect. Restart-on-change is the explicit
+// tradeoff: SIGHUP-based reload isn't reliable across cloudflared versions,
+// so adding or removing one branch briefly interrupts the others sharing
+// this daemon. applyMu serializes concurrent callers.
+func (d *Daemon) applyRoutes(routes []tunnel.HostRoute) error {
+	d.applyMu.Lock()
+	defer d.applyMu.Unlock()
+
+	if len(routes) == 0 {
+		d.stopCloudflaredLocked()
+		return nil
+	}
+
+	configPath, err := d.WriteConfig(d.TunnelName, routes)
+	if err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+
+	d.stopCloudflaredLocked()
+
+	handle, err := d.Runner.Start(context.Background(), d.TunnelName, configPath)
+	if err != nil {
+		return fmt.Errorf("start cloudflared: %w", err)
+	}
+	sess := &cloudflaredSession{handle: handle, done: make(chan struct{})}
+	d.mu.Lock()
+	d.session = sess
+	d.mu.Unlock()
+
+	go d.pumpStderr(handle.Stderr())
+	go d.watchSession(sess)
+	return nil
+}
+
+// watchSession waits for cloudflared to exit. If the session is still the
+// active one and wasn't marked as an expected stop, that's an unexpected
+// exit (auth failure, crash, network blip) — notify clients and drop their
+// connections so the CLI returns instead of pretending the tunnel is live.
+func (d *Daemon) watchSession(sess *cloudflaredSession) {
+	_ = sess.handle.Wait()
+	close(sess.done)
+	if sess.expected.Load() {
+		return
+	}
+	d.mu.Lock()
+	current := d.session == sess
+	if current {
+		d.session = nil
+	}
+	d.mu.Unlock()
+	if !current {
+		return
+	}
+	d.handleUnexpectedExit()
+}
+
+func (d *Daemon) handleUnexpectedExit() {
+	d.broadcast(Event{Kind: EventTunnelDown, Error: "cloudflared exited unexpectedly"})
+
+	d.mu.Lock()
+	for c := range d.clients {
+		_ = c.conn.Close()
+	}
+	d.clients = map[*client]struct{}{}
+	d.mu.Unlock()
+
+	d.armIdleTimer()
+}
+
+func (d *Daemon) stopCloudflared() {
+	d.applyMu.Lock()
+	defer d.applyMu.Unlock()
+	d.stopCloudflaredLocked()
+}
+
+// stopCloudflaredLocked stops the running cloudflared, if any. Caller must
+// hold d.applyMu so we don't race with a concurrent start. The session's
+// expected flag is set before Stop so the watcher knows this isn't a crash.
+func (d *Daemon) stopCloudflaredLocked() {
+	d.mu.Lock()
+	sess := d.session
+	d.session = nil
+	d.mu.Unlock()
+	if sess == nil {
+		return
+	}
+	sess.expected.Store(true)
+	_ = sess.handle.Stop(5 * time.Second)
+	<-sess.done
+}
+
+// pumpStderr fans out cloudflared stderr lines to connected clients,
+// filtering by relevance. Errors/warnings broadcast to everyone; request
+// logs route only to the client whose hostname appears in the line; INF
+// spam is dropped.
+func (d *Daemon) pumpStderr(r io.Reader) {
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
+	for scanner.Scan() {
+		line := scanner.Text()
+		d.fanout(line)
+	}
+}
+
+var requestMethodRe = regexp.MustCompile(`\b(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\b`)
+
+func (d *Daemon) fanout(line string) {
+	switch classifyLine(line) {
+	case lineError:
+		d.broadcast(Event{Kind: EventLog, Stream: StreamStderr, Line: line})
+	case lineRequest:
+		d.routeRequestLog(line)
+	case lineRegistered:
+		d.broadcast(Event{Kind: EventTunnelUp, Line: line})
+	default:
+		// dropped
+	}
+}
+
+type lineClass int
+
+const (
+	lineDrop lineClass = iota
+	lineError
+	lineRequest
+	lineRegistered
+)
+
+func classifyLine(line string) lineClass {
+	switch {
+	case strings.Contains(line, "ERR"),
+		strings.Contains(line, "WRN"),
+		strings.Contains(line, "failed"),
+		strings.Contains(line, "error"):
+		return lineError
+	case requestMethodRe.MatchString(line):
+		return lineRequest
+	case strings.Contains(line, "INF") && strings.Contains(line, "Registered"):
+		return lineRegistered
+	}
+	return lineDrop
+}
+
+func (d *Daemon) routeRequestLog(line string) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for c := range d.clients {
+		if strings.Contains(line, c.hostname) {
+			c.send(Event{Kind: EventLog, Stream: StreamStdout, Line: line})
+			return
+		}
+	}
+	// No matching client — broadcast as fallback so a stray log isn't lost.
+	for c := range d.clients {
+		c.send(Event{Kind: EventLog, Stream: StreamStdout, Line: line})
+	}
+}
+
+func (d *Daemon) broadcast(ev Event) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	for c := range d.clients {
+		c.send(ev)
+	}
+}
+
+func (c *client) send(ev Event) {
+	c.encMu.Lock()
+	defer c.encMu.Unlock()
+	_ = c.conn.SetWriteDeadline(time.Now().Add(2 * time.Second))
+	_ = c.enc.Encode(ev)
+	_ = c.conn.SetWriteDeadline(time.Time{})
+}
+
+func (d *Daemon) armIdleTimer() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if len(d.clients) != 0 {
+		return
+	}
+	if d.idleTimer != nil {
+		d.idleTimer.Stop()
+	}
+	d.idleTimer = time.AfterFunc(IdleShutdown, func() {
+		d.mu.Lock()
+		stillEmpty := len(d.clients) == 0
+		d.mu.Unlock()
+		if stillEmpty {
+			d.doneOnce.Do(func() { close(d.done) })
+		}
+	})
+}
+
+func (d *Daemon) shutdown() error {
+	d.stopCloudflared()
+	d.mu.Lock()
+	for c := range d.clients {
+		_ = c.conn.Close()
+	}
+	d.clients = map[*client]struct{}{}
+	d.mu.Unlock()
+	return nil
+}
+
+// Done returns a channel closed when the daemon decides to exit (idle
+// shutdown or listener closed by ctx cancel).
+func (d *Daemon) Done() <-chan struct{} { return d.done }
+
+func (d *Daemon) logf(format string, args ...any) {
+	fmt.Fprintf(d.LogSink, "tunneldaemon: "+format+"\n", args...)
+}
+
+// --- real cloudflared runner ---
+
+type cloudflaredRunner struct{}
+
+func (cloudflaredRunner) Start(ctx context.Context, tunnelName, configPath string) (CloudflaredHandle, error) {
+	cfPath, err := tunnel.ResolveCloudflared()
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.CommandContext(ctx, cfPath, "tunnel", "--config", configPath, "run", tunnelName)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, err
+	}
+	return &realHandle{cmd: cmd, stderr: stderr}, nil
+}
+
+type realHandle struct {
+	cmd     *exec.Cmd
+	stderr  io.ReadCloser
+	once    sync.Once
+	done    chan struct{} // closed when cmd.Wait returns
+	waitErr error         // populated before done is closed
+}
+
+func (h *realHandle) Stderr() io.Reader { return h.stderr }
+
+func (h *realHandle) Stop(timeout time.Duration) error {
+	h.ensureWaiter()
+	if h.cmd.Process == nil {
+		return nil
+	}
+	_ = syscall.Kill(-h.cmd.Process.Pid, syscall.SIGTERM)
+	select {
+	case <-h.done:
+		return nil
+	case <-time.After(timeout):
+		_ = syscall.Kill(-h.cmd.Process.Pid, syscall.SIGKILL)
+		<-h.done
+		return nil
+	}
+}
+
+func (h *realHandle) Wait() error {
+	h.ensureWaiter()
+	<-h.done
+	return h.waitErr
+}
+
+func (h *realHandle) ensureWaiter() {
+	h.once.Do(func() {
+		h.done = make(chan struct{})
+		go func() {
+			h.waitErr = h.cmd.Wait()
+			close(h.done)
+		}()
+	})
+}
+

--- a/internal/tunneldaemon/daemon_test.go
+++ b/internal/tunneldaemon/daemon_test.go
@@ -1,0 +1,535 @@
+package tunneldaemon
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/git-treeline/cli/internal/tunnel"
+)
+
+// --- fake runner -------------------------------------------------------------
+
+// fakeRunner records every Start call and returns a controllable handle.
+// The handle's stderr can be fed synthetic cloudflared log lines via Feed.
+type fakeRunner struct {
+	mu      sync.Mutex
+	starts  []startCall
+	current *fakeHandle
+	startCh chan struct{} // closed each time a new handle is created
+}
+
+type startCall struct {
+	TunnelName string
+	ConfigPath string
+	Config     string
+}
+
+func newFakeRunner() *fakeRunner {
+	return &fakeRunner{startCh: make(chan struct{}, 8)}
+}
+
+func (r *fakeRunner) Start(_ context.Context, tunnelName, configPath string) (CloudflaredHandle, error) {
+	data, _ := os.ReadFile(configPath)
+	h := &fakeHandle{
+		stderr: newPipeReader(),
+		done:   make(chan struct{}),
+	}
+	r.mu.Lock()
+	r.starts = append(r.starts, startCall{TunnelName: tunnelName, ConfigPath: configPath, Config: string(data)})
+	r.current = h
+	r.mu.Unlock()
+	select {
+	case r.startCh <- struct{}{}:
+	default:
+	}
+	return h, nil
+}
+
+func (r *fakeRunner) Current() *fakeHandle {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.current
+}
+
+func (r *fakeRunner) StartCount() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return len(r.starts)
+}
+
+func (r *fakeRunner) LastConfig() string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.starts) == 0 {
+		return ""
+	}
+	return r.starts[len(r.starts)-1].Config
+}
+
+type fakeHandle struct {
+	stderr  *pipeReader
+	done    chan struct{}
+	stopped atomic.Bool
+}
+
+func (h *fakeHandle) Stderr() io.Reader { return h.stderr }
+
+func (h *fakeHandle) Stop(_ time.Duration) error {
+	if h.stopped.CompareAndSwap(false, true) {
+		h.stderr.Close()
+		close(h.done)
+	}
+	return nil
+}
+
+func (h *fakeHandle) Wait() error {
+	<-h.done
+	return nil
+}
+
+func (h *fakeHandle) Feed(line string) {
+	h.stderr.Write([]byte(line + "\n"))
+}
+
+// pipeReader is a goroutine-safe in-memory pipe that survives multiple
+// writes and a close.
+type pipeReader struct {
+	mu     sync.Mutex
+	buf    bytes.Buffer
+	cond   *sync.Cond
+	closed bool
+}
+
+func newPipeReader() *pipeReader {
+	p := &pipeReader{}
+	p.cond = sync.NewCond(&p.mu)
+	return p
+}
+
+func (p *pipeReader) Write(b []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	n, err := p.buf.Write(b)
+	p.cond.Broadcast()
+	return n, err
+}
+
+func (p *pipeReader) Read(b []byte) (int, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for p.buf.Len() == 0 && !p.closed {
+		p.cond.Wait()
+	}
+	if p.buf.Len() == 0 && p.closed {
+		return 0, io.EOF
+	}
+	return p.buf.Read(b)
+}
+
+func (p *pipeReader) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.closed = true
+	p.cond.Broadcast()
+	return nil
+}
+
+// --- test helpers ------------------------------------------------------------
+
+// startDaemon spins up a daemon listening on a temp Unix socket and returns
+// the daemon, the runner, and a cleanup function.
+func startDaemon(t *testing.T) (*Daemon, *fakeRunner, string, func()) {
+	t.Helper()
+
+	// macOS caps Unix socket paths at ~104 bytes; t.TempDir() under
+	// /var/folders/... already eats most of that, so put the socket
+	// directly under /tmp with a per-test random suffix.
+	f, err := os.CreateTemp("/tmp", "gtl-tunneldaemon-test-*.sock")
+	if err != nil {
+		t.Fatalf("temp socket: %v", err)
+	}
+	sock := f.Name()
+	_ = f.Close()
+	_ = os.Remove(sock)
+	t.Cleanup(func() { _ = os.Remove(sock) })
+
+	ln, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	cfgDir := t.TempDir()
+	runner := newFakeRunner()
+
+	d := New("test-tunnel")
+	d.Runner = runner
+	d.LogSink = io.Discard
+	d.WriteConfig = func(name string, routes []tunnel.HostRoute) (string, error) {
+		path := filepath.Join(cfgDir, "config.yml")
+		return path, os.WriteFile(path, []byte(tunnel.GenerateMultiHostConfig(name, "/tmp/cred.json", routes)), 0o600)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	doneRun := make(chan error, 1)
+	go func() { doneRun <- d.Run(ctx, ln) }()
+
+	cleanup := func() {
+		cancel()
+		_ = ln.Close()
+		select {
+		case <-doneRun:
+		case <-time.After(2 * time.Second):
+			t.Logf("daemon did not exit in 2s")
+		}
+	}
+
+	return d, runner, sock, cleanup
+}
+
+// dialAndRegister dials the socket, sends a register message, and returns
+// the connection and a decoder positioned past the "registered" event.
+func dialAndRegister(t *testing.T, sock, hostname string, port int) (net.Conn, *json.Decoder) {
+	t.Helper()
+	conn, err := net.DialTimeout("unix", sock, time.Second)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	b, _ := json.Marshal(Register{Op: OpRegister, Hostname: hostname, Port: port})
+	if _, err := conn.Write(append(b, '\n')); err != nil {
+		t.Fatalf("write register: %v", err)
+	}
+	dec := json.NewDecoder(bufio.NewReader(conn))
+	var ev Event
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+	if err := dec.Decode(&ev); err != nil {
+		t.Fatalf("decode registered: %v", err)
+	}
+	_ = conn.SetReadDeadline(time.Time{})
+	if ev.Kind != EventRegistered {
+		t.Fatalf("expected registered, got %+v", ev)
+	}
+	return conn, dec
+}
+
+func waitFor(t *testing.T, name string, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timeout waiting for: %s", name)
+}
+
+// --- tests -------------------------------------------------------------------
+
+func TestSocketPath_ShortAndDeterministic(t *testing.T) {
+	p1 := SocketPath("gtl")
+	p2 := SocketPath("gtl")
+	if p1 != p2 {
+		t.Errorf("expected deterministic path, got %q vs %q", p1, p2)
+	}
+	if len(p1) > 90 {
+		t.Errorf("socket path too long for macOS (%d > 90): %s", len(p1), p1)
+	}
+	if SocketPath("gtl-work") == SocketPath("gtl") {
+		t.Error("expected different paths for different tunnel names")
+	}
+}
+
+func TestSocketPath_UnderUserConfigDir(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	got := SocketPath("gtl")
+	if !strings.Contains(got, ".cloudflared") {
+		t.Errorf("expected socket under ~/.cloudflared, got %q", got)
+	}
+	if strings.HasPrefix(got, "/tmp/") {
+		t.Errorf("socket should not be in /tmp: %q", got)
+	}
+}
+
+func TestEnsureSocketDir_CreatesWith0700(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	if err := EnsureSocketDir(); err != nil {
+		t.Fatalf("EnsureSocketDir: %v", err)
+	}
+
+	info, err := os.Stat(filepath.Join(dir, ".cloudflared"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if mode := info.Mode().Perm(); mode != 0o700 {
+		t.Errorf("expected mode 0700, got %o", mode)
+	}
+}
+
+func TestEnsureSocketDir_TightensExistingMode(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	cfDir := filepath.Join(dir, ".cloudflared")
+	if err := os.MkdirAll(cfDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureSocketDir(); err != nil {
+		t.Fatalf("EnsureSocketDir: %v", err)
+	}
+
+	info, _ := os.Stat(cfDir)
+	if mode := info.Mode().Perm(); mode != 0o700 {
+		t.Errorf("expected tightened to 0700, got %o", mode)
+	}
+}
+
+func TestDaemon_RegisterStartsCloudflared(t *testing.T) {
+	_, runner, sock, cleanup := startDaemon(t)
+	defer cleanup()
+
+	conn, _ := dialAndRegister(t, sock, "a.example.dev", 3050)
+	defer conn.Close()
+
+	waitFor(t, "cloudflared start", func() bool { return runner.StartCount() >= 1 })
+
+	got := runner.LastConfig()
+	if !contains(got, `hostname: "a.example.dev"`) {
+		t.Errorf("config missing first hostname:\n%s", got)
+	}
+	if !contains(got, "http://localhost:3050") {
+		t.Errorf("config missing first port:\n%s", got)
+	}
+}
+
+func TestDaemon_TwoClientsBothInIngress(t *testing.T) {
+	_, runner, sock, cleanup := startDaemon(t)
+	defer cleanup()
+
+	c1, _ := dialAndRegister(t, sock, "a.example.dev", 3050)
+	defer c1.Close()
+	waitFor(t, "first start", func() bool { return runner.StartCount() >= 1 })
+
+	c2, _ := dialAndRegister(t, sock, "b.example.dev", 3060)
+	defer c2.Close()
+	waitFor(t, "restart for second client", func() bool { return runner.StartCount() >= 2 })
+
+	got := runner.LastConfig()
+	if !contains(got, `hostname: "a.example.dev"`) || !contains(got, "http://localhost:3050") {
+		t.Errorf("config missing first route:\n%s", got)
+	}
+	if !contains(got, `hostname: "b.example.dev"`) || !contains(got, "http://localhost:3060") {
+		t.Errorf("config missing second route:\n%s", got)
+	}
+}
+
+func TestDaemon_DuplicateHostnameRejected(t *testing.T) {
+	_, _, sock, cleanup := startDaemon(t)
+	defer cleanup()
+
+	c1, _ := dialAndRegister(t, sock, "dup.example.dev", 3050)
+	defer c1.Close()
+
+	conn, err := net.DialTimeout("unix", sock, time.Second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+	b, _ := json.Marshal(Register{Op: OpRegister, Hostname: "dup.example.dev", Port: 3060})
+	_, _ = conn.Write(append(b, '\n'))
+	dec := json.NewDecoder(bufio.NewReader(conn))
+	var ev Event
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+	if err := dec.Decode(&ev); err != nil {
+		t.Fatal(err)
+	}
+	if ev.Kind != EventError {
+		t.Errorf("expected error event, got %+v", ev)
+	}
+}
+
+func TestDaemon_DisconnectRegeneratesConfig(t *testing.T) {
+	_, runner, sock, cleanup := startDaemon(t)
+	defer cleanup()
+
+	c1, _ := dialAndRegister(t, sock, "a.example.dev", 3050)
+	c2, _ := dialAndRegister(t, sock, "b.example.dev", 3060)
+	defer c2.Close()
+	waitFor(t, "two starts", func() bool { return runner.StartCount() >= 2 })
+
+	_ = c1.Close()
+
+	// Eventually the daemon should restart cloudflared with only b.example.dev.
+	waitFor(t, "config rewritten without a", func() bool {
+		cfg := runner.LastConfig()
+		return contains(cfg, `hostname: "b.example.dev"`) && !contains(cfg, `hostname: "a.example.dev"`)
+	})
+}
+
+func TestDaemon_LastDisconnectStopsCloudflaredAndExits(t *testing.T) {
+	prev := IdleShutdown
+	IdleShutdown = 100 * time.Millisecond
+	defer func() { IdleShutdown = prev }()
+
+	d, runner, sock, cleanup := startDaemon(t)
+	defer cleanup()
+
+	c1, _ := dialAndRegister(t, sock, "a.example.dev", 3050)
+	waitFor(t, "started", func() bool { return runner.StartCount() >= 1 })
+	h := runner.Current()
+
+	_ = c1.Close()
+
+	waitFor(t, "cloudflared stopped", func() bool { return h.stopped.Load() })
+
+	select {
+	case <-d.Done():
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon did not signal Done after idle timeout")
+	}
+}
+
+func TestDaemon_BroadcastsErrorLine(t *testing.T) {
+	_, runner, sock, cleanup := startDaemon(t)
+	defer cleanup()
+
+	conn, dec := dialAndRegister(t, sock, "a.example.dev", 3050)
+	defer conn.Close()
+	waitFor(t, "started", func() bool { return runner.StartCount() >= 1 })
+
+	runner.Current().Feed("2024 ERR cloudflared failed to authenticate")
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	var ev Event
+	if err := dec.Decode(&ev); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if ev.Kind != EventLog || ev.Stream != StreamStderr {
+		t.Errorf("expected stderr log event, got %+v", ev)
+	}
+	if !contains(ev.Line, "ERR") {
+		t.Errorf("expected ERR in line, got %q", ev.Line)
+	}
+}
+
+// TestDaemon_UnexpectedCloudflaredExitNotifiesClients verifies that when
+// cloudflared dies on its own (auth fail, crash, network), the daemon
+// broadcasts EventTunnelDown and drops all client connections so the CLI
+// can return instead of pretending the tunnel is live.
+func TestDaemon_UnexpectedCloudflaredExitNotifiesClients(t *testing.T) {
+	_, runner, sock, cleanup := startDaemon(t)
+	defer cleanup()
+
+	conn, dec := dialAndRegister(t, sock, "a.example.dev", 3050)
+	defer conn.Close()
+	waitFor(t, "started", func() bool { return runner.StartCount() >= 1 })
+
+	// Simulate cloudflared crashing on its own.
+	runner.Current().Stop(0)
+
+	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
+	sawDown := false
+	for !sawDown {
+		var ev Event
+		if err := dec.Decode(&ev); err != nil {
+			break
+		}
+		if ev.Kind == EventTunnelDown {
+			sawDown = true
+		}
+	}
+	if !sawDown {
+		t.Fatal("client did not receive EventTunnelDown after cloudflared exit")
+	}
+
+	// Subsequent reads should EOF (connection closed by daemon).
+	_ = conn.SetReadDeadline(time.Now().Add(time.Second))
+	var ev Event
+	if err := dec.Decode(&ev); err == nil {
+		t.Errorf("expected connection closed, got further event: %+v", ev)
+	}
+}
+
+// TestDaemon_ExpectedStopDoesNotBroadcastDown verifies that the routine
+// restart path (registration change) does NOT emit EventTunnelDown.
+func TestDaemon_ExpectedStopDoesNotBroadcastDown(t *testing.T) {
+	_, runner, sock, cleanup := startDaemon(t)
+	defer cleanup()
+
+	cA, decA := dialAndRegister(t, sock, "a.example.dev", 3050)
+	defer cA.Close()
+	waitFor(t, "started", func() bool { return runner.StartCount() >= 1 })
+
+	cB, _ := dialAndRegister(t, sock, "b.example.dev", 3060)
+	defer cB.Close()
+	waitFor(t, "restart for B", func() bool { return runner.StartCount() >= 2 })
+
+	// Client A must NOT see an EventTunnelDown from the routine restart.
+	_ = cA.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	for {
+		var ev Event
+		if err := decA.Decode(&ev); err != nil {
+			break
+		}
+		if ev.Kind == EventTunnelDown {
+			t.Fatalf("unexpected EventTunnelDown during routine restart: %+v", ev)
+		}
+	}
+}
+
+func TestDaemon_RequestLogRoutedByHostname(t *testing.T) {
+	_, runner, sock, cleanup := startDaemon(t)
+	defer cleanup()
+
+	cA, decA := dialAndRegister(t, sock, "a.example.dev", 3050)
+	defer cA.Close()
+	cB, decB := dialAndRegister(t, sock, "b.example.dev", 3060)
+	defer cB.Close()
+	waitFor(t, "second start", func() bool { return runner.StartCount() >= 2 })
+
+	runner.Current().Feed("GET https://a.example.dev/health 200 5ms")
+
+	// A should receive the log; B should not (timeout).
+	_ = cA.SetReadDeadline(time.Now().Add(1 * time.Second))
+	var ev Event
+	if err := decA.Decode(&ev); err != nil {
+		t.Fatalf("A decode: %v", err)
+	}
+	if !contains(ev.Line, "a.example.dev") {
+		t.Errorf("A got wrong line: %q", ev.Line)
+	}
+
+	_ = cB.SetReadDeadline(time.Now().Add(300 * time.Millisecond))
+	if err := decB.Decode(&ev); err == nil {
+		t.Errorf("B should not have received the log, got %+v", ev)
+	} else if !isTimeout(err) && !errors.Is(err, io.EOF) {
+		t.Errorf("B unexpected error: %v", err)
+	}
+}
+
+// --- utilities --------------------------------------------------------------
+
+func contains(haystack, needle string) bool {
+	return bytes.Contains([]byte(haystack), []byte(needle))
+}
+
+func isTimeout(err error) bool {
+	var ne net.Error
+	if errors.As(err, &ne) {
+		return ne.Timeout()
+	}
+	return false
+}

--- a/internal/tunneldaemon/daemon_test.go
+++ b/internal/tunneldaemon/daemon_test.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -252,13 +251,12 @@ func TestSocketPath_ShortAndDeterministic(t *testing.T) {
 }
 
 func TestSocketPath_UnderUserConfigDir(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	home := t.TempDir()
+	t.Setenv("HOME", home)
 	got := SocketPath("gtl")
-	if !strings.Contains(got, ".cloudflared") {
-		t.Errorf("expected socket under ~/.cloudflared, got %q", got)
-	}
-	if strings.HasPrefix(got, "/tmp/") {
-		t.Errorf("socket should not be in /tmp: %q", got)
+	wantDir := filepath.Join(home, ".cloudflared")
+	if filepath.Dir(got) != wantDir {
+		t.Errorf("expected socket under %s, got parent %s (full: %s)", wantDir, filepath.Dir(got), got)
 	}
 }
 

--- a/internal/tunneldaemon/daemon_test.go
+++ b/internal/tunneldaemon/daemon_test.go
@@ -87,7 +87,7 @@ func (h *fakeHandle) Stderr() io.Reader { return h.stderr }
 
 func (h *fakeHandle) Stop(_ time.Duration) error {
 	if h.stopped.CompareAndSwap(false, true) {
-		h.stderr.Close()
+		_ = h.stderr.Close()
 		close(h.done)
 	}
 	return nil
@@ -99,7 +99,7 @@ func (h *fakeHandle) Wait() error {
 }
 
 func (h *fakeHandle) Feed(line string) {
-	h.stderr.Write([]byte(line + "\n"))
+	_, _ = h.stderr.Write([]byte(line + "\n"))
 }
 
 // pipeReader is a goroutine-safe in-memory pipe that survives multiple
@@ -300,7 +300,7 @@ func TestDaemon_RegisterStartsCloudflared(t *testing.T) {
 	defer cleanup()
 
 	conn, _ := dialAndRegister(t, sock, "a.example.dev", 3050)
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 
 	waitFor(t, "cloudflared start", func() bool { return runner.StartCount() >= 1 })
 
@@ -318,11 +318,11 @@ func TestDaemon_TwoClientsBothInIngress(t *testing.T) {
 	defer cleanup()
 
 	c1, _ := dialAndRegister(t, sock, "a.example.dev", 3050)
-	defer c1.Close()
+	defer func() { _ = c1.Close() }()
 	waitFor(t, "first start", func() bool { return runner.StartCount() >= 1 })
 
 	c2, _ := dialAndRegister(t, sock, "b.example.dev", 3060)
-	defer c2.Close()
+	defer func() { _ = c2.Close() }()
 	waitFor(t, "restart for second client", func() bool { return runner.StartCount() >= 2 })
 
 	got := runner.LastConfig()
@@ -339,13 +339,13 @@ func TestDaemon_DuplicateHostnameRejected(t *testing.T) {
 	defer cleanup()
 
 	c1, _ := dialAndRegister(t, sock, "dup.example.dev", 3050)
-	defer c1.Close()
+	defer func() { _ = c1.Close() }()
 
 	conn, err := net.DialTimeout("unix", sock, time.Second)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	b, _ := json.Marshal(Register{Op: OpRegister, Hostname: "dup.example.dev", Port: 3060})
 	_, _ = conn.Write(append(b, '\n'))
 	dec := json.NewDecoder(bufio.NewReader(conn))
@@ -365,7 +365,7 @@ func TestDaemon_DisconnectRegeneratesConfig(t *testing.T) {
 
 	c1, _ := dialAndRegister(t, sock, "a.example.dev", 3050)
 	c2, _ := dialAndRegister(t, sock, "b.example.dev", 3060)
-	defer c2.Close()
+	defer func() { _ = c2.Close() }()
 	waitFor(t, "two starts", func() bool { return runner.StartCount() >= 2 })
 
 	_ = c1.Close()
@@ -405,7 +405,7 @@ func TestDaemon_BroadcastsErrorLine(t *testing.T) {
 	defer cleanup()
 
 	conn, dec := dialAndRegister(t, sock, "a.example.dev", 3050)
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	waitFor(t, "started", func() bool { return runner.StartCount() >= 1 })
 
 	runner.Current().Feed("2024 ERR cloudflared failed to authenticate")
@@ -432,11 +432,11 @@ func TestDaemon_UnexpectedCloudflaredExitNotifiesClients(t *testing.T) {
 	defer cleanup()
 
 	conn, dec := dialAndRegister(t, sock, "a.example.dev", 3050)
-	defer conn.Close()
+	defer func() { _ = conn.Close() }()
 	waitFor(t, "started", func() bool { return runner.StartCount() >= 1 })
 
 	// Simulate cloudflared crashing on its own.
-	runner.Current().Stop(0)
+	_ = runner.Current().Stop(0)
 
 	_ = conn.SetReadDeadline(time.Now().Add(2 * time.Second))
 	sawDown := false
@@ -468,11 +468,11 @@ func TestDaemon_ExpectedStopDoesNotBroadcastDown(t *testing.T) {
 	defer cleanup()
 
 	cA, decA := dialAndRegister(t, sock, "a.example.dev", 3050)
-	defer cA.Close()
+	defer func() { _ = cA.Close() }()
 	waitFor(t, "started", func() bool { return runner.StartCount() >= 1 })
 
 	cB, _ := dialAndRegister(t, sock, "b.example.dev", 3060)
-	defer cB.Close()
+	defer func() { _ = cB.Close() }()
 	waitFor(t, "restart for B", func() bool { return runner.StartCount() >= 2 })
 
 	// Client A must NOT see an EventTunnelDown from the routine restart.
@@ -493,9 +493,9 @@ func TestDaemon_RequestLogRoutedByHostname(t *testing.T) {
 	defer cleanup()
 
 	cA, decA := dialAndRegister(t, sock, "a.example.dev", 3050)
-	defer cA.Close()
+	defer func() { _ = cA.Close() }()
 	cB, decB := dialAndRegister(t, sock, "b.example.dev", 3060)
-	defer cB.Close()
+	defer func() { _ = cB.Close() }()
 	waitFor(t, "second start", func() bool { return runner.StartCount() >= 2 })
 
 	runner.Current().Feed("GET https://a.example.dev/health 200 5ms")

--- a/internal/tunneldaemon/protocol.go
+++ b/internal/tunneldaemon/protocol.go
@@ -1,0 +1,40 @@
+// Package tunneldaemon implements a lazy-start supervisor that lets multiple
+// `gtl tunnel` invocations share a single cloudflared process for one named
+// tunnel. The daemon owns the cloudflared lifecycle; clients register a
+// hostname+port and receive log events over a Unix socket. When the last
+// client disconnects, the daemon shuts down cloudflared and exits.
+package tunneldaemon
+
+// Wire protocol: newline-delimited JSON over a Unix socket.
+// First message client -> daemon is Register. Daemon replies with one
+// Event{Kind:"registered"} (or {Kind:"error"} and closes). Daemon then
+// pushes Event records as cloudflared produces output. Client closes the
+// connection to unregister; daemon detects EOF and removes the hostname.
+
+type Register struct {
+	Op       string `json:"op"`
+	Hostname string `json:"hostname"`
+	Port     int    `json:"port"`
+}
+
+type Event struct {
+	Kind     string `json:"kind"`
+	Hostname string `json:"hostname,omitempty"`
+	Port     int    `json:"port,omitempty"`
+	Line     string `json:"line,omitempty"`
+	Stream   string `json:"stream,omitempty"`
+	Error    string `json:"error,omitempty"`
+}
+
+const (
+	OpRegister = "register"
+
+	EventRegistered = "registered"
+	EventLog        = "log"
+	EventError      = "error"
+	EventTunnelUp   = "tunnel_up"
+	EventTunnelDown = "tunnel_down"
+
+	StreamStdout = "stdout"
+	StreamStderr = "stderr"
+)

--- a/internal/tunneldaemon/protocol_test.go
+++ b/internal/tunneldaemon/protocol_test.go
@@ -1,0 +1,64 @@
+package tunneldaemon
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestRegisterRoundtrip(t *testing.T) {
+	in := Register{Op: OpRegister, Hostname: "salt-main.gtltunnel.dev", Port: 3050}
+	b, err := json.Marshal(in)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var out Register
+	if err := json.Unmarshal(b, &out); err != nil {
+		t.Fatal(err)
+	}
+	if out != in {
+		t.Errorf("roundtrip mismatch: got %+v, want %+v", out, in)
+	}
+}
+
+func TestEventRoundtrip(t *testing.T) {
+	cases := []Event{
+		{Kind: EventRegistered, Hostname: "x.example.dev", Port: 3050},
+		{Kind: EventLog, Stream: StreamStderr, Line: "ERR something broke"},
+		{Kind: EventError, Error: "registration refused"},
+		{Kind: EventTunnelUp, Line: "INF Registered tunnel connection"},
+	}
+	for _, in := range cases {
+		b, err := json.Marshal(in)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var out Event
+		if err := json.Unmarshal(b, &out); err != nil {
+			t.Fatal(err)
+		}
+		if out != in {
+			t.Errorf("roundtrip mismatch: got %+v, want %+v", out, in)
+		}
+	}
+}
+
+func TestClassifyLine(t *testing.T) {
+	cases := []struct {
+		line string
+		want lineClass
+	}{
+		{"2024 ERR cloudflared failed", lineError},
+		{"2024 WRN retrying", lineError},
+		{"connection error: timeout", lineError},
+		{"2024 INF Registered tunnel connection", lineRegistered},
+		{"GET /api/health 200 12ms", lineRequest},
+		{"POST https://x.dev/webhook 201", lineRequest},
+		{"2024 INF Starting tunnel", lineDrop},
+		{"random unrelated line", lineDrop},
+	}
+	for _, tc := range cases {
+		if got := classifyLine(tc.line); got != tc.want {
+			t.Errorf("classifyLine(%q) = %d, want %d", tc.line, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Two concurrent `gtl tunnel` invocations sharing a named Cloudflare tunnel used to clobber each other's config and spawn competing cloudflared connectors. Cloudflare's edge load-balanced across them, so each URL only worked ~50% of the time.
- New `internal/tunneldaemon` package: a per-tunnel-name lazy supervisor. The first `gtl tunnel` forks a hidden `gtl tunnel-daemon` subcommand; subsequent invocations connect to its Unix socket and register a hostname+port. The daemon owns one cloudflared with a merged multi-host ingress, regenerates the config on every registration change, and idle-exits 5s after the last client disconnects.
- Multi-host config helpers added to `internal/tunnel` (`HostRoute`, `GenerateMultiHostConfig`, `WriteMultiHostConfig`); unused single-host `RunNamed` removed.

## Notable design choices

- **Restart-on-change.** Each register/unregister stops + restarts cloudflared rather than reloading via SIGHUP, which isn't reliable across versions. Brief blip on co-tenant tunnels is the explicit tradeoff.
- **Socket lives under `~/.cloudflared/`** (mode 0700) with `umask 0o077` around `net.Listen` so the socket file is created `0600` atomically — no `/tmp` exposure, no TOCTOU window.
- **Unexpected cloudflared exits** (auth failure, crash) broadcast `EventTunnelDown`, close all client connections, and arm idle shutdown — the CLI returns with a real error instead of staring at "Press Ctrl+C to stop" against a dead URL.
- **Connection-driven unregister.** Clients hold the socket open for the life of the tunnel; the daemon detects EOF on Ctrl+C and removes the hostname. No PID tracking, no stale-registration sweep needed.

## Test plan

- [x] `go test -race ./...` clean
- [x] `go test -race -count=5 ./internal/tunneldaemon/...` clean (flake check)
- [x] Smoke against built binary: socket created under `~/.cloudflared/` with 0700/0600 perms; two concurrent clients land in one cloudflared config with both ingress entries; unexpected cloudflared exit produces `EventTunnelDown` and clean client disconnect; daemon idle-exits after last disconnect.
- [ ] End-to-end with a real configured named tunnel — needs Cloudflare creds; run `gtl tunnel` from two repos at the same time and confirm both URLs respond.

## Not covered

- `gtl share` still uses its own single-host path; could be migrated to the daemon in a follow-up.
- Peer-credential validation on the socket (`SO_PEERCRED`/`LOCAL_PEERCRED`) is deferred; moving out of `/tmp` removes the main attack surface.