### PR TITLE
feat: add gtl db template update and sync_on_create

### DIFF
--- a/cmd/db_template.go
+++ b/cmd/db_template.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+
+	"github.com/git-treeline/cli/internal/config"
+	"github.com/git-treeline/cli/internal/worktree"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	dbTemplateCmd.AddCommand(dbTemplateUpdateCmd)
+	dbCmd.AddCommand(dbTemplateCmd)
+}
+
+var dbTemplateCmd = &cobra.Command{
+	Use:   "template",
+	Short: "Manage the root template database",
+}
+
+var dbTemplateUpdateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Pull the merge target branch and run migrations in the root repo",
+	Long: `Advances the root template database to match the current state of the
+merge target branch. Pulls latest in the root repo, then runs the
+commands.migrate command configured in .treeline.yml.
+
+The root repo must have a clean working tree. Existing worktree databases
+are not affected — run 'gtl db reset' in a worktree to re-clone from the
+updated template.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("getting working directory: %w", err)
+		}
+
+		mainRepo := worktree.DetectMainRepo(cwd)
+		pc := config.LoadProjectConfig(mainRepo)
+
+		migrateCmd := pc.MigrateCommand()
+		if migrateCmd == "" {
+			return cliErr(cmd, &CliError{
+				Message: "No migrate command configured.",
+				Hint:    "Set 'commands.migrate' in .treeline.yml (e.g. bin/rails db:migrate).",
+			})
+		}
+
+		mergeTarget := pc.MergeTarget()
+		if mergeTarget == "" {
+			mergeTarget = "main"
+		}
+
+		if err := checkCleanWorktree(mainRepo); err != nil {
+			return cliErr(cmd, &CliError{
+				Message: fmt.Sprintf("Root repo has uncommitted changes: %s", err),
+				Hint:    "Commit or stash changes in the root repo before updating the template database.",
+			})
+		}
+
+		fmt.Printf("==> Pulling %s in %s\n", mergeTarget, mainRepo)
+		pull := exec.Command("git", "pull", "origin", mergeTarget)
+		pull.Dir = mainRepo
+		pull.Stdout = os.Stdout
+		pull.Stderr = os.Stderr
+		if err := pull.Run(); err != nil {
+			return fmt.Errorf("git pull: %w", err)
+		}
+
+		fmt.Printf("==> Running: %s\n", migrateCmd)
+		migrate := exec.Command("sh", "-c", migrateCmd)
+		migrate.Dir = mainRepo
+		migrate.Stdout = os.Stdout
+		migrate.Stderr = os.Stderr
+		if err := migrate.Run(); err != nil {
+			return fmt.Errorf("migrate command failed: %w", err)
+		}
+
+		fmt.Println("==> Template database updated. Run 'gtl db reset' in any worktree to re-clone.")
+		return nil
+	},
+}
+
+// checkCleanWorktree returns an error if the git working tree at dir has
+// uncommitted changes (staged or unstaged). Untracked files are ignored.
+func checkCleanWorktree(dir string) error {
+	cmd := exec.Command("git", "status", "--porcelain", "--untracked-files=no")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("checking working tree: %w", err)
+	}
+	if len(out) > 0 {
+		return fmt.Errorf("working tree is not clean")
+	}
+	return nil
+}

--- a/cmd/db_template_test.go
+++ b/cmd/db_template_test.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func gitInit(t *testing.T, dir string) {
+	t.Helper()
+	cmds := [][]string{
+		{"git", "init", dir},
+		{"git", "-C", dir, "config", "user.email", "test@example.com"},
+		{"git", "-C", dir, "config", "user.name", "Test"},
+		{"git", "-C", dir, "commit", "--allow-empty", "-m", "init"},
+	}
+	for _, args := range cmds {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %s", args, out)
+		}
+	}
+}
+
+func TestCheckCleanWorktree_Clean(t *testing.T) {
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	if err := checkCleanWorktree(dir); err != nil {
+		t.Errorf("expected clean worktree, got error: %v", err)
+	}
+}
+
+func TestCheckCleanWorktree_StagedChanges(t *testing.T) {
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	f := filepath.Join(dir, "file.txt")
+	_ = os.WriteFile(f, []byte("hello"), 0o644)
+	_ = exec.Command("git", "-C", dir, "add", "file.txt").Run()
+
+	if err := checkCleanWorktree(dir); err == nil {
+		t.Error("expected error for staged changes, got nil")
+	}
+}
+
+func TestCheckCleanWorktree_UnstagedChanges(t *testing.T) {
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	// Commit a file first, then modify it without staging
+	f := filepath.Join(dir, "file.txt")
+	_ = os.WriteFile(f, []byte("original"), 0o644)
+	_ = exec.Command("git", "-C", dir, "add", "file.txt").Run()
+	_ = exec.Command("git", "-C", dir, "commit", "-m", "add file").Run()
+	_ = os.WriteFile(f, []byte("modified"), 0o644)
+
+	if err := checkCleanWorktree(dir); err == nil {
+		t.Error("expected error for unstaged changes, got nil")
+	}
+}
+
+func TestCheckCleanWorktree_UntrackedFilesIgnored(t *testing.T) {
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	_ = os.WriteFile(filepath.Join(dir, "untracked.txt"), []byte("new"), 0o644)
+
+	if err := checkCleanWorktree(dir); err != nil {
+		t.Errorf("expected untracked files to be ignored, got error: %v", err)
+	}
+}

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -481,6 +481,18 @@ func (pc *ProjectConfig) StartCommand() string {
 	return ""
 }
 
+func (pc *ProjectConfig) MigrateCommand() string {
+	if v, ok := Dig(pc.Data, "commands", "migrate").(string); ok {
+		return v
+	}
+	return ""
+}
+
+func (pc *ProjectConfig) DatabaseSyncOnCreate() bool {
+	v, ok := Dig(pc.Data, "database", "sync_on_create").(bool)
+	return ok && v
+}
+
 // MergeTarget returns the branch that prune --merged checks against.
 func (pc *ProjectConfig) MergeTarget() string {
 	if v, ok := pc.Data["merge_target"].(string); ok {

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -1040,3 +1040,54 @@ func TestDatabaseSources_Absent(t *testing.T) {
 		t.Error("expected empty sslmode when unset")
 	}
 }
+
+func TestMigrateCommand(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("returns empty when not set", func(t *testing.T) {
+		_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: myapp\n"), 0o644)
+		pc := LoadProjectConfig(dir)
+		if pc.MigrateCommand() != "" {
+			t.Errorf("expected empty, got %q", pc.MigrateCommand())
+		}
+	})
+
+	t.Run("returns configured command", func(t *testing.T) {
+		yml := "project: myapp\ncommands:\n  migrate: bin/rails db:migrate\n"
+		_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(yml), 0o644)
+		pc := LoadProjectConfig(dir)
+		if pc.MigrateCommand() != "bin/rails db:migrate" {
+			t.Errorf("expected bin/rails db:migrate, got %q", pc.MigrateCommand())
+		}
+	})
+}
+
+func TestDatabaseSyncOnCreate(t *testing.T) {
+	dir := t.TempDir()
+
+	t.Run("false when not set", func(t *testing.T) {
+		_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte("project: myapp\n"), 0o644)
+		pc := LoadProjectConfig(dir)
+		if pc.DatabaseSyncOnCreate() {
+			t.Error("expected false when sync_on_create not set")
+		}
+	})
+
+	t.Run("true when set", func(t *testing.T) {
+		yml := "project: myapp\ndatabase:\n  sync_on_create: true\n"
+		_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(yml), 0o644)
+		pc := LoadProjectConfig(dir)
+		if !pc.DatabaseSyncOnCreate() {
+			t.Error("expected true when sync_on_create: true")
+		}
+	})
+
+	t.Run("false when explicitly false", func(t *testing.T) {
+		yml := "project: myapp\ndatabase:\n  sync_on_create: false\n"
+		_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(yml), 0o644)
+		pc := LoadProjectConfig(dir)
+		if pc.DatabaseSyncOnCreate() {
+			t.Error("expected false when sync_on_create: false")
+		}
+	})
+}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -178,6 +178,11 @@ func (s *Setup) runPostAllocation(alloc *allocator.Allocation, redisURL string) 
 	}
 
 	if alloc.Database != "" && !alloc.Reused {
+		if s.ProjectConfig.DatabaseSyncOnCreate() {
+			if err := s.syncTemplateDatabase(); err != nil {
+				return err
+			}
+		}
 		if err := s.cloneDatabase(alloc); err != nil {
 			return err
 		}
@@ -402,6 +407,39 @@ func updateOrAppend(file, key, value string) error {
 	}
 
 	return os.WriteFile(file, []byte(content), 0o644)
+}
+
+func (s *Setup) syncTemplateDatabase() error {
+	migrateCmd := s.ProjectConfig.MigrateCommand()
+	if migrateCmd == "" {
+		s.warn("database.sync_on_create is set but commands.migrate is not configured in .treeline.yml — skipping template sync")
+		return nil
+	}
+
+	mergeTarget := s.ProjectConfig.MergeTarget()
+	if mergeTarget == "" {
+		mergeTarget = "main"
+	}
+
+	s.log("Syncing template database (pulling %s + migrating)", mergeTarget)
+
+	pull := exec.Command("git", "pull", "origin", mergeTarget)
+	pull.Dir = s.MainRepo
+	pull.Stdout = s.Log
+	pull.Stderr = s.Log
+	if err := pull.Run(); err != nil {
+		return fmt.Errorf("git pull in root repo: %w", err)
+	}
+
+	migrate := exec.Command("sh", "-c", migrateCmd)
+	migrate.Dir = s.MainRepo
+	migrate.Stdout = s.Log
+	migrate.Stderr = s.Log
+	if err := migrate.Run(); err != nil {
+		return fmt.Errorf("migrate command failed: %w", err)
+	}
+
+	return nil
 }
 
 func (s *Setup) cloneDatabase(alloc *allocator.Allocation) error {

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -993,3 +993,156 @@ func TestRunHookCommands_RunsInSpecifiedDirectory(t *testing.T) {
 		t.Error("expected proof file to exist, command did not run in specified directory")
 	}
 }
+
+// --- syncTemplateDatabase tests ---
+
+// gitInitRepo initialises a git repo at dir with an initial empty commit.
+func gitInitRepo(t *testing.T, dir string) {
+	t.Helper()
+	cmds := [][]string{
+		{"git", "init", dir},
+		{"git", "-C", dir, "config", "user.email", "test@example.com"},
+		{"git", "-C", dir, "config", "user.name", "Test"},
+		{"git", "-C", dir, "commit", "--allow-empty", "-m", "init"},
+	}
+	for _, args := range cmds {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Fatalf("%v: %s", args, out)
+		}
+	}
+}
+
+func TestSyncTemplateDatabase_SkipsWhenNoMigrateCommand(t *testing.T) {
+	s, _, _ := testSetup(t, `
+project: test
+env_file:
+  target: .env
+  source: .env
+database:
+  sync_on_create: true
+`)
+	err := s.syncTemplateDatabase()
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	log := plainOutput(s)
+	if !strings.Contains(log, "commands.migrate is not configured") {
+		t.Errorf("expected warning about missing migrate command, got: %q", log)
+	}
+}
+
+func TestSyncTemplateDatabase_RunsMigrateInMainRepo(t *testing.T) {
+	dir := t.TempDir()
+	mainRepo := filepath.Join(dir, "main")
+	worktreeDir := filepath.Join(dir, "worktree")
+	_ = os.MkdirAll(mainRepo, 0o755)
+	_ = os.MkdirAll(worktreeDir, 0o755)
+
+	gitInitRepo(t, mainRepo)
+
+	// Local bare repo acts as origin
+	bareRepo := filepath.Join(dir, "bare.git")
+	if out, err := exec.Command("git", "clone", "--bare", mainRepo, bareRepo).CombinedOutput(); err != nil {
+		t.Fatalf("git clone --bare: %s", out)
+	}
+	if out, err := exec.Command("git", "-C", mainRepo, "remote", "add", "origin", bareRepo).CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %s", out)
+	}
+
+	yml := "project: test\nmerge_target: main\ncommands:\n  migrate: touch migrate_ran\n"
+	_ = os.WriteFile(filepath.Join(mainRepo, ".treeline.yml"), []byte(yml), 0o644)
+
+	pc := config.LoadProjectConfig(mainRepo)
+	s := &Setup{
+		WorktreePath:  worktreeDir,
+		MainRepo:      mainRepo,
+		ProjectConfig: pc,
+		Log:           &bytes.Buffer{},
+	}
+
+	if err := s.syncTemplateDatabase(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(mainRepo, "migrate_ran")); err != nil {
+		t.Error("expected migrate command to have run in main repo")
+	}
+}
+
+func TestRun_SyncOnCreate_SQLite(t *testing.T) {
+	dir := t.TempDir()
+	mainRepo := filepath.Join(dir, "main")
+	worktreeDir := filepath.Join(dir, "worktree")
+	_ = os.MkdirAll(mainRepo, 0o755)
+	_ = os.MkdirAll(worktreeDir, 0o755)
+
+	gitInitRepo(t, mainRepo)
+	bareRepo := filepath.Join(dir, "bare.git")
+	if out, err := exec.Command("git", "clone", "--bare", mainRepo, bareRepo).CombinedOutput(); err != nil {
+		t.Fatalf("git clone --bare: %s", out)
+	}
+	if out, err := exec.Command("git", "-C", mainRepo, "remote", "add", "origin", bareRepo).CombinedOutput(); err != nil {
+		t.Fatalf("git remote add: %s", out)
+	}
+
+	yml := `project: test
+merge_target: main
+env_file:
+  target: .env
+  source: .env
+database:
+  adapter: sqlite
+  template: db/development.sqlite3
+  pattern: "db/{worktree}.sqlite3"
+  sync_on_create: true
+commands:
+  migrate: touch migrate_ran
+env:
+  PORT: "{port}"
+`
+	_ = os.WriteFile(filepath.Join(mainRepo, ".treeline.yml"), []byte(yml), 0o644)
+	_ = os.WriteFile(filepath.Join(mainRepo, ".env"), []byte(""), 0o644)
+	_ = os.MkdirAll(filepath.Join(mainRepo, "db"), 0o755)
+	_ = os.WriteFile(filepath.Join(mainRepo, "db", "development.sqlite3"), []byte("sqlite-data"), 0o644)
+
+	regPath := filepath.Join(dir, "registry.json")
+	confPath := filepath.Join(dir, "config.json")
+	_ = os.WriteFile(confPath, []byte(`{"port":{"base":3000,"increment":10},"redis":{"strategy":"prefixed","url":"redis://localhost:6379"}}`), 0o644)
+
+	uc := config.LoadUserConfig(confPath)
+	pc := config.LoadProjectConfig(mainRepo)
+	reg := registry.New(regPath)
+	al := allocator.New(uc, pc, reg)
+
+	s := &Setup{
+		WorktreePath:  worktreeDir,
+		MainRepo:      mainRepo,
+		UserConfig:    uc,
+		ProjectConfig: pc,
+		Registry:      reg,
+		Allocator:     al,
+		Log:           &bytes.Buffer{},
+	}
+
+	alloc, err := s.Run()
+	if err != nil {
+		t.Fatalf("Run() failed: %v", err)
+	}
+	if alloc.Database == "" {
+		t.Fatal("expected database name to be set")
+	}
+
+	// migrate command ran in main repo
+	if _, err := os.Stat(filepath.Join(mainRepo, "migrate_ran")); err != nil {
+		t.Error("expected migrate command to have run")
+	}
+
+	// SQLite DB was cloned into worktree
+	clonedPath := filepath.Join(worktreeDir, alloc.Database)
+	data, err := os.ReadFile(clonedPath)
+	if err != nil {
+		t.Fatalf("expected cloned SQLite file at %s: %v", clonedPath, err)
+	}
+	if string(data) != "sqlite-data" {
+		t.Errorf("expected cloned content, got %q", string(data))
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `commands.migrate` config key to `.treeline.yml` for specifying the project's migration command (e.g. `bin/rails db:migrate`, `mix ecto.migrate`)
- Adds `database.sync_on_create: true` flag that pulls the merge target branch and runs the migrate command in the root repo before cloning a new worktree database — so every new worktree starts with a current schema
- Adds `gtl db template update` command to advance the root template database at any time: checks for a clean working tree, pulls merge target, runs the migrate command
- `sync_on_create` only fires when a fresh database clone is happening (`!alloc.Reused`), leaving refresh/reallocate/rename flows unaffected

## Config shape

```yaml
commands:
  migrate: bin/rails db:migrate

database:
  sync_on_create: true   # optional — auto-syncs template on every new worktree
```

## Test plan

- [x] `TestMigrateCommand` — accessor returns empty when unset, returns configured value
- [x] `TestDatabaseSyncOnCreate` — false by default, true/false when explicitly set
- [x] `TestSyncTemplateDatabase_SkipsWhenNoMigrateCommand` — warns without failing
- [x] `TestSyncTemplateDatabase_RunsMigrateInMainRepo` — runs command in root repo with real local git origin
- [x] `TestRun_SyncOnCreate_SQLite` — full `Run()` flow confirming migrate fires before clone, SQLite file correctly cloned
- [x] `TestCheckCleanWorktree_*` — clean, staged, unstaged, untracked cases
- [x] Full test suite passes