### PR TITLE
Router serves state-aware status pages when upstream is down

### DIFF
--- a/internal/proxy/backend_state.go
+++ b/internal/proxy/backend_state.go
@@ -1,0 +1,102 @@
+package proxy
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/git-treeline/cli/internal/registry"
+	"github.com/git-treeline/cli/internal/supervisor"
+)
+
+// BackendState classifies why a proxied request couldn't reach the
+// upstream dev server. The router uses this to pick a status page so
+// users can tell "still starting" apart from "actually broken".
+type BackendState int
+
+const (
+	BackendUnknown      BackendState = iota
+	BackendStarting                  // supervisor + child both up, port not yet listening
+	BackendNotStarted                // allocation exists, supervisor not running
+	BackendStopped                   // supervisor running, no live child (stopped or crashed)
+	BackendUnreachable               // supervisor responded with something unexpected
+)
+
+// SupervisorProbe asks the supervisor at socketPath for its status.
+// Returns "running", "stopped", or an empty string if the supervisor
+// can't be reached. Pulled out so tests can inject a fake.
+type SupervisorProbe func(socketPath string) (string, error)
+
+// PortProbe attempts a TCP connection to localhost:port within the
+// given timeout and returns true if the port is accepting connections.
+type PortProbe func(port int, timeout time.Duration) bool
+
+func defaultSupervisorProbe(socketPath string) (string, error) {
+	return supervisor.SendWithTimeout(socketPath, "status", 500*time.Millisecond)
+}
+
+func defaultPortProbe(port int, timeout time.Duration) bool {
+	c, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), timeout)
+	if err != nil {
+		return false
+	}
+	_ = c.Close()
+	return true
+}
+
+// classifyBackend decides which status page to show when the proxy
+// can't reach the upstream. worktreePath is the absolute path of the
+// worktree this allocation lives in; port is the allocated dev server
+// port. Either probe can be nil to use the default.
+func classifyBackend(worktreePath string, port int, probeSup SupervisorProbe, probePort PortProbe) BackendState {
+	if probePort == nil {
+		probePort = defaultPortProbe
+	}
+	if probeSup == nil {
+		probeSup = defaultSupervisorProbe
+	}
+
+	if probePort(port, 200*time.Millisecond) {
+		// Port is listening — the dial failure that put us in the error
+		// handler must have been a transient blip. Show the generic
+		// "unreachable" page so the user knows it's not "still starting".
+		return BackendUnreachable
+	}
+
+	if worktreePath == "" {
+		return BackendUnknown
+	}
+
+	socketPath := supervisor.SocketPath(worktreePath)
+	resp, err := probeSup(socketPath)
+	if err != nil {
+		return BackendNotStarted
+	}
+	switch strings.TrimSpace(resp) {
+	case "running":
+		return BackendStarting
+	case "stopped":
+		return BackendStopped
+	default:
+		return BackendUnreachable
+	}
+}
+
+// findWorktreeForRoute returns the worktree path for the allocation
+// whose project/branch produces the given subdomain key. Empty string
+// means no matching allocation (the route is an alias, not a real
+// worktree). Aliases don't have supervisors so we can't classify them.
+func findWorktreeForRoute(reg *registry.Registry, subdomain string) string {
+	for _, a := range reg.Allocations() {
+		project := registry.GetString(a, "project")
+		branch := registry.GetString(a, "branch")
+		if project == "" {
+			continue
+		}
+		if RouteKey(project, branch) == subdomain {
+			return registry.GetString(a, "worktree")
+		}
+	}
+	return ""
+}

