### PR TITLE
feat: add gtl version --json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.43.11]
+
+- **`gtl version --json` outputs structured CLI and router version info.** Returns `{"cli": "0.43.11", "router": "0.43.11"}` — or `"router": null` when no router is running. Designed as a clean, stable contract for tooling (e.g. GTLRuntimeInstaller) to read the running router version without scraping human-readable output.
+
 ## [0.43.10]
 
 - **`gtl rename` is now safe when worktrees are on different branches.** Previously, rename tried to drop databases and reallocate all registered worktrees immediately, but those worktrees still had the old project name in their branch's `.treeline.yml`, causing every reallocation to fail. `gtl rename` now only updates `.treeline.yml` in the current branch and migrates user config keys, then lists the worktrees that need re-provisioning. Each worktree self-heals on the next `gtl setup` run after rebasing: setup detects the project name mismatch between its registry entry and `.treeline.yml`, drops the old database, releases the stale registry entry, and allocates fresh under the new name.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 
+	"github.com/git-treeline/cli/internal/service"
 	"github.com/spf13/cobra"
 )
 
@@ -11,12 +13,28 @@ var Version = "dev"
 
 func init() {
 	rootCmd.AddCommand(versionCmd)
+	versionCmd.Flags().Bool("json", false, "Output version info as JSON")
 }
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
 	Short: "Print version",
 	Run: func(cmd *cobra.Command, args []string) {
+		asJSON, _ := cmd.Flags().GetBool("json")
+		if asJSON {
+			router := service.RunningRouterVersion()
+			out := map[string]interface{}{
+				"cli":    Version,
+				"router": nil,
+			}
+			if router != "" {
+				out["router"] = router
+			}
+			enc := json.NewEncoder(cmd.OutOrStdout())
+			enc.SetIndent("", "  ")
+			_ = enc.Encode(out)
+			return
+		}
 		fmt.Printf("git-treeline %s\n", Version)
 	},
 }


### PR DESCRIPTION
## Summary

- Adds `--json` flag to `gtl version`
- Outputs `{"cli": "...", "router": "..."|null}` — router is `null` when no router version file exists
- Uses existing `service.RunningRouterVersion()` — no new I/O paths

## Test plan

- [ ] `gtl version` still prints `git-treeline <version>` unchanged
- [ ] `gtl version --json` with router running returns both versions
- [ ] `gtl version --json` with router absent returns `"router": null`