### PR TITLE
gtl tunnel reset + clearer errors for broken Cloudflare setups

### DIFF
--- a/cmd/tunnel.go
+++ b/cmd/tunnel.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -32,8 +33,12 @@ func init() {
 	tunnelCmd.AddCommand(tunnelStatusCmd)
 	tunnelCmd.AddCommand(tunnelDefaultCmd)
 	tunnelCmd.AddCommand(tunnelRemoveCmd)
+	tunnelCmd.AddCommand(tunnelResetCmd)
+	tunnelResetCmd.Flags().BoolVarP(&tunnelResetYes, "yes", "y", false, "skip confirmation prompt")
 	rootCmd.AddCommand(tunnelCmd)
 }
+
+var tunnelResetYes bool
 
 var tunnelCmd = &cobra.Command{
 	Use:   "tunnel [port]",
@@ -161,6 +166,26 @@ account that owns that zone. gtl stores per-domain credentials automatically.`,
 			if err := tunnel.CreateTunnel(tunnelName); err != nil {
 				return fmt.Errorf("failed to create tunnel: %w", err)
 			}
+		} else if !tunnel.HasTunnelCredentials(tunnelName) {
+			// Adopting an existing tunnel that we didn't create — the
+			// connector credentials only live on the machine where
+			// `cloudflared tunnel create` originally ran. Granting
+			// Cloudflare account access shares the tunnel definition but
+			// NOT the credentials. Refuse to save a broken config.
+			return cliErr(cmd, &CliError{
+				Message: fmt.Sprintf("Tunnel %q exists in your Cloudflare account, but its connector credentials aren't on this machine.", tunnelName),
+				Hint: fmt.Sprintf(`Cloudflare doesn't distribute connector credentials through the API — they
+only exist on the machine that originally ran 'cloudflared tunnel create'.
+
+Two ways forward:
+  1. Get %s from the user who created the tunnel
+     (securely — it contains an API token) and place it at the same path
+     on this machine, then re-run 'gtl tunnel setup'.
+  2. Pick a different tunnel name to create a new tunnel here. Heads up:
+     wildcard DNS for a domain points to one tunnel at a time — creating
+     a new one will overwrite the routing for everyone else on that
+     domain.`, tunnel.CredentialsPath(tunnelName)),
+			})
 		}
 
 		existingDomain := uc.TunnelDomain("")
@@ -406,6 +431,108 @@ tunnels (random *.trycloudflare.com URLs).`,
 	},
 }
 
