### PR TITLE
release: remove unmanaged worktrees when --remove-worktree is passed

### DIFF
--- a/cmd/release.go
+++ b/cmd/release.go
@@ -87,6 +87,14 @@ func runReleaseSingle(args []string) error {
 						fmt.Println(style.Dimf("  These commits may be lost if you remove the worktree."))
 						fmt.Println()
 					}
+					if releaseDryRun {
+						fmt.Printf("Would remove worktree %s. (dry-run)\n", filepath.Base(absPath))
+						return nil
+					}
+					if !confirm.Prompt("Remove worktree?", releaseForce, nil) {
+						fmt.Println("Aborted.")
+						return nil
+					}
 					removeWorktreeDir(absPath, releaseForce)
 					return nil
 				}

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -75,6 +75,23 @@ func runReleaseSingle(args []string) error {
 	reg := registry.New("")
 	alloc := reg.Find(absPath)
 	if alloc == nil {
+		if releaseRemoveWorktree {
+			if _, err := os.Stat(absPath); err == nil {
+				mainRepo := worktree.DetectMainRepo(absPath)
+				if mainRepo != absPath {
+					unpushed := worktree.UnpushedCommitCount(absPath)
+					if unpushed > 0 {
+						branch := worktree.CurrentBranch(absPath)
+						fmt.Println()
+						fmt.Println(style.Warnf("Branch %q has %d unpushed commit(s).", branch, unpushed))
+						fmt.Println(style.Dimf("  These commits may be lost if you remove the worktree."))
+						fmt.Println()
+					}
+					removeWorktreeDir(absPath, releaseForce)
+					return nil
+				}
+			}
+		}
 		return errNoAllocation(absPath)
 	}
 


### PR DESCRIPTION
## Summary

- `gtl release <path> --remove-worktree` previously returned "No allocation found" and did nothing when the path had no GTL allocation record
- Now, if `--remove-worktree` is set and the path is a valid linked git worktree, GTL warns about unpushed commits and removes it via `git worktree remove`, then exits 0
- The "No allocation found" error is preserved for all other cases (no flag, or path is not a linked worktree)

## Motivation

The Treeline Mac app calls `gtl release <path> --force --remove-worktree --drop-db` when archiving worktrees. Worktrees created by Conductor's agent runner are valid git worktrees but have no GTL allocation record, causing the removal to silently no-op and leaving stale entries on disk and in git's worktree list.

## Behavior matrix

| Allocation exists | `--remove-worktree` | Path is linked worktree | Result |
|---|---|---|---|
| Yes | Yes | — | Existing: deallocate + remove |
| Yes | No | — | Existing: deallocate only |
| No | Yes | Yes | **New**: remove worktree + exit 0 |
| No | Yes | No | "No allocation found" (unchanged) |
| No | No | — | "No allocation found" (unchanged) |

## Test plan

- [ ] `gtl release <unmanaged-worktree-path> --remove-worktree` removes the directory and prunes the worktree registration
- [ ] `gtl release <unmanaged-worktree-path> --remove-worktree --force` skips confirmation
- [ ] `gtl release <unmanaged-worktree-path>` (no flag) still returns "No allocation found"
- [ ] `gtl release <managed-worktree-path> --remove-worktree` still follows existing allocation path
- [ ] All existing tests pass