### PR TITLE
feat: support explicit pg connection params to avoid Postgres.app socket prompt

### DIFF
--- a/cmd/db.go
+++ b/cmd/db.go
@@ -192,7 +192,7 @@ func resolveDB() (*dbInfo, error) {
 	}
 
 	adapterName := pc.DatabaseAdapter()
-	adapter, err := database.ForAdapter(adapterName)
+	adapter, err := database.ForAdapter(adapterName, pc.DatabaseConnArgs())
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -154,7 +154,7 @@ func dropDatabases(adapterName string, entries []registry.Allocation) {
 	if len(entries) == 0 {
 		return
 	}
-	adapter, err := database.ForAdapter(adapterName)
+	adapter, err := database.ForAdapter(adapterName, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "  warning: %v\n", err)
 		return

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -136,6 +137,35 @@ func (pc *ProjectConfig) DatabaseTemplate() string {
 		return s
 	}
 	return ""
+}
+
+// DatabaseConnArgs builds connection flag arguments for psql/createdb/dropdb
+// from optional database.host, database.port, and database.user config values.
+// Setting host: localhost forces TCP connections, which avoids Postgres.app's
+// Unix socket authorization dialog when gtl is invoked from a native macOS app.
+func (pc *ProjectConfig) DatabaseConnArgs() []string {
+	var args []string
+	if host, ok := Dig(pc.Data, "database", "host").(string); ok && host != "" {
+		args = append(args, "-h", host)
+	}
+	switch p := Dig(pc.Data, "database", "port").(type) {
+	case string:
+		if p != "" {
+			args = append(args, "-p", p)
+		}
+	case float64:
+		if p != 0 {
+			args = append(args, "-p", strconv.Itoa(int(p)))
+		}
+	case int:
+		if p != 0 {
+			args = append(args, "-p", strconv.Itoa(p))
+		}
+	}
+	if user, ok := Dig(pc.Data, "database", "user").(string); ok && user != "" {
+		args = append(args, "-U", user)
+	}
+	return args
 }
 
 func (pc *ProjectConfig) DatabasePattern() string {

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -911,6 +912,62 @@ func TestProjectConfig_Validate(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), c.wantErr) {
 				t.Errorf("expected error containing %q, got: %v", c.wantErr, err)
+			}
+		})
+	}
+}
+
+func TestDatabaseConnArgs(t *testing.T) {
+	tests := []struct {
+		name     string
+		yaml     string
+		wantArgs []string
+	}{
+		{
+			name:     "no connection config",
+			yaml:     "project: test\n",
+			wantArgs: nil,
+		},
+		{
+			name:     "host only forces TCP",
+			yaml:     "project: test\ndatabase:\n  host: localhost\n",
+			wantArgs: []string{"-h", "localhost"},
+		},
+		{
+			name:     "host and port as integer",
+			yaml:     "project: test\ndatabase:\n  host: localhost\n  port: 5432\n",
+			wantArgs: []string{"-h", "localhost", "-p", "5432"},
+		},
+		{
+			name:     "host and port as string",
+			yaml:     "project: test\ndatabase:\n  host: localhost\n  port: \"5433\"\n",
+			wantArgs: []string{"-h", "localhost", "-p", "5433"},
+		},
+		{
+			name:     "host, port, and user",
+			yaml:     "project: test\ndatabase:\n  host: localhost\n  port: 5432\n  user: myuser\n",
+			wantArgs: []string{"-h", "localhost", "-p", "5432", "-U", "myuser"},
+		},
+		{
+			name:     "user without host",
+			yaml:     "project: test\ndatabase:\n  user: myuser\n",
+			wantArgs: []string{"-U", "myuser"},
+		},
+		{
+			name:     "empty host ignored",
+			yaml:     "project: test\ndatabase:\n  host: \"\"\n",
+			wantArgs: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(tt.yaml), 0o644)
+			pc := LoadProjectConfig(dir)
+			got := pc.DatabaseConnArgs()
+			if !reflect.DeepEqual(got, tt.wantArgs) {
+				t.Errorf("DatabaseConnArgs() = %v, want %v", got, tt.wantArgs)
 			}
 		})
 	}

