### PR TITLE
Resolve project drift during setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.43.7]
+
+- **`gtl setup` and `gtl install` can now resolve project-name drift without throwing away local data.** When `.treeline.yml` has been renamed but the registry still has the old project name, setup/install now offer a Resolve path that keeps the YAML name, resets the registry entry, and either renames, drops, or leaves the existing worktree database based on an explicit prompt. Database operations fail closed: invalid prompt input, adapter errors, existence-check failures, drop failures, and SQLite rename collisions preserve the registry entry so the user can retry safely.
+- **`gtl serve install` is more tolerant of transient macOS launchd reload failures.** LaunchAgent bootstrap now retries the narrow `launchctl` exit-code-5 case after re-running bootout, which covers the common "just unloaded but launchd still thinks it is loaded" race without retrying unrelated failures.
+- **Go toolchain bumped to 1.26.4** to pick up standard-library security fixes flagged by `govulncheck`.
+
 ## [0.43.6]
 
 - **Native macOS apps (e.g. Treeline.app) no longer get a Postgres.app permission dialog when creating worktree databases.** When `gtl` is spawned from a native app rather than a shell, `psql`/`createdb`/`dropdb` fell back to Unix socket connections, and Postgres.app's bundle-authorization dialog fired because the connection was attributed to the parent app's process family. Adding `host: localhost` (or any explicit host) to the `database:` block in `.treeline.yml` now forces TCP connections instead — bypassing the socket authorization entirely. `database.port` and `database.user` are also supported for full connection control.

--- a/cmd/drift.go
+++ b/cmd/drift.go
@@ -4,19 +4,22 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/git-treeline/cli/internal/config"
+	"github.com/git-treeline/cli/internal/database"
 	"github.com/git-treeline/cli/internal/registry"
 	"github.com/git-treeline/cli/internal/style"
 )
 