--- a/internal/proxy/backend_state_test.go
+++ b/internal/proxy/backend_state_test.go
@@ -1,0 +1,135 @@
+package proxy
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestClassifyBackend_PortListening(t *testing.T) {
+	portUp := func(int, time.Duration) bool { return true }
+	supCalled := false
+	supFn := func(string) (string, error) {
+		supCalled = true
+		return "running", nil
+	}
+
+	got := classifyBackend("/tmp/wt", 3000, supFn, portUp)
+	if got != BackendUnreachable {
+		t.Errorf("port listening should yield BackendUnreachable, got %v", got)
+	}
+	if supCalled {
+		t.Error("supervisor should not be probed when port is listening")
+	}
+}
+
+func TestClassifyBackend_StartingUp(t *testing.T) {
+	portDown := func(int, time.Duration) bool { return false }
+	supRunning := func(string) (string, error) { return "running", nil }
+
+	if got := classifyBackend("/tmp/wt", 3000, supRunning, portDown); got != BackendStarting {
+		t.Errorf("expected BackendStarting, got %v", got)
+	}
+}
+
+func TestClassifyBackend_NotStarted(t *testing.T) {
+	portDown := func(int, time.Duration) bool { return false }
+	supMissing := func(string) (string, error) { return "", fmt.Errorf("no socket") }
+
+	if got := classifyBackend("/tmp/wt", 3000, supMissing, portDown); got != BackendNotStarted {
+		t.Errorf("expected BackendNotStarted, got %v", got)
+	}
+}
+
+func TestClassifyBackend_Stopped(t *testing.T) {
+	portDown := func(int, time.Duration) bool { return false }
+	supStopped := func(string) (string, error) { return "stopped", nil }
+
+	if got := classifyBackend("/tmp/wt", 3000, supStopped, portDown); got != BackendStopped {
+		t.Errorf("expected BackendStopped, got %v", got)
+	}
+}
+
+func TestClassifyBackend_SupervisorWeirdResponse(t *testing.T) {
+	portDown := func(int, time.Duration) bool { return false }
+	supWeird := func(string) (string, error) { return "wat", nil }
+
+	if got := classifyBackend("/tmp/wt", 3000, supWeird, portDown); got != BackendUnreachable {
+		t.Errorf("expected BackendUnreachable for unknown supervisor response, got %v", got)
+	}
+}
+
+func TestClassifyBackend_AliasRouteNoWorktree(t *testing.T) {
+	portDown := func(int, time.Duration) bool { return false }
+	supCalled := false
+	supFn := func(string) (string, error) {
+		supCalled = true
+		return "running", nil
+	}
+
+	got := classifyBackend("", 3000, supFn, portDown)
+	if got != BackendUnknown {
+		t.Errorf("empty worktree path should yield BackendUnknown, got %v", got)
+	}
+	if supCalled {
+		t.Error("supervisor should not be probed when worktree is unknown")
+	}
+}
+
+func TestClassifyBackend_StatusResponseTrimmed(t *testing.T) {
+	portDown := func(int, time.Duration) bool { return false }
+	supTrailingWS := func(string) (string, error) { return "  running\n", nil }
+
+	if got := classifyBackend("/tmp/wt", 3000, supTrailingWS, portDown); got != BackendStarting {
+		t.Errorf("whitespace in supervisor response should not break classification, got %v", got)
+	}
+}
+
+func TestDataForState_StartingHasRefreshAndElapsed(t *testing.T) {
+	d := dataForState(BackendStarting, "salt-main", 3000)
+	if d.Refresh != 2 {
+		t.Errorf("starting state should refresh every 2s, got %d", d.Refresh)
+	}
+	if !d.ShowElapsed {
+		t.Error("starting state should show elapsed counter")
+	}
+	if d.Tone != "amber" {
+		t.Errorf("starting state should use amber tone, got %s", d.Tone)
+	}
+}
+
+func TestDataForState_StoppedHasNoAutoRefresh(t *testing.T) {
+	d := dataForState(BackendStopped, "salt-main", 3000)
+	if d.Refresh != 0 {
+		t.Errorf("stopped state should not auto-refresh (user must run gtl start), got refresh=%d", d.Refresh)
+	}
+	if d.Command == "" {
+		t.Error("stopped state should suggest a recovery command")
+	}
+}
+
+func TestDataForState_NotStartedSuggestsGtlStart(t *testing.T) {
+	d := dataForState(BackendNotStarted, "salt-main", 3000)
+	if d.Command != "gtl start" {
+		t.Errorf("not-started state should suggest 'gtl start', got %q", d.Command)
+	}
+}
+
+func TestToneClasses(t *testing.T) {
+	cases := []struct {
+		tone string
+		want string // substring expected to appear
+	}{
+		{"amber", "amber-100"},
+		{"rose", "rose-100"},
+		{"slate", "slate-100"},
+		{"unknown", "slate-100"}, // default fallback
+	}
+	for _, tc := range cases {
+		got := toneClasses(tc.tone)
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("toneClasses(%q) = %q, expected to contain %q", tc.tone, got, tc.want)
+		}
+	}
+}