+var tunnelResetCmd = &cobra.Command{
+	Use:   "reset",
+	Short: "Clear all gtl tunnel state and Cloudflare credentials on this machine",
+	Long: `Removes all gtl tunnel configuration entries, the default Cloudflare
+cert.pem, per-domain cert-*.pem files, and tunnel credential JSONs.
+
+Use this when tunnel state on this machine is wedged — most commonly
+when you authenticated with a Cloudflare account that doesn't have
+the permissions you need, and subsequent 'gtl tunnel setup' runs
+keep reusing the same dead cert.pem.
+
+Does NOT delete the actual Cloudflare-side tunnel definitions; for
+that, run 'cloudflared tunnel delete <name>' once your account has
+the right permissions.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		uc := config.LoadUserConfig("")
+		configs := uc.TunnelConfigs()
+		configNames := sortedKeys(configs)
+
+		defaultCert := tunnel.DefaultCertPath()
+		hasDefaultCert := fileExistsForReset(defaultCert)
+		domainCerts := tunnel.FindDomainCerts()
+		credentials := tunnel.FindTunnelCredentialFiles(configNames)
+
+		if !hasDefaultCert && len(configs) == 0 && len(domainCerts) == 0 && len(credentials) == 0 {
+			fmt.Println("Nothing to reset — no gtl tunnel state on this machine.")
+			return nil
+		}
+
+		fmt.Println("This will reset gtl's Cloudflare tunnel state:")
+		if len(configs) > 0 {
+			fmt.Printf("  • Remove %d tunnel configuration(s): %s\n", len(configs), strings.Join(configNames, ", "))
+		}
+		if hasDefaultCert {
+			fmt.Printf("  • Delete default cert: %s\n", defaultCert)
+		}
+		for _, c := range domainCerts {
+			fmt.Printf("  • Delete domain cert: %s\n", c)
+		}
+		for _, c := range credentials {
+			fmt.Printf("  • Delete tunnel credentials: %s\n", c)
+		}
+
+		fmt.Println()
+		fmt.Println("Cloudflare-side tunnel definitions are NOT deleted. To remove them:")
+		if len(configs) == 0 {
+			fmt.Println("  cloudflared tunnel delete <name>")
+		} else {
+			for _, name := range configNames {
+				fmt.Printf("  cloudflared tunnel delete %s\n", name)
+			}
+		}
+		fmt.Println()
+		fmt.Println("After reset, run 'gtl tunnel setup' to authenticate fresh.")
+
+		if !tunnelResetYes {
+			fmt.Println()
+			if !confirm.Prompt("Continue?", false, nil) {
+				return cliErr(cmd, &CliError{Message: "Aborted."})
+			}
+		}
+
+		for _, name := range configNames {
+			uc.DeleteTunnel(name)
+		}
+		if len(configs) > 0 {
+			if err := uc.Save(); err != nil {
+				return fmt.Errorf("save user config: %w", err)
+			}
+		}
+
+		toDelete := append([]string{}, credentials...)
+		toDelete = append(toDelete, domainCerts...)
+		if hasDefaultCert {
+			toDelete = append(toDelete, defaultCert)
+		}
+		removed := tunnel.DeleteCloudflaredFiles(toDelete)
+
+		fmt.Println()
+		fmt.Printf("%s removed %d file(s) and %d tunnel config(s).\n",
+			style.Successf("Reset complete."), len(removed), len(configs))
+		return nil
+	},
+}
+
+func fileExistsForReset(p string) bool {
+	info, err := os.Stat(p)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func sortedKeys(m map[string]string) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
 func tunnelConfigNames(configs map[string]string) []string {
 	names := make([]string, 0, len(configs))
 	for name := range configs {
@@ -425,6 +552,23 @@ func validateTunnelPrereqs(tunnelName string) error {
 		return &CliError{
 			Message: fmt.Sprintf("Tunnel %q not found.", tunnelName),
 			Hint:    "Run 'gtl tunnel setup' to create it.",
+		}
+	}
+	if !tunnel.HasTunnelCredentials(tunnelName) {
+		// The tunnel exists in Cloudflare but its connector credentials
+		// JSON isn't on this machine. Without it cloudflared will refuse
+		// to start; surface the real error here instead of letting the
+		// daemon report "cloudflared exited unexpectedly".
+		return &CliError{
+			Message: fmt.Sprintf("Tunnel %q exists, but its connector credentials are missing on this machine (looked for %s).", tunnelName, tunnel.CredentialsPath(tunnelName)),
+			Hint: `Cloudflare doesn't share connector credentials through the API — only the
+machine that ran 'cloudflared tunnel create' has them.
+
+To fix:
+  • Get the credentials JSON from the tunnel's creator (securely — it
+    contains an API token) and place it at the path above; OR
+  • Run 'gtl tunnel reset' followed by 'gtl tunnel setup' to create
+    your own tunnel under a different name.`,
 		}
 	}
 	return nil

--- a/cmd/tunnel_test.go
+++ b/cmd/tunnel_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"sort"
 	"testing"
 )
@@ -24,5 +26,30 @@ func TestTunnelConfigNames_Empty(t *testing.T) {
 	names := tunnelConfigNames(map[string]string{})
 	if len(names) != 0 {
 		t.Errorf("expected empty, got %v", names)
+	}
+}
+
+func TestSortedKeys(t *testing.T) {
+	got := sortedKeys(map[string]string{"c": "", "a": "", "b": ""})
+	want := []string{"a", "b", "c"}
+	if len(got) != 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		t.Errorf("sortedKeys = %v, want %v", got, want)
+	}
+}
+
+func TestFileExistsForReset(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "f.txt")
+	if fileExistsForReset(file) {
+		t.Error("expected false for non-existent")
+	}
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if !fileExistsForReset(file) {
+		t.Error("expected true after write")
+	}
+	if fileExistsForReset(dir) {
+		t.Error("expected false for directory")
 	}
 }

--- a/internal/tunnel/reset.go
+++ b/internal/tunnel/reset.go
@@ -1,0 +1,110 @@
+package tunnel
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// CredentialsPath returns the absolute path where the connector
+// credentials JSON for a named tunnel should live. Prefers the canonical
+// cloudflared format (<UUID>.json) when the UUID can be resolved;
+// otherwise falls back to <tunnelName>.json — matching what
+// findCredentialsFile writes into the generated config.
+func CredentialsPath(tunnelName string) string {
+	return findCredentialsFile(tunnelName)
+}
+
+// HasTunnelCredentials reports whether a connector credentials JSON for
+// the named tunnel exists locally. Cloudflare doesn't distribute these
+// through the API — they're only on the machine that ran
+// `cloudflared tunnel create`. Granting account access lets you list and
+// manage a tunnel but does NOT give you its credentials; without the
+// JSON file cloudflared exits at startup with "credentials file ...
+// doesn't exist or is not a file".
+func HasTunnelCredentials(tunnelName string) bool {
+	dir := ConfigDir()
+	if id := lookupTunnelID(tunnelName); id != "" {
+		if info, err := os.Stat(filepath.Join(dir, id+".json")); err == nil && !info.IsDir() {
+			return true
+		}
+	}
+	if info, err := os.Stat(filepath.Join(dir, tunnelName+".json")); err == nil && !info.IsDir() {
+		return true
+	}
+	return false
+}
+
+// FindDomainCerts returns absolute paths of per-domain cert files
+// (cert-<domain>.pem) in the cloudflared config dir. Used by reset to
+// enumerate what would be deleted.
+func FindDomainCerts() []string {
+	dir := ConfigDir()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, e := range entries {
+		name := e.Name()
+		if !strings.HasPrefix(name, "cert-") || !strings.HasSuffix(name, ".pem") {
+			continue
+		}
+		out = append(out, filepath.Join(dir, name))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// FindTunnelCredentialFiles returns absolute paths of credential JSONs
+// associated with the given tunnel names. Includes both the UUID-based
+// path (canonical cloudflared format) and the name-based fallback. Only
+// returns paths that actually exist on disk.
+func FindTunnelCredentialFiles(tunnelNames []string) []string {
+	dir := ConfigDir()
+	seen := map[string]bool{}
+	for _, name := range tunnelNames {
+		if id := lookupTunnelID(name); id != "" {
+			p := filepath.Join(dir, id+".json")
+			if fileExists(p) {
+				seen[p] = true
+			}
+		}
+		p := filepath.Join(dir, name+".json")
+		if fileExists(p) {
+			seen[p] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// DefaultCertPath returns the path to the default Cloudflare cert.pem.
+func DefaultCertPath() string {
+	return filepath.Join(ConfigDir(), "cert.pem")
+}
+
+// DeleteCloudflaredFiles removes the given files, ignoring errors for
+// paths that don't exist. Returns the list of paths actually removed.
+func DeleteCloudflaredFiles(paths []string) []string {
+	var removed []string
+	for _, p := range paths {
+		if err := os.Remove(p); err == nil {
+			removed = append(removed, p)
+		}
+	}
+	return removed
+}
+
+func fileExists(p string) bool {
+	info, err := os.Stat(p)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}

--- a/internal/tunnel/reset_test.go
+++ b/internal/tunnel/reset_test.go
@@ -1,0 +1,123 @@
+package tunnel
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+)
+
+func setupCloudflaredDir(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	dir := filepath.Join(home, ".cloudflared")
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func touch(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestHasTunnelCredentials_FalseWhenMissing(t *testing.T) {
+	setupCloudflaredDir(t)
+	if HasTunnelCredentials("any") {
+		t.Error("expected false with empty dir")
+	}
+}
+
+func TestHasTunnelCredentials_TrueForNameBasedFallback(t *testing.T) {
+	dir := setupCloudflaredDir(t)
+	touch(t, filepath.Join(dir, "my-tunnel.json"))
+	if !HasTunnelCredentials("my-tunnel") {
+		t.Error("expected true when name.json exists")
+	}
+}
+
+func TestHasTunnelCredentials_IgnoresDirectory(t *testing.T) {
+	dir := setupCloudflaredDir(t)
+	if err := os.Mkdir(filepath.Join(dir, "weird.json"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if HasTunnelCredentials("weird") {
+		t.Error("expected false for directory at credentials path")
+	}
+}
+
+func TestFindDomainCerts(t *testing.T) {
+	dir := setupCloudflaredDir(t)
+	touch(t, filepath.Join(dir, "cert.pem"))               // default — should NOT be returned
+	touch(t, filepath.Join(dir, "cert-example.com.pem"))   // per-domain — included
+	touch(t, filepath.Join(dir, "cert-other.dev.pem"))     // per-domain — included
+	touch(t, filepath.Join(dir, "some-uuid.json"))         // credentials — not a cert
+	touch(t, filepath.Join(dir, "cert-no-pem-suffix.txt")) // wrong suffix — excluded
+
+	got := FindDomainCerts()
+	sort.Strings(got)
+	want := []string{
+		filepath.Join(dir, "cert-example.com.pem"),
+		filepath.Join(dir, "cert-other.dev.pem"),
+	}
+	if len(got) != len(want) {
+		t.Fatalf("got %d certs, want %d: %v", len(got), len(want), got)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Errorf("[%d]: got %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestFindTunnelCredentialFiles_NameBased(t *testing.T) {
+	dir := setupCloudflaredDir(t)
+	touch(t, filepath.Join(dir, "alpha.json"))
+	touch(t, filepath.Join(dir, "beta.json"))
+	touch(t, filepath.Join(dir, "gamma.json"))
+
+	got := FindTunnelCredentialFiles([]string{"alpha", "beta"})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 paths, got %d: %v", len(got), got)
+	}
+	if !strings.Contains(got[0], "alpha.json") || !strings.Contains(got[1], "beta.json") {
+		t.Errorf("unexpected paths: %v", got)
+	}
+}
+
+func TestFindTunnelCredentialFiles_SkipsMissing(t *testing.T) {
+	setupCloudflaredDir(t)
+	got := FindTunnelCredentialFiles([]string{"never-existed"})
+	if len(got) != 0 {
+		t.Errorf("expected empty result, got %v", got)
+	}
+}
+
+func TestDeleteCloudflaredFiles_RemovesExisting(t *testing.T) {
+	dir := setupCloudflaredDir(t)
+	a := filepath.Join(dir, "a.json")
+	b := filepath.Join(dir, "b.json")
+	touch(t, a)
+	touch(t, b)
+
+	removed := DeleteCloudflaredFiles([]string{a, b, filepath.Join(dir, "missing.json")})
+	if len(removed) != 2 {
+		t.Errorf("expected 2 removed, got %d: %v", len(removed), removed)
+	}
+	if fileExists(a) || fileExists(b) {
+		t.Error("files should have been deleted")
+	}
+}
+
+func TestDefaultCertPath(t *testing.T) {
+	setupCloudflaredDir(t)
+	got := DefaultCertPath()
+	if !strings.HasSuffix(got, "/.cloudflared/cert.pem") {
+		t.Errorf("unexpected default cert path: %s", got)
+	}
+}

--- a/internal/tunneldaemon/daemon.go
+++ b/internal/tunneldaemon/daemon.go
@@ -89,9 +89,10 @@ type Daemon struct {
 // cloudflaredSession bundles a running cloudflared with the metadata we
 // need to tell intentional stops apart from unexpected exits.
 type cloudflaredSession struct {
-	handle   CloudflaredHandle
-	done     chan struct{} // closed when handle.Wait returns
-	expected atomic.Bool   // set before any clean stop
+	handle      CloudflaredHandle
+	done        chan struct{} // closed when handle.Wait returns
+	stderrDrain chan struct{} // closed when pumpStderr finishes consuming stderr
+	expected    atomic.Bool   // set before any clean stop
 }
 
 type client struct {
@@ -275,12 +276,16 @@ func (d *Daemon) applyRoutes(routes []tunnel.HostRoute) error {
 	if err != nil {
 		return fmt.Errorf("start cloudflared: %w", err)
 	}
-	sess := &cloudflaredSession{handle: handle, done: make(chan struct{})}
+	sess := &cloudflaredSession{
+		handle:      handle,
+		done:        make(chan struct{}),
+		stderrDrain: make(chan struct{}),
+	}
 	d.mu.Lock()
 	d.session = sess
 	d.mu.Unlock()
 
-	go d.pumpStderr(handle.Stderr())
+	go d.pumpStderr(handle.Stderr(), sess.stderrDrain)
 	go d.watchSession(sess)
 	return nil
 }
@@ -289,9 +294,20 @@ func (d *Daemon) applyRoutes(routes []tunnel.HostRoute) error {
 // active one and wasn't marked as an expected stop, that's an unexpected
 // exit (auth failure, crash, network blip) — notify clients and drop their
 // connections so the CLI returns instead of pretending the tunnel is live.
+// Waits for pumpStderr to drain first so cloudflared's last error lines
+// reach the connected clients before we close their connections.
 func (d *Daemon) watchSession(sess *cloudflaredSession) {
 	_ = sess.handle.Wait()
 	close(sess.done)
+
+	// Drain stderr with a deadline so a misbehaving pipe can't hang the
+	// daemon. Two seconds is plenty for any reasonable cloudflared exit
+	// message.
+	select {
+	case <-sess.stderrDrain:
+	case <-time.After(2 * time.Second):
+	}
+
 	if sess.expected.Load() {
 		return
 	}
@@ -345,8 +361,11 @@ func (d *Daemon) stopCloudflaredLocked() {
 // pumpStderr fans out cloudflared stderr lines to connected clients,
 // filtering by relevance. Errors/warnings broadcast to everyone; request
 // logs route only to the client whose hostname appears in the line; INF
-// spam is dropped.
-func (d *Daemon) pumpStderr(r io.Reader) {
+// spam is dropped. The drained channel is closed when the underlying
+// reader returns — used by watchSession to wait for cloudflared's death
+// rattle before tearing down client connections.
+func (d *Daemon) pumpStderr(r io.Reader, drained chan<- struct{}) {
+	defer close(drained)
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 64*1024), 1024*1024)
 	for scanner.Scan() {

--- a/internal/tunneldaemon/daemon_test.go
+++ b/internal/tunneldaemon/daemon_test.go
@@ -423,6 +423,52 @@ func TestDaemon_BroadcastsErrorLine(t *testing.T) {
 	}
 }
 
+// TestDaemon_StderrDrainsBeforeTunnelDown pins the fix for the Blake
+// scenario: cloudflared exited with a useful error message, but the
+// daemon closed client connections the instant handle.Wait returned —
+// before pumpStderr had finished consuming the stderr pipe. The client
+// only ever saw "cloudflared exited unexpectedly" and never the real
+// error. The fix is to wait for pumpStderr to drain before broadcasting
+// tunnel_down and closing connections. This test feeds an error line,
+// then stops cloudflared, and asserts the error event lands on the wire
+// BEFORE the tunnel_down event.
+func TestDaemon_StderrDrainsBeforeTunnelDown(t *testing.T) {
+	_, runner, sock, cleanup := startDaemon(t)
+	defer cleanup()
+
+	conn, dec := dialAndRegister(t, sock, "a.example.dev", 3050)
+	defer func() { _ = conn.Close() }()
+	waitFor(t, "started", func() bool { return runner.StartCount() >= 1 })
+
+	// Feed an error line, then immediately stop cloudflared to mimic an
+	// unexpected exit right after the error is logged.
+	runner.Current().Feed("2024 ERR auth failed: 403 Forbidden")
+	_ = runner.Current().Stop(0)
+
+	var sawErr, sawDown bool
+	_ = conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	for !sawDown {
+		var ev Event
+		if err := dec.Decode(&ev); err != nil {
+			break
+		}
+		switch ev.Kind {
+		case EventLog:
+			if !sawDown && contains(ev.Line, "auth failed") {
+				sawErr = true
+			}
+		case EventTunnelDown:
+			sawDown = true
+		}
+	}
+	if !sawErr {
+		t.Error("client did not receive the cloudflared error line before tunnel_down")
+	}
+	if !sawDown {
+		t.Error("client did not receive tunnel_down event")
+	}
+}
+
 // TestDaemon_UnexpectedCloudflaredExitNotifiesClients verifies that when
 // cloudflared dies on its own (auth fail, crash, network), the daemon
 // broadcasts EventTunnelDown and drops all client connections so the CLI


### PR DESCRIPTION
## Why

Onboarding a teammate to a shared Cloudflare tunnel surfaced three failure modes that all looked the same from the user's perspective: \`gtl tunnel\` errored with \"cloudflared exited unexpectedly\" and there was no way to know why or recover without manually inspecting \`~/.cloudflared/\`. The underlying issue: Cloudflare doesn't distribute connector credentials through the API — granting account access shares the tunnel definition but NOT the JSON file cloudflared needs to attach a connector. gtl was happily saving configs for tunnels that physically couldn't run, then producing useless error messages when they didn't.

## What

Four changes, all in the same \"make tunnel onboarding survivable\" theme:

1. **\`gtl tunnel reset\`** — clears all gtl tunnel state on this machine: configs, default \`cert.pem\`, per-domain \`cert-*.pem\`, credentials JSONs for configured tunnels. \`-y\` to skip prompt. Doesn't touch Cloudflare-side tunnel definitions (prints \`cloudflared tunnel delete\` hint).
2. **Drain stderr before \`tunnel_down\`** — the daemon was closing client connections the instant \`handle.Wait()\` returned, before \`pumpStderr\` finished consuming buffered stderr. Users got \"cloudflared exited unexpectedly\" with none of cloudflared's actual error message. Now the daemon waits for stderr to drain (with a 2s safety timeout) before broadcasting tunnel_down.
3. **Pre-flight credentials check in \`validateTunnelPrereqs\`** — if the tunnel exists in Cloudflare's view but the connector credentials JSON isn't on this machine, \`gtl tunnel\` errors immediately with the exact missing-file path and a clear explanation. No round-trip through the daemon.
4. **Setup hard-fails when adopting tunnels without local credentials** — \`gtl tunnel setup\` used to save configs for tunnels you could see but couldn't connect to. Now it refuses, with two actionable options (get the credentials from the creator, or create a new tunnel under a different name).

## What this does NOT do

Better error handling, not a runtime guarantee. Credentials that exist locally could still be revoked, scoped wrong, or mismatched against the tunnel UUID — cloudflared only finds out on connect. Adding a setup-time dry-connect is the natural follow-up.

## Test plan

- [x] \`go test -race ./...\` clean
- [x] \`golangci-lint run ./...\` clean
- [x] New regression test pins the stderr-drain ordering: error event lands on the wire BEFORE tunnel_down.
- [x] \`internal/tunnel/reset_test.go\` covers \`HasTunnelCredentials\` (missing / name-fallback / ignores directory), \`FindDomainCerts\` (filters correctly), \`FindTunnelCredentialFiles\`, \`DeleteCloudflaredFiles\`.
- [x] Smoke test on the built binary against a sandbox \`HOME\`:
  - \`gtl tunnel reset\` shows the right summary, refuses on \"n\".
  - \`gtl tunnel reset -y\` deletes \`cert.pem\` + per-domain certs.
  - Second run reports \"Nothing to reset\".