-// detectProjectDrift compares the project name in .treeline.yml against the
-// registry allocation. Returns the YAML name, registry name, and whether they
-// differ. No drift is reported when no allocation exists yet.
-func detectProjectDrift(absPath string) (yamlName, registryName string, drifted bool) {
-	return detectProjectDriftWith(absPath, registry.New(""))
-}
+// driftReader is the buffered reader used for interactive prompts.
+// Tests replace it with a bufio.NewReader(strings.NewReader(...)) so that
+// multiple prompt calls share the same buffer and reads don't get lost.
+var driftReader = bufio.NewReader(os.Stdin)
+
+// adapterFor is overridable in tests to inject a mock database adapter.
+var adapterFor = database.ForAdapter
 
 // detectProjectDriftWith is the testable core — accepts an explicit registry.
 func detectProjectDriftWith(absPath string, reg *registry.Registry) (yamlName, registryName string, drifted bool) {
@@ -34,12 +37,21 @@ func detectProjectDriftWith(absPath string, reg *registry.Registry) (yamlName, r
 	return yamlName, registryName, yamlName != registryName
 }
 
-// checkDriftOrAbort detects project name drift and prompts the user to revert
-// .treeline.yml. Returns nil if there's no drift or the user accepted the
-// revert. Returns a non-nil error (suitable for cliErr) if the user declined
-// — the caller should not proceed.
+// checkDriftOrAbort is called by start and env-sync. It offers only Abort and
+// Revert — Resolve is restricted to setup since those callers have no
+// allocation to work with after the registry entry is reset.
 func checkDriftOrAbort(absPath string) error {
-	yamlName, registryName, drifted := detectProjectDrift(absPath)
+	return checkDriftOrAbortWith(absPath, registry.New(""), false)
+}
+
+// checkDriftOrAbortForSetup is called by gtl setup. It also offers Resolve,
+// which resets the registry entry so setup can reallocate under the new name.
+func checkDriftOrAbortForSetup(absPath string) error {
+	return checkDriftOrAbortWith(absPath, registry.New(""), true)
+}
+
+func checkDriftOrAbortWith(absPath string, reg *registry.Registry, resolveEnabled bool) error {
+	yamlName, registryName, drifted := detectProjectDriftWith(absPath, reg)
 	if !drifted {
 		return nil
 	}
@@ -47,23 +59,154 @@ func checkDriftOrAbort(absPath string) error {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, style.Warnf("Project name mismatch:"))
 	fmt.Fprintf(os.Stderr, "    .treeline.yml says %q, registry says %q.\n\n", yamlName, registryName)
-	fmt.Fprintln(os.Stderr, "  All routing, databases, and resolve links use", fmt.Sprintf("%q.", registryName))
+	fmt.Fprintln(os.Stderr, "  How do you want to fix this?")
+	fmt.Fprintf(os.Stderr, "    [1] Abort — leave everything as-is\n")
+	fmt.Fprintf(os.Stderr, "    [2] Revert — update .treeline.yml back to %q\n", registryName)
+	if resolveEnabled {
+		fmt.Fprintf(os.Stderr, "    [3] Resolve — keep %q, reset the registry entry and fix the database\n", yamlName)
+	}
 	fmt.Fprintln(os.Stderr)
 
-	if promptDefaultYes(fmt.Sprintf("  Revert .treeline.yml to %q?", registryName)) {
+	maxChoice := 2
+	if resolveEnabled {
+		maxChoice = 3
+	}
+
+	switch promptChoice(maxChoice) {
+	case 2:
 		if err := revertProjectInYAML(absPath, registryName); err != nil {
 			return fmt.Errorf("reverting project name: %w", err)
 		}
 		fmt.Fprintf(os.Stderr, "  Reverted project to %q in .treeline.yml.\n\n", registryName)
 		return nil
+	case 3:
+		return resolveRegistryDrift(absPath, yamlName, registryName, reg)
+	default:
+		return &CliError{
+			Message: fmt.Sprintf("Project name mismatch: .treeline.yml=%q, registry=%q.", yamlName, registryName),
+			Hint:    "Run 'gtl setup' to resolve.",
+		}
+	}
+}
+
+type dbResolutionKind int
+
+const (
+	dbLeave  dbResolutionKind = iota
+	dbRename dbResolutionKind = iota
+	dbDrop   dbResolutionKind = iota
+)
+
+// resolveRegistryDrift collects all decisions about the database upfront,
+// shows a plan summary, confirms once, then executes: DB action first so that
+// a failure leaves the registry entry intact and the user can retry.
+func resolveRegistryDrift(absPath, yamlName, registryName string, reg *registry.Registry) error {
+	alloc := reg.Find(absPath)
+	if alloc == nil {
+		return nil
 	}
 
-	return &CliError{
-		Message: fmt.Sprintf("Project name mismatch: .treeline.yml=%q, registry=%q.", yamlName, registryName),
-		Hint: fmt.Sprintf("To rename the project, release all worktrees first:\n"+
-			"    gtl release --all --project %s\n"+
-			"  Then update .treeline.yml and run gtl setup.", registryName),
+	oldDB := registry.GetString(alloc, "database")
+	adapterName := registry.GetString(alloc, "database_adapter")
+
+	dbAction := dbLeave
+	var oldDBPath, newDB, newDBPath string
+
+	if oldDB != "" {
+		pc := config.LoadProjectConfig(absPath)
+		adapter, err := adapterFor(adapterName, pc.DatabaseConnArgs())
+		if err != nil {
+			return fmt.Errorf("opening database adapter: %w", err)
+		}
+		oldDBPath = oldDB
+		if adapterName == "sqlite" {
+			oldDBPath = filepath.Join(absPath, oldDB)
+		}
+
+		exists, err := adapter.Exists(oldDBPath)
+		if err != nil {
+			return fmt.Errorf("checking database %s: %w", oldDB, err)
+		}
+		if exists {
+			if strings.HasPrefix(oldDB, registryName) {
+				newDB = yamlName + oldDB[len(registryName):]
+				newDBPath = newDB
+				if adapterName == "sqlite" {
+					newDBPath = filepath.Join(absPath, newDB)
+				}
+				fmt.Fprintln(os.Stderr)
+				fmt.Fprintf(os.Stderr, "  Database found: %s\n", oldDB)
+				fmt.Fprintf(os.Stderr, "    [1] Rename to %s (keeps your data)\n", newDB)
+				fmt.Fprintf(os.Stderr, "    [2] Drop and recreate fresh\n")
+				fmt.Fprintln(os.Stderr)
+				switch promptChoice(2) {
+				case 1:
+					dbAction = dbRename
+				case 2:
+					dbAction = dbDrop
+				default:
+					return &CliError{Message: "Aborted — no valid choice entered."}
+				}
+			} else {
+				fmt.Fprintln(os.Stderr)
+				fmt.Fprintf(os.Stderr, "  Database found: %s\n", oldDB)
+				fmt.Fprintf(os.Stderr, "    [1] Drop it (a fresh one will be created on setup)\n")
+				fmt.Fprintf(os.Stderr, "    [2] Leave it as-is\n")
+				fmt.Fprintln(os.Stderr)
+				switch promptChoice(2) {
+				case 1:
+					dbAction = dbDrop
+				case 2:
+					dbAction = dbLeave
+				default:
+					return &CliError{Message: "Aborted — no valid choice entered."}
+				}
+			}
+		}
 	}
+
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintln(os.Stderr, "  Plan:")
+	fmt.Fprintf(os.Stderr, "    • Reset registry entry for this worktree\n")
+	switch dbAction {
+	case dbRename:
+		fmt.Fprintf(os.Stderr, "    • Rename database: %s → %s\n", oldDB, newDB)
+	case dbDrop:
+		fmt.Fprintf(os.Stderr, "    • Drop database %s (a fresh one will be created on setup)\n", oldDB)
+	}
+	fmt.Fprintln(os.Stderr)
+
+	if !promptDefaultYes("  Proceed?") {
+		return &CliError{Message: "Aborted."}
+	}
+
+	if dbAction != dbLeave {
+		pc := config.LoadProjectConfig(absPath)
+		adapter, err := adapterFor(adapterName, pc.DatabaseConnArgs())
+		if err != nil {
+			return fmt.Errorf("opening database adapter: %w", err)
+		}
+		switch dbAction {
+		case dbRename:
+			fmt.Printf("==> Renaming database %s → %s\n", oldDB, newDB)
+			if err := adapter.Rename(oldDBPath, newDBPath); err != nil {
+				return fmt.Errorf("renaming database: %w", err)
+			}
+		case dbDrop:
+			fmt.Printf("==> Dropping database %s\n", oldDB)
+			if err := adapter.Drop(oldDBPath); err != nil {
+				return fmt.Errorf("dropping database %s: %w", oldDB, err)
+			}
+		}
+	}
+
+	fmt.Println("==> Resetting registry entry")
+	if _, err := reg.Release(absPath); err != nil {
+		return fmt.Errorf("releasing registry entry: %w", err)
+	}
+
+	fmt.Fprintln(os.Stderr)
+	return nil
 }
 
 // revertProjectInYAML writes the registry project name back to .treeline.yml.
@@ -72,17 +215,27 @@ func revertProjectInYAML(absPath, registryName string) error {
 	return pc.SetProject(registryName)
 }
 
+// promptChoice reads a numeric choice in [1, max] from driftReader.
+// Returns 0 if the input is invalid or out of range.
+func promptChoice(max int) int {
+	fmt.Printf("  Enter choice [1-%d]: ", max)
+	line, _ := driftReader.ReadString('\n')
+	var n int
+	if _, err := fmt.Sscanf(strings.TrimSpace(line), "%d", &n); err == nil && n >= 1 && n <= max {
+		return n
+	}
+	return 0
+}
+
 // promptDefaultYes asks a [Y/n] question where Enter defaults to yes.
 func promptDefaultYes(message string) bool {
 	fmt.Printf("%s [Y/n] ", message)
-	scanner := bufio.NewScanner(os.Stdin)
-	if scanner.Scan() {
-		answer := strings.TrimSpace(strings.ToLower(scanner.Text()))
-		if answer == "" || answer == "y" || answer == "yes" {
-			return true
-		}
+	line, err := driftReader.ReadString('\n')
+	if err != nil && line == "" {
+		return false // EOF with no input — treat as abort
 	}
-	return false
+	answer := strings.TrimSpace(strings.ToLower(line))
+	return answer == "" || answer == "y" || answer == "yes"
 }
 
 // doctorProjectDrift reports project name drift as a diagnostic finding.
@@ -99,7 +252,7 @@ func doctorProjectDriftWith(absPath string, reg *registry.Registry) bool {
 	fmt.Println("\nProject")
 	doctorLine("Name drift", fmt.Sprintf("⚠ .treeline.yml=%q, registry=%q", yamlName, registryName))
 	fmt.Println("  Routing, databases, and resolve links use", fmt.Sprintf("%q.", registryName))
-	fmt.Printf("  To fix: revert project: in .treeline.yml to %q\n", registryName)
+	fmt.Printf("  To fix: run 'gtl setup' and choose option [3] to resolve.\n")
 	return true
 }
 

--- a/cmd/drift_test.go
+++ b/cmd/drift_test.go
@@ -1,11 +1,14 @@
 package cmd
 
 import (
+	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/git-treeline/cli/internal/database"
 	"github.com/git-treeline/cli/internal/registry"
 )
 
@@ -168,5 +171,211 @@ func TestDoctorProjectDriftWith_Drifted(t *testing.T) {
 
 	if !doctorProjectDriftWith(dir, reg) {
 		t.Error("expected drift reported")
+	}
+}
+
+// --- resolver tests ---
+
+type mockDB struct {
+	existing map[string]bool
+	dropErr  error
+	existErr error
+	renamed  []string
+	dropped  []string
+}
+
+func newMockDB(names ...string) *mockDB {
+	m := &mockDB{existing: map[string]bool{}}
+	for _, n := range names {
+		m.existing[n] = true
+	}
+	return m
+}
+
+func (m *mockDB) Clone(template, target string) error   { return nil }
+func (m *mockDB) Restore(target, dumpFile string) error { return nil }
+func (m *mockDB) Exists(name string) (bool, error)      { return m.existing[name], m.existErr }
+func (m *mockDB) Drop(target string) error {
+	if m.dropErr != nil {
+		return m.dropErr
+	}
+	m.dropped = append(m.dropped, target)
+	delete(m.existing, target)
+	return nil
+}
+func (m *mockDB) Rename(old, new string) error {
+	m.renamed = append(m.renamed, old+"->"+new)
+	if m.existing[old] {
+		delete(m.existing, old)
+		m.existing[new] = true
+	}
+	return nil
+}
+
+func TestResolveRegistryDrift_InvalidSubmenuInput_NoDropOrRelease(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: new_name\n"), 0o644)
+
+	reg := newTestRegistry(t)
+	_ = reg.Allocate(registry.Allocation{
+		"worktree":         dir,
+		"project":          "old_name",
+		"port":             float64(3002),
+		"database":         "old_name_development_feat",
+		"database_adapter": "postgresql",
+	})
+
+	mock := newMockDB("old_name_development_feat")
+	origAdapter := adapterFor
+	origInput := driftReader
+	defer func() { adapterFor = origAdapter; driftReader = origInput }()
+
+	adapterFor = func(name string, args []string) (database.Adapter, error) { return mock, nil }
+	driftReader = bufio.NewReader(strings.NewReader("xyz\n")) // invalid input for rename/drop submenu
+
+	err := resolveRegistryDrift(dir, "new_name", "old_name", reg)
+	if err == nil {
+		t.Fatal("expected error on invalid input")
+	}
+
+	// Registry entry must still be present.
+	if reg.Find(dir) == nil {
+		t.Error("registry entry was released despite invalid input")
+	}
+	if len(mock.dropped) > 0 {
+		t.Errorf("database was dropped despite invalid input: %v", mock.dropped)
+	}
+	if len(mock.renamed) > 0 {
+		t.Errorf("database was renamed despite invalid input: %v", mock.renamed)
+	}
+}
+
+func TestResolveRegistryDrift_AdapterError_RegistryPreserved(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: new_name\n"), 0o644)
+
+	reg := newTestRegistry(t)
+	_ = reg.Allocate(registry.Allocation{
+		"worktree":         dir,
+		"project":          "old_name",
+		"port":             float64(3002),
+		"database":         "old_name_development_feat",
+		"database_adapter": "bad_adapter",
+	})
+
+	origAdapter := adapterFor
+	defer func() { adapterFor = origAdapter }()
+	adapterFor = func(name string, args []string) (database.Adapter, error) {
+		return nil, fmt.Errorf("unsupported adapter %s", name)
+	}
+
+	err := resolveRegistryDrift(dir, "new_name", "old_name", reg)
+	if err == nil || !strings.Contains(err.Error(), "opening database adapter") {
+		t.Fatalf("expected adapter error, got: %v", err)
+	}
+	if reg.Find(dir) == nil {
+		t.Error("registry entry was released on adapter error")
+	}
+}
+
+func TestResolveRegistryDrift_ExistsError_RegistryPreserved(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: new_name\n"), 0o644)
+
+	reg := newTestRegistry(t)
+	_ = reg.Allocate(registry.Allocation{
+		"worktree":         dir,
+		"project":          "old_name",
+		"port":             float64(3002),
+		"database":         "old_name_development_feat",
+		"database_adapter": "postgresql",
+	})
+
+	mock := newMockDB()
+	mock.existErr = fmt.Errorf("connection refused")
+	origAdapter := adapterFor
+	defer func() { adapterFor = origAdapter }()
+	adapterFor = func(name string, args []string) (database.Adapter, error) { return mock, nil }
+
+	err := resolveRegistryDrift(dir, "new_name", "old_name", reg)
+	if err == nil || !strings.Contains(err.Error(), "checking database") {
+		t.Fatalf("expected 'checking database' error, got: %v", err)
+	}
+	if reg.Find(dir) == nil {
+		t.Error("registry entry was released on Exists error")
+	}
+}
+
+func TestResolveRegistryDrift_DropError_RegistryPreserved(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: new_name\n"), 0o644)
+
+	reg := newTestRegistry(t)
+	_ = reg.Allocate(registry.Allocation{
+		"worktree":         dir,
+		"project":          "old_name",
+		"port":             float64(3002),
+		"database":         "old_name_development_feat",
+		"database_adapter": "postgresql",
+	})
+
+	mock := newMockDB("old_name_development_feat")
+	mock.dropErr = fmt.Errorf("permission denied")
+	origAdapter := adapterFor
+	origInput := driftReader
+	defer func() { adapterFor = origAdapter; driftReader = origInput }()
+	adapterFor = func(name string, args []string) (database.Adapter, error) { return mock, nil }
+	// Choose: drop (2), then confirm proceed (y)
+	driftReader = bufio.NewReader(strings.NewReader("2\ny\n"))
+
+	err := resolveRegistryDrift(dir, "new_name", "old_name", reg)
+	if err == nil || !strings.Contains(err.Error(), "dropping database") {
+		t.Fatalf("expected 'dropping database' error, got: %v", err)
+	}
+	if reg.Find(dir) == nil {
+		t.Error("registry entry was released despite drop error")
+	}
+}
+
+func TestCheckDriftOrAbortWith_NoResolveOption_ForNonSetupCallers(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: new_name\n"), 0o644)
+
+	reg := newTestRegistry(t)
+	_ = reg.Allocate(registry.Allocation{"worktree": dir, "project": "old_name", "port": float64(3002)})
+
+	origInput := driftReader
+	defer func() { driftReader = origInput }()
+	// Enter "3" — should be treated as invalid (max=2 when resolveEnabled=false)
+	driftReader = bufio.NewReader(strings.NewReader("3\n"))
+
+	err := checkDriftOrAbortWith(dir, reg, false)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	// Registry must be untouched — "3" fell through to abort.
+	if reg.Find(dir) == nil {
+		t.Error("registry entry was modified when resolve is disabled")
+	}
+}
+
+func TestCheckDriftOrAbortWith_ResolveOption_OnlyForSetup(t *testing.T) {
+	dir := t.TempDir()
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: new_name\n"), 0o644)
+
+	reg := newTestRegistry(t)
+	_ = reg.Allocate(registry.Allocation{"worktree": dir, "project": "old_name", "port": float64(3002)})
+
+	origInput := driftReader
+	defer func() { driftReader = origInput }()
+	// "3" to select Resolve, no DB so just confirm "y"
+	driftReader = bufio.NewReader(strings.NewReader("3\ny\n"))
+
+	err := checkDriftOrAbortWith(dir, reg, true /* resolveEnabled */)
+	if err != nil {
+		t.Fatalf("expected nil after resolve, got: %v", err)
+	}
+	if reg.Find(dir) != nil {
+		t.Error("registry entry should have been released after resolve")
 	}
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -80,7 +80,7 @@ What it does:
 		}
 
 		// Step 3: setup (allocate ports, write env, copy files)
-		if err := checkDriftOrAbort(worktreeRoot); err != nil {
+		if err := checkDriftOrAbortForSetup(worktreeRoot); err != nil {
 			return cliErr(cmd, err)
 		}
 

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"bytes"
 	"io"
 	"os"
@@ -10,6 +11,7 @@ import (
 
 	"github.com/git-treeline/cli/internal/config"
 	"github.com/git-treeline/cli/internal/detect"
+	"github.com/git-treeline/cli/internal/registry"
 	setupPkg "github.com/git-treeline/cli/internal/setup"
 )
 
@@ -176,6 +178,48 @@ func TestInstallCmd_HappyPathInstallsHookAndAllocates(t *testing.T) {
 	}
 	if !uc.HasExplicitRouterDomain() {
 		t.Error("expected install-created config to persist router.domain explicitly")
+	}
+}
+
+func TestInstallCmd_DriftResolveReallocates(t *testing.T) {
+	dir := t.TempDir()
+	initGitRepo(t, dir)
+	t.Chdir(dir)
+	t.Setenv("GTL_HOME", filepath.Join(t.TempDir(), "gtl-home"))
+	t.Setenv("GTL_HEADLESS", "1")
+
+	oldRegistryPath := setupPkg.RegistryPath
+	setupPkg.RegistryPath = ""
+	t.Cleanup(func() { setupPkg.RegistryPath = oldRegistryPath })
+
+	yml := "project: new_name\nport_count: 1\nenv_file: .env.test\nenv:\n  PORT: \"{port}\"\n"
+	if err := os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(yml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	reg := registry.New("")
+	if err := reg.Allocate(registry.Allocation{
+		"worktree": dir,
+		"project":  "old_name",
+		"port":     float64(41000),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	origInput := driftReader
+	driftReader = bufio.NewReader(strings.NewReader("3\ny\n"))
+	t.Cleanup(func() { driftReader = origInput })
+
+	if err := installCmd.RunE(installCmd, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	alloc := reg.Find(dir)
+	if alloc == nil {
+		t.Fatal("expected install to reallocate after drift resolve")
+	}
+	if got := registry.GetString(alloc, "project"); got != "new_name" {
+		t.Errorf("expected reallocated project new_name, got %q", got)
 	}
 }
 

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -60,7 +60,7 @@ var setupCmd = &cobra.Command{
 		}
 
 		setupAbs, _ := filepath.Abs(path)
-		if err := checkDriftOrAbort(setupAbs); err != nil {
+		if err := checkDriftOrAbortForSetup(setupAbs); err != nil {
 			return cliErr(cmd, err)
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/git-treeline/cli
 
-go 1.26.3
+go 1.26.4
 
 require (
 	charm.land/bubbles/v2 v2.1.0

--- a/internal/database/adapter.go
+++ b/internal/database/adapter.go
@@ -11,11 +11,13 @@ import "fmt"
 //   - Clone creates a new database from a template
 //   - Drop removes a database
 //   - Exists checks if a database already exists
+//   - Rename renames an existing database in place
 //   - Restore loads a dump file into a database
 type Adapter interface {
 	Clone(template, target string) error
 	Drop(target string) error
 	Exists(name string) (bool, error)
+	Rename(oldName, newName string) error
 	Restore(target, dumpFile string) error
 }
 

--- a/internal/database/mock_test.go
+++ b/internal/database/mock_test.go
@@ -38,6 +38,18 @@ func (m *mockAdapter) Exists(name string) (bool, error) {
 	return m.existing[name], nil
 }
 
+func (m *mockAdapter) Rename(oldName, newName string) error {
+	m.calls = append(m.calls, fmt.Sprintf("rename:%s->%s", oldName, newName))
+	if m.failOn == "rename" {
+		return fmt.Errorf("rename failed")
+	}
+	if m.existing[oldName] {
+		delete(m.existing, oldName)
+		m.existing[newName] = true
+	}
+	return nil
+}
+
 func (m *mockAdapter) Restore(target, dumpFile string) error {
 	m.calls = append(m.calls, fmt.Sprintf("restore:%s<-%s", target, dumpFile))
 	if m.failOn == "restore" {

--- a/internal/database/postgresql.go
+++ b/internal/database/postgresql.go
@@ -121,6 +121,26 @@ func (pg *PostgreSQL) Drop(target string) error {
 	return pg.runSilent("dropdb", "--if-exists", target)
 }
 
+func (pg *PostgreSQL) Rename(oldName, newName string) error {
+	if !dbIdentifierRe.MatchString(oldName) {
+		return fmt.Errorf("invalid database identifier: %q", oldName)
+	}
+	if !dbIdentifierRe.MatchString(newName) {
+		return fmt.Errorf("invalid database identifier: %q", newName)
+	}
+	// Terminate active connections before renaming — ALTER DATABASE RENAME TO
+	// requires no other sessions connected to the target database.
+	// SAFETY: oldName is validated by dbIdentifierRe above.
+	terminateSQL := fmt.Sprintf(
+		"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '%s' AND pid <> pg_backend_pid();",
+		oldName,
+	)
+	_ = pg.runSilent("psql", "-d", "postgres", "-c", terminateSQL)
+	// SAFETY: both identifiers are validated by dbIdentifierRe above.
+	renameSQL := fmt.Sprintf("ALTER DATABASE %s RENAME TO %s", oldName, newName)
+	return pg.runSilent("psql", "-d", "postgres", "-c", renameSQL)
+}
+
 func (pg *PostgreSQL) Restore(target, dumpFile string) error {
 	if !dbIdentifierRe.MatchString(target) {
 		return fmt.Errorf("invalid database identifier: %q", target)

--- a/internal/database/sqlite.go
+++ b/internal/database/sqlite.go
@@ -64,6 +64,22 @@ func (s *SQLite) Drop(target string) error {
 	return nil
 }
 
+func (s *SQLite) Rename(oldPath, newPath string) error {
+	if err := os.MkdirAll(filepath.Dir(newPath), 0o755); err != nil {
+		return fmt.Errorf("creating target directory: %w", err)
+	}
+	if _, err := os.Stat(newPath); err == nil {
+		return fmt.Errorf("target database already exists: %s", newPath)
+	}
+	if err := os.Rename(oldPath, newPath); err != nil {
+		return err
+	}
+	// Best-effort rename of WAL mode companion files.
+	_ = os.Rename(oldPath+"-wal", newPath+"-wal")
+	_ = os.Rename(oldPath+"-shm", newPath+"-shm")
+	return nil
+}
+
 func (s *SQLite) Restore(target, dumpFile string) error {
 	if err := s.Drop(target); err != nil {
 		return err

--- a/internal/database/sqlite_test.go
+++ b/internal/database/sqlite_test.go
@@ -221,3 +221,72 @@ func TestSQLite_Restore_CommandFailure(t *testing.T) {
 		t.Errorf("expected 'restoring' in error, got: %v", err)
 	}
 }
+
+func TestSQLite_Rename_MovesFile(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "old.db")
+	newPath := filepath.Join(dir, "new.db")
+	walPath := oldPath + "-wal"
+	shmPath := oldPath + "-shm"
+
+	_ = os.WriteFile(oldPath, []byte("data"), 0o644)
+	_ = os.WriteFile(walPath, []byte("wal"), 0o644)
+	_ = os.WriteFile(shmPath, []byte("shm"), 0o644)
+
+	s := &SQLite{}
+	if err := s.Rename(oldPath, newPath); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(newPath); err != nil {
+		t.Errorf("expected new path to exist: %v", err)
+	}
+	if _, err := os.Stat(newPath + "-wal"); err != nil {
+		t.Errorf("expected new wal path to exist: %v", err)
+	}
+	if _, err := os.Stat(oldPath); err == nil {
+		t.Error("expected old path to be gone")
+	}
+}
+
+func TestSQLite_Rename_TargetExists_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "old.db")
+	newPath := filepath.Join(dir, "new.db")
+
+	_ = os.WriteFile(oldPath, []byte("old data"), 0o644)
+	_ = os.WriteFile(newPath, []byte("existing data"), 0o644)
+
+	s := &SQLite{}
+	err := s.Rename(oldPath, newPath)
+	if err == nil {
+		t.Fatal("expected error when target exists")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Errorf("expected 'already exists' in error, got: %v", err)
+	}
+
+	// Original file must be untouched.
+	data, _ := os.ReadFile(newPath)
+	if string(data) != "existing data" {
+		t.Error("existing target was clobbered")
+	}
+}
+
+func TestSQLite_Rename_MissingSource_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	oldPath := filepath.Join(dir, "missing.db")
+	newPath := filepath.Join(dir, "new.db")
+
+	s := &SQLite{}
+	err := s.Rename(oldPath, newPath)
+	if err == nil {
+		t.Fatal("expected error when source is missing")
+	}
+	if !os.IsNotExist(err) {
+		t.Errorf("expected not-exist error, got: %v", err)
+	}
+	if _, statErr := os.Stat(newPath); !os.IsNotExist(statErr) {
+		t.Errorf("target should not be created, stat err=%v", statErr)
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -6,6 +6,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -17,6 +18,16 @@ import (
 
 	"github.com/git-treeline/cli/internal/platform"
 )
+
+// launchctlExitCode extracts the numeric exit code from a launchctl error,
+// returning -1 if the error is nil or not an exec.ExitError.
+func launchctlExitCode(err error) int {
+	var ee *exec.ExitError
+	if errors.As(err, &ee) {
+		return ee.ExitCode()
+	}
+	return -1
+}
 
 // runCmd executes a command and returns its error. Overridable for tests so
 // service-management code can be exercised without touching launchctl/systemctl.
@@ -294,8 +305,11 @@ func bounceLaunchAgent(wait time.Duration) error {
 	return waitForFreshVersion(before, wait)
 }
 
+// plistPathFn returns the plist path. Overridable in tests.
+var plistPathFn = PlistPath
+
 func reloadLaunchAgent(wait time.Duration) error {
-	plist := PlistPath()
+	plist := plistPathFn()
 	if _, err := os.Stat(plist); err != nil {
 		return fmt.Errorf("plist not found at %s — run 'gtl serve install' first", plist)
 	}
@@ -305,8 +319,24 @@ func reloadLaunchAgent(wait time.Duration) error {
 	// because it returns non-zero when the service isn't currently
 	// loaded — that's fine, we're about to bootstrap.
 	_ = runCmd("launchctl", "bootout", target)
-	if err := runCmd("launchctl", "bootstrap", launchDomain(), plist); err != nil {
-		return fmt.Errorf("launchctl bootstrap %s: %w", plist, err)
+
+	// On some macOS versions launchd needs a moment to settle after bootout
+	// before it will accept a bootstrap for the same label. Retry a few times
+	// on exit 5 ("already loaded / I/O error"), re-running bootout each time.
+	const maxRetries = 3
+	var bootstrapErr error
+	for i := 0; i < maxRetries; i++ {
+		if i > 0 {
+			sleepFn(500 * time.Millisecond)
+			_ = runCmd("launchctl", "bootout", target)
+		}
+		bootstrapErr = runCmd("launchctl", "bootstrap", launchDomain(), plist)
+		if bootstrapErr == nil || launchctlExitCode(bootstrapErr) != 5 {
+			break
+		}
+	}
+	if bootstrapErr != nil {
+		return fmt.Errorf("launchctl bootstrap %s: %w", plist, bootstrapErr)
 	}
 	return waitForFreshVersion(before, wait)
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,10 +1,13 @@
 package service
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestGeneratePlist(t *testing.T) {
@@ -97,5 +100,115 @@ func TestGenerateUnit(t *testing.T) {
 		if !strings.Contains(content, check) {
 			t.Errorf("unit missing %q", check)
 		}
+	}
+}
+
+// fakeExitErr runs "sh -c exit N" and returns the *exec.ExitError, which is
+// what launchctlExitCode inspects.
+func fakeExitErr(t *testing.T, code int) error {
+	t.Helper()
+	err := exec.Command("sh", "-c", fmt.Sprintf("exit %d", code)).Run()
+	if err == nil {
+		t.Fatalf("expected non-zero exit for code %d", code)
+	}
+	return err
+}
+
+// setupReloadTest creates a temp plist file, redirects plistPathFn and
+// sleepFn, and writes GTL_HOME so RouterVersionFile() lands in a temp dir.
+// Returns a cleanup func that restores all overrides.
+func setupReloadTest(t *testing.T) (versionFile string, cleanup func()) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("GTL_HOME", tmp)
+
+	plist := filepath.Join(tmp, "router.plist")
+	if err := os.WriteFile(plist, []byte("<plist/>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	origPlistFn := plistPathFn
+	origRunCmd := runCmd
+	origSleep := sleepFn
+
+	plistPathFn = func() string { return plist }
+	sleepFn = func(time.Duration) {}
+
+	versionFile = RouterVersionFile()
+
+	return versionFile, func() {
+		plistPathFn = origPlistFn
+		runCmd = origRunCmd
+		sleepFn = origSleep
+	}
+}
+
+func TestReloadLaunchAgent_BootstrapRetry_SucceedsAfterExit5(t *testing.T) {
+	versionFile, cleanup := setupReloadTest(t)
+	defer cleanup()
+
+	bootstrapCalls := 0
+	runCmd = func(name string, args ...string) error {
+		if name == "launchctl" && len(args) > 0 && args[0] == "bootstrap" {
+			bootstrapCalls++
+			if bootstrapCalls < 3 {
+				return fakeExitErr(t, 5)
+			}
+			// Simulate the router writing its version file on successful start.
+			_ = os.WriteFile(versionFile, []byte("v1"), 0o644)
+			return nil
+		}
+		return nil
+	}
+
+	if err := reloadLaunchAgent(2 * time.Second); err != nil {
+		t.Fatalf("expected success after retries, got: %v", err)
+	}
+	if bootstrapCalls != 3 {
+		t.Errorf("expected 3 bootstrap calls, got %d", bootstrapCalls)
+	}
+}
+
+func TestReloadLaunchAgent_BootstrapRetry_StopsAtMaxRetries(t *testing.T) {
+	_, cleanup := setupReloadTest(t)
+	defer cleanup()
+
+	bootstrapCalls := 0
+	runCmd = func(name string, args ...string) error {
+		if name == "launchctl" && len(args) > 0 && args[0] == "bootstrap" {
+			bootstrapCalls++
+			return fakeExitErr(t, 5)
+		}
+		return nil
+	}
+
+	err := reloadLaunchAgent(100 * time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error after exhausting retries")
+	}
+	if bootstrapCalls != 3 {
+		t.Errorf("expected exactly 3 bootstrap attempts (maxRetries), got %d", bootstrapCalls)
+	}
+}
+
+func TestReloadLaunchAgent_BootstrapRetry_NoRetryOnNonFiveError(t *testing.T) {
+	_, cleanup := setupReloadTest(t)
+	defer cleanup()
+
+	bootstrapCalls := 0
+	runCmd = func(name string, args ...string) error {
+		if name == "launchctl" && len(args) > 0 && args[0] == "bootstrap" {
+			bootstrapCalls++
+			return fakeExitErr(t, 1) // non-5 failure
+		}
+		return nil
+	}
+
+	err := reloadLaunchAgent(100 * time.Millisecond)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if bootstrapCalls != 1 {
+		t.Errorf("expected exactly 1 bootstrap attempt for non-5 error, got %d", bootstrapCalls)
 	}
 }


### PR DESCRIPTION
## Summary
- add setup/install project-drift resolution that can reset the registry and safely rename/drop/leave databases
- add database adapter Rename support for PostgreSQL and SQLite with SQLite collision/missing-source safety
- retry macOS launchctl bootstrap exit code 5 during router reload
- bump Go toolchain to 1.26.4 for govulncheck stdlib fixes

## Verification
- make ci
