### PR TITLE
Fix tunnel DNS verification false negative from OS cache

### DIFF
--- a/cmd/tunnel.go
+++ b/cmd/tunnel.go
@@ -210,41 +210,18 @@ Two ways forward:
 		}
 
 		wildcardHost := "*." + domain
-		fmt.Println(style.Actionf("Routing %s → tunnel %q", wildcardHost, tunnelName))
-		if err := tunnel.RouteDNSWithCert(tunnelName, wildcardHost, certPath); err != nil {
-			return cliErr(cmd, printDNSManualInstructions(tunnelName, domain, err))
+		if err := routeDNSWithReauth(realDNSRouter(), tunnelName, domain, wildcardHost, &certPath); err != nil {
+			return cliErr(cmd, err)
 		}
 
-		// Verify DNS was created in the correct zone
+		// At this point cloudflared's API confirmed the route exists in
+		// the correct zone — a wrong-zone cert would have failed above
+		// with a 403. The remaining concern is just public propagation,
+		// so the check is informational.
 		testHost := "gtl-verify." + domain
 		fmt.Println(style.Dimf("Verifying DNS propagation..."))
-		if !tunnel.VerifyDNS(testHost, 10*time.Second) {
-			// DNS routing "succeeded" but record wasn't created in the right zone
-			// This happens when cert.pem is scoped to a different zone
-			fmt.Println()
-			fmt.Println(style.Warnf("DNS record was not created in the %s zone.", domain))
-			fmt.Println(style.Dimf("Your cloudflared credentials are for a different Cloudflare zone."))
-			fmt.Println()
-
-			if confirm.Prompt(fmt.Sprintf("Authenticate with the Cloudflare account that owns %s?", domain), true, nil) {
-				fmt.Println()
-				fmt.Println(style.Actionf("Opening Cloudflare login — select the zone for %s", domain))
-				if err := tunnel.LoginForDomain(domain); err != nil {
-					return fmt.Errorf("login failed: %w", err)
-				}
-
-				certPath = tunnel.CertPathForDomain(domain)
-				fmt.Println(style.Actionf("Routing %s → tunnel %q", wildcardHost, tunnelName))
-				if err := tunnel.RouteDNSWithCert(tunnelName, wildcardHost, certPath); err != nil {
-					return cliErr(cmd, printDNSManualInstructions(tunnelName, domain, err))
-				}
-
-				if !tunnel.VerifyDNS(testHost, 10*time.Second) {
-					return cliErr(cmd, printDNSManualInstructions(tunnelName, domain, nil))
-				}
-			} else {
-				return cliErr(cmd, printDNSManualInstructions(tunnelName, domain, nil))
-			}
+		if !tunnel.VerifyDNS(testHost, 30*time.Second) {
+			fmt.Println(style.Dimf("Record not visible from public DNS yet; propagation can take a minute. The tunnel will work once it resolves."))
 		}
 
 		if certPath != "" {
@@ -276,6 +253,68 @@ Two ways forward:
 	},
 }
 
+// dnsRouter bundles the side-effecting calls routeDNSWithReauth makes, so
+// tests can drive each branch without invoking cloudflared, opening a
+// browser, or reading stdin.
+type dnsRouter struct {
+	route  func(tunnelName, host, certPath string) error
+	login  func(domain string) error
+	prompt func(message string) bool
+}
+
+func realDNSRouter() dnsRouter {
+	return dnsRouter{
+		route: tunnel.RouteDNSWithCert,
+		login: tunnel.LoginForDomain,
+		prompt: func(msg string) bool {
+			return confirm.Prompt(msg, false, nil)
+		},
+	}
+}
+
+// routeDNSWithReauth attempts cloudflared's `tunnel route dns`. When it fails
+// and we used the default cert (no domain-specific cert on disk yet), the
+// most likely cause is that cert.pem is scoped to a different Cloudflare
+// zone — that's the failure mode we can recover from by re-authenticating.
+// On a successful re-login the caller's certPath is updated so the saved
+// config records the domain-specific cert.
+func routeDNSWithReauth(d dnsRouter, tunnelName, domain, wildcardHost string, certPath *string) error {
+	fmt.Println(style.Actionf("Routing %s → tunnel %q", wildcardHost, tunnelName))
+	err := d.route(tunnelName, wildcardHost, *certPath)
+	if err == nil {
+		return nil
+	}
+
+	// Only offer re-auth when we used the default cert. If a domain-
+	// specific cert was already on disk and still failed, re-login won't
+	// help; surface the error.
+	if *certPath != "" {
+		return printDNSManualInstructions(tunnelName, domain, err)
+	}
+
+	fmt.Println()
+	fmt.Println(style.Warnf("Cloudflare rejected the DNS route: %v", err))
+	fmt.Println(style.Dimf("Most often this means your current cloudflared credentials don't have access to the %s zone.", domain))
+	fmt.Println()
+
+	if !d.prompt(fmt.Sprintf("Authenticate with the Cloudflare account that owns %s?", domain)) {
+		return printDNSManualInstructions(tunnelName, domain, err)
+	}
+
+	fmt.Println()
+	fmt.Println(style.Actionf("Opening Cloudflare login — select the zone for %s", domain))
+	if err := d.login(domain); err != nil {
+		return fmt.Errorf("login failed: %w", err)
+	}
+
+	*certPath = tunnel.CertPathForDomain(domain)
+	fmt.Println(style.Actionf("Routing %s → tunnel %q", wildcardHost, tunnelName))
+	if err := d.route(tunnelName, wildcardHost, *certPath); err != nil {
+		return printDNSManualInstructions(tunnelName, domain, err)
+	}
+	return nil
+}
+
 func printDNSManualInstructions(tunnelName, domain string, err error) error {
 	tunnelUUID := tunnel.GetTunnelUUID(tunnelName)
 	if tunnelUUID == "" {
@@ -293,15 +332,9 @@ func printDNSManualInstructions(tunnelName, domain string, err error) error {
 	fmt.Printf("  Proxy:  Proxied (orange cloud)\n")
 	fmt.Println()
 
-	if err != nil {
-		return &CliError{
-			Message: "DNS routing failed",
-			Hint:    "Add the CNAME record manually in Cloudflare dashboard, then re-run setup.",
-		}
-	}
 	return &CliError{
-		Message: "DNS record not found in target zone",
-		Hint:    "Add the CNAME record manually in Cloudflare dashboard.",
+		Message: "DNS routing failed",
+		Hint:    "Add the CNAME record manually in Cloudflare dashboard, then re-run setup.",
 	}
 }
 

--- a/cmd/tunnel_test.go
+++ b/cmd/tunnel_test.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -34,6 +37,195 @@ func TestSortedKeys(t *testing.T) {
 	want := []string{"a", "b", "c"}
 	if len(got) != 3 || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
 		t.Errorf("sortedKeys = %v, want %v", got, want)
+	}
+}
+
+// --- routeDNSWithReauth tests ---
+
+// recordingRouter captures the calls routeDNSWithReauth makes and replays
+// scripted responses, so each test can describe a flow as a small program.
+type recordingRouter struct {
+	routeResponses []error
+	loginErr       error
+	promptAnswer   bool
+
+	routeCalls  []routeCall
+	loginCalls  []string
+	promptCalls []string
+}
+
+type routeCall struct {
+	tunnelName string
+	host       string
+	certPath   string
+}
+
+func (r *recordingRouter) deps() dnsRouter {
+	return dnsRouter{
+		route: func(tunnelName, host, certPath string) error {
+			r.routeCalls = append(r.routeCalls, routeCall{tunnelName, host, certPath})
+			if len(r.routeCalls) > len(r.routeResponses) {
+				return fmt.Errorf("unscripted route call #%d", len(r.routeCalls))
+			}
+			return r.routeResponses[len(r.routeCalls)-1]
+		},
+		login: func(domain string) error {
+			r.loginCalls = append(r.loginCalls, domain)
+			return r.loginErr
+		},
+		prompt: func(msg string) bool {
+			r.promptCalls = append(r.promptCalls, msg)
+			return r.promptAnswer
+		},
+	}
+}
+
+func TestRouteDNSWithReauth_SuccessFirstTry(t *testing.T) {
+	rec := &recordingRouter{routeResponses: []error{nil}}
+	certPath := ""
+
+	var err error
+	captureStdout(t, func() {
+		err = routeDNSWithReauth(rec.deps(), "gtl", "devtunl.com", "*.devtunl.com", &certPath)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rec.routeCalls) != 1 {
+		t.Errorf("expected 1 route call, got %d", len(rec.routeCalls))
+	}
+	if len(rec.promptCalls) != 0 {
+		t.Errorf("did not expect a prompt; got %d: %v", len(rec.promptCalls), rec.promptCalls)
+	}
+	if len(rec.loginCalls) != 0 {
+		t.Errorf("did not expect a login; got %d", len(rec.loginCalls))
+	}
+	if certPath != "" {
+		t.Errorf("certPath should not change on first-try success; got %q", certPath)
+	}
+}
+
+func TestRouteDNSWithReauth_DefaultCertFails_ReauthSucceeds(t *testing.T) {
+	rec := &recordingRouter{
+		routeResponses: []error{errors.New("403 Forbidden"), nil},
+		promptAnswer:   true,
+	}
+	certPath := ""
+
+	var err error
+	captureStdout(t, func() {
+		err = routeDNSWithReauth(rec.deps(), "gtl", "devtunl.com", "*.devtunl.com", &certPath)
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rec.routeCalls) != 2 {
+		t.Fatalf("expected 2 route calls, got %d", len(rec.routeCalls))
+	}
+	if rec.routeCalls[0].certPath != "" {
+		t.Errorf("first call should use default cert (empty path); got %q", rec.routeCalls[0].certPath)
+	}
+	if rec.routeCalls[1].certPath == "" {
+		t.Error("second call should use domain-specific cert path")
+	}
+	if len(rec.loginCalls) != 1 || rec.loginCalls[0] != "devtunl.com" {
+		t.Errorf("expected one login for devtunl.com; got %v", rec.loginCalls)
+	}
+	if certPath == "" {
+		t.Error("expected certPath to be updated to domain-specific path after relogin")
+	}
+}
+
+func TestRouteDNSWithReauth_DefaultCertFails_UserDeclinesReauth(t *testing.T) {
+	rec := &recordingRouter{
+		routeResponses: []error{errors.New("403 Forbidden")},
+		promptAnswer:   false,
+	}
+	certPath := ""
+
+	var err error
+	captureStdout(t, func() {
+		err = routeDNSWithReauth(rec.deps(), "gtl", "devtunl.com", "*.devtunl.com", &certPath)
+	})
+	if err == nil {
+		t.Fatal("expected error when user declines re-auth")
+	}
+	var ce *CliError
+	if !errors.As(err, &ce) {
+		t.Errorf("expected *CliError, got %T: %v", err, err)
+	}
+	if len(rec.loginCalls) != 0 {
+		t.Errorf("login should not run when prompt is declined; got %v", rec.loginCalls)
+	}
+	if len(rec.routeCalls) != 1 {
+		t.Errorf("expected only the initial route call; got %d", len(rec.routeCalls))
+	}
+}
+
+func TestRouteDNSWithReauth_DefaultCertFails_RetryAlsoFails(t *testing.T) {
+	rec := &recordingRouter{
+		routeResponses: []error{errors.New("403"), errors.New("403 again")},
+		promptAnswer:   true,
+	}
+	certPath := ""
+
+	var err error
+	captureStdout(t, func() {
+		err = routeDNSWithReauth(rec.deps(), "gtl", "devtunl.com", "*.devtunl.com", &certPath)
+	})
+	if err == nil {
+		t.Fatal("expected error when retry also fails")
+	}
+	var ce *CliError
+	if !errors.As(err, &ce) {
+		t.Errorf("expected *CliError, got %T", err)
+	}
+	if len(rec.loginCalls) != 1 {
+		t.Errorf("expected one login attempt; got %v", rec.loginCalls)
+	}
+	if len(rec.routeCalls) != 2 {
+		t.Errorf("expected two route calls; got %d", len(rec.routeCalls))
+	}
+}
+
+// When a domain-specific cert was already on disk and the route still fails,
+// re-login won't help (cert is already domain-scoped). The function must
+// surface the error without prompting or logging in.
+func TestRouteDNSWithReauth_DomainCertFails_NoReauthOffered(t *testing.T) {
+	rec := &recordingRouter{
+		routeResponses: []error{errors.New("some other failure")},
+	}
+	certPath := "/home/u/.cloudflared/cert-devtunl.com.pem"
+
+	var err error
+	captureStdout(t, func() {
+		err = routeDNSWithReauth(rec.deps(), "gtl", "devtunl.com", "*.devtunl.com", &certPath)
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if len(rec.promptCalls) != 0 {
+		t.Errorf("must not prompt when domain cert was used; got %v", rec.promptCalls)
+	}
+	if len(rec.loginCalls) != 0 {
+		t.Errorf("must not re-login when domain cert was used; got %v", rec.loginCalls)
+	}
+	if certPath != "/home/u/.cloudflared/cert-devtunl.com.pem" {
+		t.Errorf("certPath should not be mutated; got %q", certPath)
+	}
+}
+
+// Regression guard for the removed misleading message. printDNSManualInstructions
+// should never claim "credentials are for a different Cloudflare zone" — that
+// was a guess with no evidence. The actual zone-mismatch path runs only when
+// RouteDNS itself errors with a 403, which the caller already surfaces.
+func TestPrintDNSManualInstructions_NoBogusZoneClaim(t *testing.T) {
+	stdout := captureStdout(t, func() {
+		_ = printDNSManualInstructions("gtl", "devtunl.com", errors.New("403"))
+	})
+	bad := "credentials are for a different Cloudflare zone"
+	if strings.Contains(stdout, bad) {
+		t.Errorf("output should not contain %q (it was a guess, not evidence):\n%s", bad, stdout)
 	}
 }
 

--- a/internal/tunnel/tunnel.go
+++ b/internal/tunnel/tunnel.go
@@ -4,6 +4,7 @@ package tunnel
 
 import (
 	"bufio"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -357,10 +358,42 @@ func RouteDNSWithCert(tunnelName, hostname, certPath string) error {
 	return cmd.Run()
 }
 
-// VerifyDNS checks if a hostname resolves (has DNS records).
-// Returns true if the hostname resolves within the timeout.
+// PublicDNSResolver is the authoritative resolver VerifyDNS queries.
+// Cloudflare's 1.1.1.1 is appropriate since we're verifying records hosted
+// on Cloudflare and it's a public anycast resolver.
+const PublicDNSResolver = "1.1.1.1:53"
+
+// VerifyDNS polls an authoritative public resolver until the hostname
+// resolves or the timeout elapses.
+//
+// Why not net.LookupHost: that goes through the OS resolver. On macOS,
+// mDNSResponder caches NXDOMAIN responses for several minutes; any earlier
+// lookup of the hostname (browser, shell completion, or gtl itself during
+// setup) pins the negative answer and a 10–30s wait can't outlast it. We
+// dial 1.1.1.1 directly to bypass that cache.
 func VerifyDNS(hostname string, timeout time.Duration) bool {
-	return verifyDNSWith(hostname, timeout, net.LookupHost, 2*time.Second)
+	return verifyDNSWith(hostname, timeout, lookupHostPublic, 2*time.Second)
+}
+
+func lookupHostPublic(hostname string) ([]string, error) {
+	return lookupHostVia(hostname, PublicDNSResolver, 5*time.Second)
+}
+
+// lookupHostVia is the test seam — it dials `resolver` directly instead of
+// going through the OS resolver. PreferGo + a non-nil Dial guarantees Go's
+// pure resolver is used regardless of GODEBUG/netdns settings, which is the
+// whole point: we must not touch mDNSResponder's cache.
+func lookupHostVia(hostname, resolver string, timeout time.Duration) ([]string, error) {
+	r := &net.Resolver{
+		PreferGo: true,
+		Dial: func(ctx context.Context, network, _ string) (net.Conn, error) {
+			d := net.Dialer{Timeout: timeout}
+			return d.DialContext(ctx, network, resolver)
+		},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	return r.LookupHost(ctx, hostname)
 }
 
 func verifyDNSWith(hostname string, timeout time.Duration, lookup func(string) ([]string, error), interval time.Duration) bool {

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -2,6 +2,7 @@ package tunnel
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -422,6 +423,33 @@ func TestVerifyDNS_RetryThenSucceed(t *testing.T) {
 	}
 	if attempts < 3 {
 		t.Errorf("expected at least 3 attempts, got %d", attempts)
+	}
+}
+
+// lookupHostVia must dial the provided resolver and ignore the OS resolver.
+// We point it at a UDP port that's bound but never replies, so a correct
+// implementation hits its own timeout. A regression that wired the system
+// resolver back in would succeed (or fail with a different error shape).
+func TestLookupHostVia_UsesGivenResolverNotSystem(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	defer pc.Close()
+	resolver := pc.LocalAddr().String()
+
+	// example.com would resolve fine via the system resolver. If our
+	// implementation accidentally falls back to it, this lookup will
+	// succeed and the assertion below will fail.
+	start := time.Now()
+	_, err = lookupHostVia("example.com.", resolver, 200*time.Millisecond)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected lookup to fail when resolver is unresponsive, got success — system resolver may be in the path")
+	}
+	if elapsed > 2*time.Second {
+		t.Errorf("lookup took %v — expected to time out near 200ms", elapsed)
 	}
 }
 

--- a/internal/tunnel/tunnel_test.go
+++ b/internal/tunnel/tunnel_test.go
@@ -435,7 +435,7 @@ func TestLookupHostVia_UsesGivenResolverNotSystem(t *testing.T) {
 	if err != nil {
 		t.Fatalf("listen: %v", err)
 	}
-	defer pc.Close()
+	defer func() { _ = pc.Close() }()
 	resolver := pc.LocalAddr().String()
 
 	// example.com would resolve fine via the system resolver. If our


### PR DESCRIPTION
## Summary

`gtl tunnel setup` was failing after Cloudflare's API had already confirmed the DNS record exists. Two bugs stacked:

1. **OS cache poisoning.** `VerifyDNS` used `net.LookupHost`, which on macOS goes through `mDNSResponder`. `mDNSResponder` caches NXDOMAIN for minutes, so any earlier lookup of `*.{domain}` (browser, shell completion, gtl itself during setup) pinned the negative answer. The 10-second verification couldn't outlast the negative cache, even when the record had been created seconds earlier.
2. **Evidence-free diagnosis.** When verification failed, gtl printed `Your cloudflared credentials are for a different Cloudflare zone.` and pushed users into a re-auth flow. This was a hard-coded guess — `cloudflared tunnel route dns` calls the Cloudflare API, and a wrong-zone cert fails there with a 403, not silently. If `RouteDNSWithCert` returned `nil`, the zone was correct.

## Changes

- **Bypass the OS resolver.** `VerifyDNS` now dials `1.1.1.1:53` directly through `net.Resolver{PreferGo: true, Dial: ...}`. `lookupHostVia(hostname, resolver, timeout)` is exposed as a test seam.
- **Trust cloudflared's exit status.** A successful `RouteDNSWithCert` is the authoritative signal that the record exists in the correct zone. The post-routing DNS check is now a propagation hint (soft warning), not a hard gate.
- **Move re-auth to where evidence lives.** Extracted `routeDNSWithReauth` with injectable `dnsRouter` deps. The re-auth offer fires only when `RouteDNS` itself errors on the first attempt with the default cert — the actual recovery path.
- **Drop the misleading message.** The "credentials are for a different Cloudflare zone" line is gone.

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] New `TestLookupHostVia_UsesGivenResolverNotSystem` proves the bypass — fails if anyone reverts to `net.LookupHost` (system resolver would resolve `example.com` and the test would no longer time out)
- [x] Five new tests cover every branch of `routeDNSWithReauth`: success first try, default-cert fail → re-auth succeeds, default-cert fail → user declines, default-cert fail → retry fails, domain-cert fail (no re-auth offered)
- [x] Regression guard pinning the absence of the bogus zone-mismatch string
- [ ] Manual smoke: run `gtl tunnel setup` on a machine where `mDNSResponder` has cached NXDOMAIN for the verification hostname — should now complete cleanly