### PR TITLE
fix: rename is focused; setup handles stale allocations on project rename

### DIFF
--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -6,9 +6,7 @@ import (
 
 	"github.com/git-treeline/cli/internal/config"
 	"github.com/git-treeline/cli/internal/confirm"
-	"github.com/git-treeline/cli/internal/database"
 	"github.com/git-treeline/cli/internal/registry"
-	"github.com/git-treeline/cli/internal/setup"
 	"github.com/git-treeline/cli/internal/style"
 	"github.com/git-treeline/cli/internal/worktree"
 	"github.com/spf13/cobra"
@@ -101,80 +99,17 @@ and router keys.`,
 			fmt.Println(style.Actionf("Migrated %d user-config key(s)", migrated))
 		}
 
-		dropDatabases(pc.DatabaseAdapter(), entries)
-
-		var paths []string
-		for _, e := range entries {
-			wt := registry.GetString(e, "worktree")
-			if wt == "" {
-				continue
-			}
-			if _, err := reg.Release(wt); err != nil {
-				fmt.Fprintf(os.Stderr, "  warning: failed to release %s: %v\n", wt, err)
-			}
-			if info, statErr := os.Stat(wt); statErr == nil && info.IsDir() {
-				paths = append(paths, wt)
-			}
-		}
-
-		successes := 0
-		var failures []string
-		if len(paths) > 0 {
+		if len(entries) > 0 {
 			fmt.Println()
-			fmt.Println("Reallocating worktrees under new project name...")
-		}
-		for _, p := range paths {
-			fmt.Printf("\n→ %s\n", p)
-			s := setup.New(p, "", uc)
-			if _, err := s.Run(); err != nil {
-				fmt.Fprintf(os.Stderr, "  ✗ %v\n", err)
-				failures = append(failures, p)
-				continue
+			fmt.Println("Commit this change and rebase each worktree, then run `gtl setup` to re-provision:")
+			for _, e := range entries {
+				wt := registry.GetString(e, "worktree")
+				if wt != "" {
+					fmt.Printf("  %s\n", wt)
+				}
 			}
-			successes++
 		}
 
-		fmt.Println()
-		fmt.Printf("Rename complete: %d worktree(s) reallocated", successes)
-		if len(failures) > 0 {
-			fmt.Printf(", %d failed", len(failures))
-		}
-		fmt.Println(".")
-		if len(failures) > 0 {
-			return fmt.Errorf("%d reallocation(s) failed", len(failures))
-		}
 		return nil
 	},
-}
-
-// dropDatabases drops every database name listed in the registry entries,
-// using the configured adapter. Errors are reported but don't abort the
-// rename — the worktree re-allocation step will surface any real problem.
-func dropDatabases(adapterName string, entries []registry.Allocation) {
-	if len(entries) == 0 {
-		return
-	}
-	adapter, err := database.ForAdapter(adapterName, nil)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "  warning: %v\n", err)
-		return
-	}
-	for _, e := range entries {
-		dbName := registry.GetString(e, "database")
-		if dbName == "" {
-			continue
-		}
-		exists, err := adapter.Exists(dbName)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "  warning: checking %s: %v\n", dbName, err)
-			continue
-		}
-		if !exists {
-			continue
-		}
-		fmt.Printf("==> Dropping %s\n", dbName)
-		if err := adapter.Drop(dbName); err != nil {
-			fmt.Fprintf(os.Stderr, "  warning: dropping %s: %v\n", dbName, err)
-		}
-	}
 }

--- a/cmd/rename_test.go
+++ b/cmd/rename_test.go
@@ -1,0 +1,156 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/git-treeline/cli/internal/config"
+	"github.com/git-treeline/cli/internal/registry"
+)
+
+func makeRenameEnv(t *testing.T) (mainRepo string, reg *registry.Registry) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("GTL_HOME", filepath.Join(dir, "gtl-home"))
+	mainRepo = filepath.Join(dir, "repo")
+	if err := os.MkdirAll(mainRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Use registry.New("") so it resolves via GTL_HOME — same path the command uses.
+	reg = registry.New("")
+	return mainRepo, reg
+}
+
+func writeRenameConfig(t *testing.T, dir, projectName string) {
+	t.Helper()
+	content := "project: " + projectName + "\n"
+	if err := os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRenameCmd_InvalidName(t *testing.T) {
+	mainRepo, _ := makeRenameEnv(t)
+	writeRenameConfig(t, mainRepo, "myapp")
+	t.Chdir(mainRepo)
+	renameYes = true
+	t.Cleanup(func() { renameYes = false })
+
+	err := renameCmd.RunE(renameCmd, []string{"my-app"})
+	if err == nil {
+		t.Fatal("expected error for invalid project name with dashes")
+	}
+	if !strings.Contains(err.Error(), "invalid project name") {
+		t.Errorf("expected 'invalid project name' error, got: %v", err)
+	}
+}
+
+func TestRenameCmd_SameNameIsNoop(t *testing.T) {
+	mainRepo, _ := makeRenameEnv(t)
+	writeRenameConfig(t, mainRepo, "myapp")
+	t.Chdir(mainRepo)
+	renameYes = true
+	t.Cleanup(func() { renameYes = false })
+
+	out := captureStdout(t, func() {
+		if err := renameCmd.RunE(renameCmd, []string{"myapp"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if !strings.Contains(out, "already named") {
+		t.Errorf("expected 'already named' message, got: %q", out)
+	}
+
+	// .treeline.yml should be unchanged
+	data, _ := os.ReadFile(filepath.Join(mainRepo, ".treeline.yml"))
+	if !strings.Contains(string(data), "project: myapp") {
+		t.Errorf("expected project name unchanged, got: %s", data)
+	}
+}
+
+func TestRenameCmd_MissingConfig(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("GTL_HOME", filepath.Join(dir, "gtl-home"))
+	t.Chdir(dir)
+	renameYes = true
+	t.Cleanup(func() { renameYes = false })
+
+	err := renameCmd.RunE(renameCmd, []string{"newname"})
+	if err == nil {
+		t.Fatal("expected error when .treeline.yml is missing")
+	}
+}
+
+func TestRenameCmd_UpdatesProjectConfig(t *testing.T) {
+	mainRepo, _ := makeRenameEnv(t)
+	writeRenameConfig(t, mainRepo, "old_name")
+	t.Chdir(mainRepo)
+	renameYes = true
+	t.Cleanup(func() { renameYes = false })
+
+	if err := renameCmd.RunE(renameCmd, []string{"new_name"}); err != nil {
+		t.Fatal(err)
+	}
+
+	pc := config.LoadProjectConfig(mainRepo)
+	if pc.Project() != "new_name" {
+		t.Errorf("expected project name 'new_name', got %q", pc.Project())
+	}
+}
+
+func TestRenameCmd_ListsAffectedWorktrees(t *testing.T) {
+	mainRepo, reg := makeRenameEnv(t)
+	writeRenameConfig(t, mainRepo, "old_name")
+	t.Chdir(mainRepo)
+	renameYes = true
+	t.Cleanup(func() { renameYes = false })
+
+	// Register a fake worktree under the old project name
+	_ = reg.Allocate(registry.Allocation{
+		"project":  "old_name",
+		"worktree": "/fake/worktree/path",
+		"port":     3010,
+	})
+
+	out := captureStdout(t, func() {
+		if err := renameCmd.RunE(renameCmd, []string{"new_name"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if !strings.Contains(out, "/fake/worktree/path") {
+		t.Errorf("expected affected worktree path in output, got: %q", out)
+	}
+	if !strings.Contains(out, "gtl setup") {
+		t.Errorf("expected 'gtl setup' instructions in output, got: %q", out)
+	}
+}
+
+func TestRenameCmd_DoesNotTouchRegistry(t *testing.T) {
+	mainRepo, reg := makeRenameEnv(t)
+	writeRenameConfig(t, mainRepo, "old_name")
+	t.Chdir(mainRepo)
+	renameYes = true
+	t.Cleanup(func() { renameYes = false })
+
+	_ = reg.Allocate(registry.Allocation{
+		"project":  "old_name",
+		"worktree": "/fake/worktree/path",
+		"port":     3010,
+		"database": "old_name_development_feat",
+	})
+
+	if err := renameCmd.RunE(renameCmd, []string{"new_name"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Registry entry should still be there — rename doesn't touch it.
+	// Each worktree cleans up its own stale entry on next gtl setup.
+	entries := reg.FindByProject("old_name")
+	if len(entries) != 1 {
+		t.Errorf("expected registry entry to remain untouched, got %d entries", len(entries))
+	}
+}

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -87,6 +87,9 @@ func (s *Setup) Run() (*allocator.Allocation, error) {
 	if err := s.ProjectConfig.Validate(); err != nil {
 		return nil, err
 	}
+	if err := s.handleProjectRename(); err != nil {
+		return nil, err
+	}
 	if pruned, err := s.Registry.Prune(); err == nil && pruned > 0 {
 		s.log("Reclaimed %d stale allocation(s)", pruned)
 	}
@@ -439,6 +442,39 @@ func (s *Setup) syncTemplateDatabase() error {
 		return fmt.Errorf("migrate command failed: %w", err)
 	}
 
+	return nil
+}
+
+func (s *Setup) handleProjectRename() error {
+	entry := s.Registry.Find(s.WorktreePath)
+	if entry == nil {
+		return nil
+	}
+	entryProject := registry.GetString(entry, "project")
+	if entryProject == s.ProjectConfig.Project() {
+		return nil
+	}
+	oldDB := registry.GetString(entry, "database")
+	if oldDB != "" {
+		s.log("Project renamed %s → %s, dropping database %s", entryProject, s.ProjectConfig.Project(), oldDB)
+		adapterName := registry.GetString(entry, "database_adapter")
+		if adapter, err := database.ForAdapter(adapterName, nil); err == nil {
+			dbPath := oldDB
+			if adapterName == "sqlite" {
+				dbPath = filepath.Join(s.WorktreePath, oldDB)
+			}
+			if exists, err := adapter.Exists(dbPath); err == nil && exists {
+				if err := adapter.Drop(dbPath); err != nil {
+					s.warn("failed to drop %s: %v", oldDB, err)
+				}
+			}
+		}
+	} else {
+		s.log("Project renamed %s → %s, re-provisioning", entryProject, s.ProjectConfig.Project())
+	}
+	if _, err := s.Registry.Release(s.WorktreePath); err != nil {
+		return fmt.Errorf("releasing stale registry entry: %w", err)
+	}
 	return nil
 }
 

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1040,7 +1040,6 @@ func TestSyncTemplateDatabase_RunsMigrateInMainRepo(t *testing.T) {
 
 	gitInitRepo(t, mainRepo)
 
-	// Local bare repo acts as origin
 	bareRepo := filepath.Join(dir, "bare.git")
 	if out, err := exec.Command("git", "clone", "--bare", mainRepo, bareRepo).CombinedOutput(); err != nil {
 		t.Fatalf("git clone --bare: %s", out)
@@ -1131,12 +1130,10 @@ env:
 		t.Fatal("expected database name to be set")
 	}
 
-	// migrate command ran in main repo
 	if _, err := os.Stat(filepath.Join(mainRepo, "migrate_ran")); err != nil {
 		t.Error("expected migrate command to have run")
 	}
 
-	// SQLite DB was cloned into worktree
 	clonedPath := filepath.Join(worktreeDir, alloc.Database)
 	data, err := os.ReadFile(clonedPath)
 	if err != nil {
@@ -1144,5 +1141,178 @@ env:
 	}
 	if string(data) != "sqlite-data" {
 		t.Errorf("expected cloned content, got %q", string(data))
+	}
+}
+
+// --- handleProjectRename tests ---
+
+func testSetupWithRegistry(t *testing.T, yamlContent string) (*Setup, string, string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	mainRepo := filepath.Join(dir, "main")
+	worktreePath := filepath.Join(dir, "worktree")
+	_ = os.MkdirAll(mainRepo, 0o755)
+	_ = os.MkdirAll(worktreePath, 0o755)
+
+	_ = os.WriteFile(filepath.Join(mainRepo, ".treeline.yml"), []byte(yamlContent), 0o644)
+
+	regPath := filepath.Join(dir, "registry.json")
+	confPath := filepath.Join(dir, "config.json")
+	_ = os.WriteFile(confPath, []byte(`{"port":{"base":3000,"increment":10},"redis":{"strategy":"prefixed","url":"redis://localhost:6379"}}`), 0o644)
+
+	uc := config.LoadUserConfig(confPath)
+	pc := config.LoadProjectConfig(mainRepo)
+	reg := registry.New(regPath)
+	al := allocator.New(uc, pc, reg)
+
+	s := &Setup{
+		WorktreePath:  worktreePath,
+		MainRepo:      mainRepo,
+		UserConfig:    uc,
+		ProjectConfig: pc,
+		Registry:      reg,
+		Allocator:     al,
+		Log:           &bytes.Buffer{},
+	}
+
+	return s, mainRepo, worktreePath, regPath
+}
+
+func TestHandleProjectRename_NoExistingEntry(t *testing.T) {
+	s, mainRepo, _, _ := testSetupWithRegistry(t, `
+project: myapp
+env_file:
+  target: .env.local
+  source: .env.local
+env:
+  PORT: "{port}"
+`)
+	_ = os.WriteFile(filepath.Join(mainRepo, ".env.local"), []byte(""), 0o644)
+
+	alloc, err := s.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if alloc.Port == 0 {
+		t.Error("expected a port to be allocated")
+	}
+	if alloc.Reused {
+		t.Error("expected a fresh allocation, not reused")
+	}
+}
+
+func TestHandleProjectRename_MatchingProject_Reuses(t *testing.T) {
+	s, mainRepo, worktreePath, _ := testSetupWithRegistry(t, `
+project: myapp
+env_file:
+  target: .env.local
+  source: .env.local
+env:
+  PORT: "{port}"
+`)
+	_ = os.WriteFile(filepath.Join(mainRepo, ".env.local"), []byte(""), 0o644)
+
+	_ = s.Registry.Allocate(registry.Allocation{
+		"project":  "myapp",
+		"worktree": worktreePath,
+		"port":     3010,
+		"ports":    []any{float64(3010)},
+	})
+
+	alloc, err := s.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !alloc.Reused {
+		t.Error("expected allocation to be reused when project name matches")
+	}
+	if alloc.Port != 3010 {
+		t.Errorf("expected port 3010, got %d", alloc.Port)
+	}
+}
+
+func TestHandleProjectRename_MismatchedProject_ReleasesEntry(t *testing.T) {
+	s, mainRepo, worktreePath, _ := testSetupWithRegistry(t, `
+project: myapp_new
+env_file:
+  target: .env.local
+  source: .env.local
+env:
+  PORT: "{port}"
+`)
+	_ = os.WriteFile(filepath.Join(mainRepo, ".env.local"), []byte(""), 0o644)
+
+	_ = s.Registry.Allocate(registry.Allocation{
+		"project":  "myapp_old",
+		"worktree": worktreePath,
+		"port":     3010,
+		"ports":    []any{float64(3010)},
+	})
+
+	alloc, err := s.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if alloc.Reused {
+		t.Error("expected fresh allocation after project rename, not reused")
+	}
+
+	if s.Registry.Find(worktreePath) != nil {
+		entry := s.Registry.Find(worktreePath)
+		if proj, _ := entry["project"].(string); proj == "myapp_old" {
+			t.Error("expected stale registry entry to be released")
+		}
+	}
+
+	plain := ansiRE.ReplaceAllString(s.Log.(*bytes.Buffer).String(), "")
+	if !strings.Contains(plain, "myapp_old") || !strings.Contains(plain, "myapp_new") {
+		t.Errorf("expected rename message in log, got: %q", plain)
+	}
+}
+
+func TestHandleProjectRename_MismatchedProject_DropsSQLiteDB(t *testing.T) {
+	s, mainRepo, worktreePath, _ := testSetupWithRegistry(t, `
+project: myapp_new
+env_file:
+  target: .env
+  source: .env
+database:
+  adapter: sqlite
+  template: db/development.sqlite3
+  pattern: "db/{worktree}.sqlite3"
+env:
+  PORT: "{port}"
+  DATABASE_PATH: "{database}"
+`)
+	_ = os.WriteFile(filepath.Join(mainRepo, ".env"), []byte(""), 0o644)
+	_ = os.MkdirAll(filepath.Join(mainRepo, "db"), 0o755)
+	_ = os.WriteFile(filepath.Join(mainRepo, "db", "development.sqlite3"), []byte("sqlite-data"), 0o644)
+
+	oldDBRelPath := "db/myapp_old_wt.sqlite3"
+	oldDBAbsPath := filepath.Join(worktreePath, oldDBRelPath)
+	_ = os.MkdirAll(filepath.Join(worktreePath, "db"), 0o755)
+	_ = os.WriteFile(oldDBAbsPath, []byte("old-data"), 0o644)
+
+	_ = s.Registry.Allocate(registry.Allocation{
+		"project":          "myapp_old",
+		"worktree":         worktreePath,
+		"port":             3010,
+		"ports":            []any{float64(3010)},
+		"database":         oldDBRelPath,
+		"database_adapter": "sqlite",
+	})
+
+	alloc, err := s.Run()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if alloc.Reused {
+		t.Error("expected fresh allocation, not reused")
+	}
+
+	if _, err := os.Stat(oldDBAbsPath); err == nil {
+		t.Error("expected old SQLite database file to be dropped")
 	}
 }

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -1000,7 +1000,7 @@ func TestRunHookCommands_RunsInSpecifiedDirectory(t *testing.T) {
 func gitInitRepo(t *testing.T, dir string) {
 	t.Helper()
 	cmds := [][]string{
-		{"git", "init", dir},
+		{"git", "init", "--initial-branch=main", dir},
 		{"git", "-C", dir, "config", "user.email", "test@example.com"},
 		{"git", "-C", dir, "config", "user.name", "Test"},
 		{"git", "-C", dir, "commit", "--allow-empty", "-m", "init"},


### PR DESCRIPTION
## Summary

- `gtl rename` was broken when worktrees existed on different branches: it dropped databases and tried to reallocate all worktrees immediately, but those worktrees still had the old project name in their branch's `.treeline.yml`, causing every reallocation to fail with a validation error
- `gtl rename` is now focused: it updates `.treeline.yml` in the current branch, migrates user config keys, and lists the worktrees that need re-provisioning — nothing else
- `gtl setup` now detects a project name mismatch between the registry entry and `.treeline.yml` (which happens after a worktree rebases onto the renamed branch), drops the old database, releases the stale registry entry, and allocates fresh under the new name
- Each worktree self-heals on the next `gtl setup` run after rebasing

## Test plan

- [ ] `TestRenameCmd_InvalidName` — rejects names with dashes
- [ ] `TestRenameCmd_SameNameIsNoop` — no-op when name is unchanged
- [ ] `TestRenameCmd_MissingConfig` — error when no `.treeline.yml`
- [ ] `TestRenameCmd_UpdatesProjectConfig` — `.treeline.yml` updated with new name
- [ ] `TestRenameCmd_ListsAffectedWorktrees` — prints worktree paths + `gtl setup` instructions
- [ ] `TestRenameCmd_DoesNotTouchRegistry` — registry entries left intact for worktrees to self-heal
- [ ] `TestHandleProjectRename_NoExistingEntry` — proceeds normally with no prior registry entry
- [ ] `TestHandleProjectRename_MatchingProject_Reuses` — reuses existing entry when project name matches
- [ ] `TestHandleProjectRename_MismatchedProject_ReleasesEntry` — releases stale entry and allocates fresh
- [ ] `TestHandleProjectRename_MismatchedProject_DropsSQLiteDB` — drops old SQLite file before re-provisioning