--- a/internal/database/adapter.go
+++ b/internal/database/adapter.go
@@ -21,10 +21,12 @@ type Adapter interface {
 
 // ForAdapter returns the adapter for the given name.
 // Defaults to PostgreSQL for empty string (backward compatibility).
-func ForAdapter(name string) (Adapter, error) {
+// connArgs are connection flags (e.g. ["-h", "localhost"]) prepended to every
+// pg tool invocation; pass nil when no explicit connection is needed.
+func ForAdapter(name string, connArgs []string) (Adapter, error) {
 	switch name {
 	case "postgresql", "":
-		return &PostgreSQL{}, nil
+		return &PostgreSQL{ConnArgs: connArgs}, nil
 	case "sqlite":
 		return &SQLite{}, nil
 	default:

--- a/internal/database/postgresql.go
+++ b/internal/database/postgresql.go
@@ -23,32 +23,39 @@ var templateLocks sync.Map
 // PostgreSQL implements the Adapter interface for PostgreSQL databases.
 // Clone uses createdb --template, Drop uses dropdb --if-exists.
 type PostgreSQL struct {
+	// ConnArgs are prepended to every pg tool invocation (e.g. ["-h", "localhost", "-p", "5432"]).
+	// Setting -h forces TCP instead of Unix socket, which avoids Postgres.app's
+	// socket authorization dialog when gtl is invoked from a native macOS app.
+	ConnArgs   []string
 	execRun    func(name string, args ...string) error
 	execOutput func(name string, args ...string) ([]byte, error)
 }
 
 func (pg *PostgreSQL) run(name string, args ...string) error {
+	all := append(pg.ConnArgs, args...)
 	if pg.execRun != nil {
-		return pg.execRun(name, args...)
+		return pg.execRun(name, all...)
 	}
-	cmd := exec.Command(name, args...)
+	cmd := exec.Command(name, all...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 
 func (pg *PostgreSQL) runSilent(name string, args ...string) error {
+	all := append(pg.ConnArgs, args...)
 	if pg.execRun != nil {
-		return pg.execRun(name, args...)
+		return pg.execRun(name, all...)
 	}
-	return exec.Command(name, args...).Run()
+	return exec.Command(name, all...).Run()
 }
 
 func (pg *PostgreSQL) output(name string, args ...string) ([]byte, error) {
+	all := append(pg.ConnArgs, args...)
 	if pg.execOutput != nil {
-		return pg.execOutput(name, args...)
+		return pg.execOutput(name, all...)
 	}
-	return exec.Command(name, args...).Output()
+	return exec.Command(name, all...).Output()
 }
 
 func (pg *PostgreSQL) Exists(name string) (bool, error) {

--- a/internal/database/postgresql_test.go
+++ b/internal/database/postgresql_test.go
@@ -405,7 +405,7 @@ func TestForAdapter(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			adapter, err := ForAdapter(tt.name)
+			adapter, err := ForAdapter(tt.name, nil)
 			if tt.wantErr {
 				if err == nil {
 					t.Error("expected error")
@@ -419,5 +419,143 @@ func TestForAdapter(t *testing.T) {
 				t.Fatal("expected non-nil adapter")
 			}
 		})
+	}
+}
+
+func TestForAdapter_ConnArgsPropagated(t *testing.T) {
+	connArgs := []string{"-h", "localhost", "-p", "5432"}
+	adapter, err := ForAdapter("postgresql", connArgs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pg, ok := adapter.(*PostgreSQL)
+	if !ok {
+		t.Fatal("expected *PostgreSQL")
+	}
+	if len(pg.ConnArgs) != len(connArgs) {
+		t.Fatalf("ConnArgs = %v, want %v", pg.ConnArgs, connArgs)
+	}
+	for i, v := range connArgs {
+		if pg.ConnArgs[i] != v {
+			t.Errorf("ConnArgs[%d] = %q, want %q", i, pg.ConnArgs[i], v)
+		}
+	}
+}
+
+// --- ConnArgs prepend tests ---
+
+func testPgWithConnArgs(t *testing.T, connArgs []string) (*PostgreSQL, *[]cmdCall) {
+	t.Helper()
+	var calls []cmdCall
+	pg := &PostgreSQL{
+		ConnArgs: connArgs,
+		execRun: func(name string, args ...string) error {
+			calls = append(calls, cmdCall{name, args})
+			return nil
+		},
+		execOutput: func(name string, args ...string) ([]byte, error) {
+			calls = append(calls, cmdCall{name, args})
+			return []byte(" myapp_dev | user | UTF8\n"), nil
+		},
+	}
+	return pg, &calls
+}
+
+func TestPostgreSQL_ConnArgs_PrependedToExists(t *testing.T) {
+	pg, calls := testPgWithConnArgs(t, []string{"-h", "localhost", "-p", "5432"})
+
+	_, err := pg.Exists("myapp_dev")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(*calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(*calls))
+	}
+	args := (*calls)[0].args
+	if len(args) < 3 || args[0] != "-h" || args[1] != "localhost" || args[2] != "-p" {
+		t.Errorf("expected ConnArgs prepended, got: %v", args)
+	}
+}
+
+func TestPostgreSQL_ConnArgs_PrependedToClone(t *testing.T) {
+	pg, calls := testPgWithConnArgs(t, []string{"-h", "localhost"})
+
+	err := pg.Clone("myapp_dev", "myapp_feat")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(*calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d: %v", len(*calls), *calls)
+	}
+	// Both psql (terminate) and createdb should have ConnArgs prepended
+	for i, call := range *calls {
+		if len(call.args) == 0 || call.args[0] != "-h" {
+			t.Errorf("call[%d] %s: expected -h as first arg, got %v", i, call.name, call.args)
+		}
+	}
+	// createdb args: [-h localhost myapp_feat --template myapp_dev]
+	createdbCall := (*calls)[1]
+	if createdbCall.name != "createdb" {
+		t.Fatalf("expected createdb, got %s", createdbCall.name)
+	}
+	// ConnArgs are [-h localhost], so target is at index 2
+	connOffset := 2
+	if createdbCall.args[connOffset] != "myapp_feat" {
+		t.Errorf("createdb target = %q, want myapp_feat (args: %v)", createdbCall.args[connOffset], createdbCall.args)
+	}
+}
+
+func TestPostgreSQL_ConnArgs_PrependedToDrop(t *testing.T) {
+	pg, calls := testPgWithConnArgs(t, []string{"-h", "localhost"})
+
+	err := pg.Drop("myapp_feat")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(*calls) != 1 {
+		t.Fatalf("expected 1 call, got %d", len(*calls))
+	}
+	args := (*calls)[0].args
+	if len(args) == 0 || args[0] != "-h" {
+		t.Errorf("expected ConnArgs prepended to dropdb, got: %v", args)
+	}
+}
+
+func TestPostgreSQL_ConnArgs_PrependedToRestore(t *testing.T) {
+	dir := t.TempDir()
+	dumpFile := filepath.Join(dir, "dump.sql")
+	_ = os.WriteFile(dumpFile, []byte("CREATE TABLE foo;"), 0o644)
+
+	pg, calls := testPgWithConnArgs(t, []string{"-h", "localhost"})
+
+	err := pg.Restore("myapp_feat", dumpFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(*calls) != 2 {
+		t.Fatalf("expected 2 calls, got %d", len(*calls))
+	}
+	for i, call := range *calls {
+		if len(call.args) == 0 || call.args[0] != "-h" {
+			t.Errorf("call[%d] %s: expected -h as first arg, got %v", i, call.name, call.args)
+		}
+	}
+}
+
+func TestPostgreSQL_NoConnArgs_UnchangedBehavior(t *testing.T) {
+	pg, calls := testPg(t, " myapp_dev | user | UTF8\n", "")
+
+	err := pg.Clone("myapp_dev", "myapp_feat")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createdbCall := (*calls)[1]
+	if createdbCall.args[0] != "myapp_feat" {
+		t.Errorf("without ConnArgs, first createdb arg should be target, got: %v", createdbCall.args)
 	}
 }

--- a/internal/format/format.go
+++ b/internal/format/format.go
@@ -79,7 +79,7 @@ func DropDatabases(allocs []Allocation) {
 			continue
 		}
 		adapterName := GetStr(a, "database_adapter")
-		adapter, err := database.ForAdapter(adapterName)
+		adapter, err := database.ForAdapter(adapterName, nil)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: %s, skipping database drop for %s\n", err, db)
 			continue
@@ -102,7 +102,7 @@ func DropSingleDB(alloc Allocation, worktreePath string) {
 		return
 	}
 	adapterName := GetStr(alloc, "database_adapter")
-	adapter, err := database.ForAdapter(adapterName)
+	adapter, err := database.ForAdapter(adapterName, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: %s, skipping database drop\n", err)
 		return

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -406,7 +406,7 @@ func updateOrAppend(file, key, value string) error {
 
 func (s *Setup) cloneDatabase(alloc *allocator.Allocation) error {
 	adapterName := s.ProjectConfig.DatabaseAdapter()
-	adapter, err := database.ForAdapter(adapterName)
+	adapter, err := database.ForAdapter(adapterName, s.ProjectConfig.DatabaseConnArgs())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- Adds `database.host`, `database.port`, and `database.user` fields to `.treeline.yml`
- When set, these are passed as `-h`/`-p`/`-U` flags to every `psql`, `createdb`, `dropdb`, and `pg_restore` invocation
- Setting `host: localhost` forces TCP connections instead of Unix socket, which bypasses Postgres.app's bundle authorization dialog when `gtl` is spawned from a native macOS app

**Usage** — add to `.treeline.yml`:
\`\`\`yaml
database:
  adapter: postgresql
  template: myapp_dev
  host: localhost   # forces TCP, avoids Postgres.app socket auth prompt
\`\`\`

## Test plan

- [x] `TestForAdapter_ConnArgsPropagated` — verifies `ForAdapter` threads `connArgs` into the `PostgreSQL` struct
- [x] `TestPostgreSQL_ConnArgs_PrependedTo*` — four tests verifying `ConnArgs` are prepended to `Exists`, `Clone`, `Drop`, and `Restore` commands
- [x] `TestPostgreSQL_NoConnArgs_UnchangedBehavior` — verifies nil `ConnArgs` leaves existing behavior unchanged
- [x] `TestDatabaseConnArgs` — seven cases covering host-only, host+port (int/string), host+port+user, user-only, empty host, and no config