### PR TITLE
feat: add host: localhost to postgresql database templates

### DIFF
--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -53,6 +53,9 @@ func nextJS(project, templateDB string, det *detect.Result) string {
 		fmt.Fprintf(&b, "  adapter: postgresql\n")
 		fmt.Fprintf(&b, "  template: %s\n", templateDB)
 		fmt.Fprintf(&b, "  pattern: \"{template}_{worktree}\"\n")
+		fmt.Fprintf(&b, "  host: localhost\n")
+		fmt.Fprintf(&b, "  # port: 5432\n")
+		fmt.Fprintf(&b, "  # user: postgres\n")
 	}
 
 	if emit {
@@ -104,6 +107,9 @@ func rails(project, templateDB string, det *detect.Result) string {
 	} else {
 		fmt.Fprintf(&b, "  template: %s\n", templateDB)
 		fmt.Fprintf(&b, "  pattern: \"{template}_{worktree}\"\n")
+		fmt.Fprintf(&b, "  host: localhost\n")
+		fmt.Fprintf(&b, "  # port: 5432\n")
+		fmt.Fprintf(&b, "  # user: postgres\n")
 	}
 
 	b.WriteString("\ncopy_files:\n")
@@ -173,6 +179,9 @@ func phoenix(project, templateDB string, det *detect.Result) string {
 		}
 		fmt.Fprintf(&b, "  template: %s\n", tdb)
 		fmt.Fprintf(&b, "  pattern: \"{template}_{worktree}\"\n")
+		fmt.Fprintf(&b, "  host: localhost\n")
+		fmt.Fprintf(&b, "  # port: 5432\n")
+		fmt.Fprintf(&b, "  # user: postgres\n")
 	}
 
 	if emit {


### PR DESCRIPTION
Sets `host: localhost` as the default in generated `.treeline.yml` for Rails, Phoenix, and Next.js+Prisma projects.

Forces TCP connections when treeline runs psql/createdb/dropdb, avoiding the Postgres.app Unix socket authorization dialog when `gtl` is invoked from a native macOS app (e.g. Treeline.app).

Also adds `# port: 5432` and `# user: postgres` as commented hints, documenting the option for teams using a shared remote template database.