--- a/internal/proxy/backend_status_e2e_test.go
+++ b/internal/proxy/backend_status_e2e_test.go
@@ -1,0 +1,65 @@
+package proxy
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/git-treeline/cli/internal/registry"
+)
+
+// TestRouter_ServesStatusPageWhenBackendDown drives the full router
+// through ErrorHandler when the upstream isn't listening. The status
+// classifier may fall through to NotStarted (no supervisor socket in
+// the test env) — either way the response must be the styled page,
+// not Go's bare default error string.
+func TestRouter_ServesStatusPageWhenBackendDown(t *testing.T) {
+	// Allocate but don't actually serve on this port; we want the
+	// backend dial to fail so ErrorHandler fires.
+	deadPort := freePort(t)
+
+	reg := testRegistry(t, []registry.Allocation{
+		{
+			"project":  "salt",
+			"branch":   "main",
+			"port":     float64(deadPort),
+			"ports":    []any{float64(deadPort)},
+			"worktree": "/nonexistent/salt-main",
+		},
+	})
+
+	router := NewRouter(0, reg)
+	ts := httptest.NewServer(router)
+	defer ts.Close()
+
+	req, _ := http.NewRequest("GET", ts.URL+"/", nil)
+	req.Host = "salt-main.localhost"
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusServiceUnavailable && resp.StatusCode != http.StatusBadGateway {
+		t.Errorf("expected 503 or 502, got %d", resp.StatusCode)
+	}
+
+	if got := resp.Header.Get("Content-Type"); !strings.HasPrefix(got, "text/html") {
+		t.Errorf("expected text/html response, got %q", got)
+	}
+
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	body := string(bodyBytes)
+
+	if !strings.Contains(body, "salt-main") {
+		t.Errorf("response should mention the subdomain; body:\n%s", body)
+	}
+	if !strings.Contains(body, "git-treeline router") {
+		t.Errorf("response should be the styled router page; body:\n%s", body)
+	}
+	if !strings.Contains(body, "cdn.tailwindcss.com") {
+		t.Errorf("response should include Tailwind styling; body:\n%s", body)
+	}
+}

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -201,10 +201,10 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	r.proxyTo(w, req, targetPort)
+	r.proxyTo(w, req, subdomain, targetPort)
 }
 
