### PR TITLE
Pin goreleaser project_name to restore git-treeline.rb formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,12 @@
 version: 2
 
+# Pin project_name so the rename from github.com/git-treeline/git-treeline
+# to github.com/git-treeline/cli doesn't change the tarball naming or the
+# Homebrew formula filename. Without this, goreleaser defaults to the repo
+# name ("cli"), which silently created a stale cli.rb in the tap and froze
+# users on the legacy git-treeline.rb formula at the pre-rename version.
+project_name: git-treeline
+
 builds:
   - binary: git-treeline
     main: .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.41.1]
+
+- **Restored the `git-treeline` Homebrew formula.** The repo rename from `git-treeline/git-treeline` to `git-treeline/cli` silently changed goreleaser's default `project_name` from `git-treeline` to `cli`, so v0.40.0 through v0.41.0 updated a new `cli.rb` formula in the tap and stopped updating the legacy `git-treeline.rb`. Anyone who installed via `brew install git-treeline/tap/git-treeline` was frozen at v0.39.2 because `brew upgrade` saw no changes. Pinning `project_name: git-treeline` in `.goreleaser.yml` reverts tarball names to `git-treeline_X_*` and resumes updates to `git-treeline.rb`; the orphaned `cli.rb` has been removed from the tap.
+
 ## [0.41.0]
 
 - **Multiplexed `gtl tunnel` across repos sharing a named tunnel.** Two concurrent `gtl tunnel` invocations used to overwrite each other's `~/.cloudflared/gtl-<name>.yml` and spawn competing cloudflared connectors; with Cloudflare's edge load-balancing, each URL only worked roughly half the time. A new lazy-start daemon (`internal/tunneldaemon`) now owns one cloudflared per named tunnel and merges every active `gtl tunnel`'s hostname into a single multi-host ingress. The first invocation forks the hidden `gtl tunnel-daemon` helper; subsequent invocations register over a Unix socket and disconnect cleanly on Ctrl+C. The daemon idle-exits 5s after the last client leaves.


### PR DESCRIPTION
## Why

The repo rename from \`git-treeline/git-treeline\` to \`git-treeline/cli\` silently changed goreleaser's default \`project_name\` (which defaults to the repo name). Result:

- v0.40.0 → v0.41.0 wrote a new \`cli.rb\` to the homebrew-tap and stopped touching \`git-treeline.rb\`.
- Tarballs got renamed from \`git-treeline_X_*\` to \`cli_X_*\`.
- Anyone who installed via \`brew install git-treeline/tap/git-treeline\` was frozen at v0.39.2 because \`brew upgrade\` saw no changes to that formula.

## What

1. Pin \`project_name: git-treeline\` in \`.goreleaser.yml\` so the formula filename, tarball names, and class name all stay on the legacy identifier.
2. CHANGELOG entry for v0.41.1 (otherwise empty — it exists to push the corrected formula to the tap so existing brew installs start picking up new releases).

## Followup (not in this PR)

- Delete \`cli.rb\` from \`git-treeline/homebrew-tap\` so the orphaned formula doesn't linger.
- Tag \`v0.41.1\` once this lands.