-func (r *Router) proxyTo(w http.ResponseWriter, req *http.Request, targetPort int) {
+func (r *Router) proxyTo(w http.ResponseWriter, req *http.Request, subdomain string, targetPort int) {
 	backendHost := resolveLocalhost(targetPort)
 	target := &url.URL{
 		Scheme: "http",
@@ -230,8 +230,21 @@ func (r *Router) proxyTo(w http.ResponseWriter, req *http.Request, targetPort in
 				pr.Out.Header.Set("X-Forwarded-For", pr.In.RemoteAddr)
 			}
 		},
+		ErrorHandler: func(w http.ResponseWriter, _ *http.Request, _ error) {
+			r.serveBackendStatus(w, subdomain, targetPort)
+		},
 	}
 	proxy.ServeHTTP(w, req)
+}
+
+// serveBackendStatus is invoked when the reverse proxy can't reach the
+// upstream. It probes the supervisor and the port to decide whether the
+// server is still booting, never started, or crashed, then serves a
+// state-specific HTML page.
+func (r *Router) serveBackendStatus(w http.ResponseWriter, subdomain string, port int) {
+	worktreePath := findWorktreeForRoute(r.registry, subdomain)
+	state := classifyBackend(worktreePath, port, nil, nil)
+	renderBackendStatusPage(w, state, subdomain, port)
 }
 
 func (r *Router) refreshRoutes() {

--- a/internal/proxy/starting_page.go
+++ b/internal/proxy/starting_page.go
@@ -1,0 +1,182 @@
+package proxy
+
+import (
+	"html/template"
+	"net/http"
+	"strings"
+)
+
+// statusPageData drives the Tailwind status template.
+type statusPageData struct {
+	Title       string
+	Subdomain   string
+	Port        int
+	Message     string
+	Hint        template.HTML // raw HTML allowed (e.g. inline <code>)
+	Command     string        // shell command to copy/run; rendered in a <pre>
+	StatusBadge string        // small label shown next to subdomain (e.g. "starting")
+	Tone        string        // color tone: "amber" | "slate" | "rose"
+	Refresh     int           // meta refresh interval in seconds; 0 disables
+	ShowElapsed bool          // whether to render the JS elapsed counter
+}
+
+// renderBackendStatusPage maps a BackendState into a fully styled status
+// page and writes it to w. status is the HTTP status code to return.
+func renderBackendStatusPage(w http.ResponseWriter, state BackendState, subdomain string, port int) {
+	data := dataForState(state, subdomain, port)
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	switch state {
+	case BackendStarting:
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Header().Set("Retry-After", "2")
+	case BackendNotStarted, BackendStopped:
+		w.WriteHeader(http.StatusServiceUnavailable)
+	case BackendUnreachable, BackendUnknown:
+		w.WriteHeader(http.StatusBadGateway)
+	default:
+		w.WriteHeader(http.StatusBadGateway)
+	}
+
+	_ = statusPageTemplate.Execute(w, data)
+}
+
+func dataForState(state BackendState, subdomain string, port int) statusPageData {
+	d := statusPageData{
+		Subdomain: subdomain,
+		Port:      port,
+	}
+	switch state {
+	case BackendStarting:
+		d.Title = "Starting up"
+		d.StatusBadge = "starting"
+		d.Tone = "amber"
+		d.Message = "Your dev server is booting. This page will refresh automatically once it's ready."
+		d.Refresh = 2
+		d.ShowElapsed = true
+	case BackendNotStarted:
+		d.Title = "Server not started"
+		d.StatusBadge = "idle"
+		d.Tone = "slate"
+		d.Message = "The router has a route for this worktree but nothing's running on its port yet."
+		d.Hint = template.HTML("Start the server from the worktree directory:")
+		d.Command = "gtl start"
+		d.Refresh = 10
+	case BackendStopped:
+		d.Title = "Server stopped"
+		d.StatusBadge = "stopped"
+		d.Tone = "rose"
+		d.Message = "The supervisor is up but the server isn't running. It may have crashed or been stopped manually."
+		d.Hint = template.HTML("Restart it and check the logs if it keeps exiting:")
+		d.Command = "gtl start"
+	case BackendUnreachable:
+		d.Title = "Backend unreachable"
+		d.StatusBadge = "error"
+		d.Tone = "rose"
+		d.Message = "The router couldn't proxy this request even though the port was listening. The connection was dropped mid-request."
+	default:
+		d.Title = "Backend unreachable"
+		d.StatusBadge = "unknown"
+		d.Tone = "slate"
+		d.Message = "The router couldn't determine what's wrong with this backend."
+	}
+	return d
+}
+
+// toneClasses returns the Tailwind utility classes for the small status
+// badge based on tone. Kept as a template function so the HTML stays
+// declarative.
+func toneClasses(tone string) string {
+	switch tone {
+	case "amber":
+		return "bg-amber-100 text-amber-800 dark:bg-amber-900/40 dark:text-amber-200 ring-1 ring-amber-200 dark:ring-amber-800"
+	case "rose":
+		return "bg-rose-100 text-rose-800 dark:bg-rose-900/40 dark:text-rose-200 ring-1 ring-rose-200 dark:ring-rose-800"
+	default:
+		return "bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300 ring-1 ring-slate-200 dark:ring-slate-700"
+	}
+}
+
+func toneDot(tone string) string {
+	switch tone {
+	case "amber":
+		return "bg-amber-500"
+	case "rose":
+		return "bg-rose-500"
+	default:
+		return "bg-slate-400"
+	}
+}
+
+var statusPageTemplate = template.Must(template.New("status").Funcs(template.FuncMap{
+	"toneClasses": toneClasses,
+	"toneDot":     toneDot,
+	"trimSpace":   strings.TrimSpace,
+}).Parse(statusPageHTML))
+
+// statusPageHTML is intentionally readable: served once per click, no
+// build step, dark-mode aware via prefers-color-scheme. Tailwind's play
+// CDN handles class compilation in the browser.
+const statusPageHTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>{{.Title}} · {{.Subdomain}}</title>
+{{if .Refresh}}<meta http-equiv="refresh" content="{{.Refresh}}">{{end}}
+<script src="https://cdn.tailwindcss.com"></script>
+<script>tailwind.config={darkMode:'media'}</script>
+</head>
+<body class="min-h-screen flex items-center justify-center bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-slate-100 font-sans antialiased">
+  <main class="w-full max-w-md mx-4">
+    <div class="rounded-2xl border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-900 shadow-sm p-8">
+      <div class="flex items-start justify-between gap-4 mb-5">
+        <div class="min-w-0">
+          <h1 class="text-xl font-semibold tracking-tight">{{.Title}}</h1>
+          <p class="mt-1 text-sm font-mono text-slate-500 dark:text-slate-400 truncate">{{.Subdomain}}</p>
+        </div>
+        <span class="shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium {{toneClasses .Tone}}">
+          <span class="w-1.5 h-1.5 rounded-full {{toneDot .Tone}} {{if eq .Tone "amber"}}animate-pulse{{end}}"></span>
+          {{.StatusBadge}}
+        </span>
+      </div>
+
+      <p class="text-slate-700 dark:text-slate-300 leading-relaxed">{{.Message}}</p>
+
+      {{if .Hint}}<p class="mt-4 text-sm text-slate-600 dark:text-slate-400">{{.Hint}}</p>{{end}}
+
+      {{if .Command}}
+      <div class="mt-3 group relative">
+        <pre class="px-3 py-2 rounded-lg bg-slate-100 dark:bg-slate-800/80 text-sm font-mono text-slate-800 dark:text-slate-200 overflow-x-auto"><code id="cmd">{{.Command}}</code></pre>
+        <button type="button"
+                onclick="navigator.clipboard.writeText(document.getElementById('cmd').textContent).then(()=>{const b=event.currentTarget;b.textContent='copied';setTimeout(()=>b.textContent='copy',1200)})"
+                class="absolute top-1.5 right-1.5 px-2 py-0.5 text-xs rounded-md bg-white dark:bg-slate-900 text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-700 opacity-0 group-hover:opacity-100 transition-opacity">copy</button>
+      </div>
+      {{end}}
+
+      {{if .ShowElapsed}}
+      <p id="elapsed" class="mt-5 text-xs text-slate-500 dark:text-slate-400" aria-live="polite">Waiting…</p>
+      <script>
+        (function(){
+          var start = Date.now();
+          function tick(){
+            var s = Math.floor((Date.now()-start)/1000);
+            var el = document.getElementById('elapsed');
+            if (el) el.textContent = 'Retrying every 2s · waiting ' + s + 's';
+          }
+          tick();
+          setInterval(tick, 1000);
+        })();
+      </script>
+      {{end}}
+
+      <div class="mt-6 pt-5 border-t border-slate-100 dark:border-slate-800 flex items-center justify-between text-xs text-slate-400 dark:text-slate-500">
+        <span>git-treeline router</span>
+        <span class="font-mono">port {{.Port}}</span>
+      </div>
+    </div>
+    <p class="mt-3 text-center text-xs text-slate-400 dark:text-slate-600">This page is served by your local <code class="font-mono">gtl serve</code> router.</p>
+  </main>
+</body>
+</html>
+`

--- a/internal/proxy/starting_page_test.go
+++ b/internal/proxy/starting_page_test.go
@@ -1,0 +1,91 @@
+package proxy
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRenderBackendStatusPage_Starting(t *testing.T) {
+	rec := httptest.NewRecorder()
+	renderBackendStatusPage(rec, BackendStarting, "salt-main", 3050)
+
+	if got := rec.Code; got != 503 {
+		t.Errorf("starting state should return 503, got %d", got)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"Starting up",
+		"salt-main",
+		"port 3050",
+		`http-equiv="refresh"`,
+		`content="2"`,
+		"git-treeline router",
+		"cdn.tailwindcss.com",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestRenderBackendStatusPage_NotStarted(t *testing.T) {
+	rec := httptest.NewRecorder()
+	renderBackendStatusPage(rec, BackendNotStarted, "salt-main", 3050)
+
+	if got := rec.Code; got != 503 {
+		t.Errorf("not-started state should return 503, got %d", got)
+	}
+	body := rec.Body.String()
+	for _, want := range []string{
+		"Server not started",
+		"gtl start",
+		`content="10"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestRenderBackendStatusPage_Stopped_NoRefresh(t *testing.T) {
+	rec := httptest.NewRecorder()
+	renderBackendStatusPage(rec, BackendStopped, "salt-main", 3050)
+
+	body := rec.Body.String()
+	if !strings.Contains(body, "Server stopped") {
+		t.Error("body missing 'Server stopped'")
+	}
+	if strings.Contains(body, `http-equiv="refresh"`) {
+		t.Error("stopped state must NOT auto-refresh (user has to run gtl start)")
+	}
+}
+
+func TestRenderBackendStatusPage_Unreachable(t *testing.T) {
+	rec := httptest.NewRecorder()
+	renderBackendStatusPage(rec, BackendUnreachable, "salt-main", 3050)
+
+	if got := rec.Code; got != 502 {
+		t.Errorf("unreachable state should return 502, got %d", got)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "Backend unreachable") {
+		t.Error("body missing 'Backend unreachable' title")
+	}
+}
+
+func TestRenderBackendStatusPage_EscapesSubdomain(t *testing.T) {
+	// The subdomain comes from request host parsing. The renderer must
+	// HTML-escape it to avoid letting an attacker craft a host header
+	// that injects script into the status page.
+	rec := httptest.NewRecorder()
+	renderBackendStatusPage(rec, BackendStarting, `<script>alert(1)</script>`, 3050)
+
+	body := rec.Body.String()
+	if strings.Contains(body, "<script>alert(1)</script>") {
+		t.Error("subdomain must be HTML-escaped in the rendered page")
+	}
+	if !strings.Contains(body, "&lt;script&gt;") {
+		t.Errorf("expected HTML entities in body, got:\n%s", body)
+	}
+}


### PR DESCRIPTION
## Why

Today: user runs \`gtl start\`, clicks the router URL printed seconds later, server isn't ready, browser shows Go's bare \`ReverseProxy\` error string. Looks broken; isn't.

## What

Custom \`ErrorHandler\` on the reverse proxy. When the upstream dial fails, the router probes:

- the allocated port (TCP dial)
- the worktree's supervisor socket via \`supervisor.Send(socket, \"status\")\`

…and serves one of four Tailwind-styled status pages:

| State | Trigger | HTTP | Refresh | UX |
| --- | --- | --- | --- | --- |
| Starting | supervisor running, child running, port not listening yet | 503 | every 2s + \`Retry-After\` | amber pulsing badge, elapsed counter |
| Not started | supervisor not reachable | 503 | every 10s | suggests \`gtl start\` (copy button) |
| Stopped | supervisor up, child stopped/crashed | 503 | **none** — user must act | suggests \`gtl start\` |
| Unreachable | port listening, proxy dropped mid-request | 502 | none | real failure, don't paper over |

Pages are dark-mode aware (\`prefers-color-scheme\`), have a copy-to-clipboard button on recovery commands, and HTML-escape the subdomain so a crafted Host header can't inject script.

## Test plan

- [x] \`go test -race ./...\` clean
- [x] \`golangci-lint run ./...\` clean
- [x] Unit tests: classifier covers all states + probe ordering (skip supervisor probe when port is up)
- [x] Renderer tests: status codes, refresh headers, XSS escape on subdomain
- [x] End-to-end test: real router + httptest server with a dead backend port → response is the styled page (not Go's bare error)
- [x] Visual: rendered pages dumped to \`/tmp\` and opened in browser for review
- [ ] Live dogfood: run \`gtl serve\` with the new binary, observe the page on a worktree whose server hasn't started yet