### PR TITLE
fix: rename updates stale worktree .treeline.yml when main repo already renamed

### DIFF
--- a/cmd/rename.go
+++ b/cmd/rename.go
@@ -56,6 +56,20 @@ and router keys.`,
 
 		oldName := pc.Project()
 		if oldName == newName {
+			// Main repo is already correct. If we're in a linked worktree whose own
+			// .treeline.yml still has a stale name (e.g. branch predates a rename),
+			// update it so that `gtl setup` stops failing.
+			worktreeRoot := worktree.DetectRepoRoot(cwd)
+			if worktreeRoot != mainRepo {
+				wpc := config.LoadProjectConfig(worktreeRoot)
+				if wpc.Exists() && wpc.Project() != newName {
+					if err := wpc.SetProject(newName); err != nil {
+						return fmt.Errorf("rewriting %s in worktree: %w", config.ProjectConfigFile, err)
+					}
+					fmt.Println(style.Actionf("Updated %s in current worktree (main repo was already up-to-date)", config.ProjectConfigFile))
+					return nil
+				}
+			}
 			fmt.Printf("Project is already named %q. Nothing to do.\n", newName)
 			return nil
 		}

--- a/cmd/rename_test.go
+++ b/cmd/rename_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -126,6 +127,65 @@ func TestRenameCmd_ListsAffectedWorktrees(t *testing.T) {
 	}
 	if !strings.Contains(out, "gtl setup") {
 		t.Errorf("expected 'gtl setup' instructions in output, got: %q", out)
+	}
+}
+
+func TestRenameCmd_SameNameUpdatesStaleWorktree(t *testing.T) {
+	mainRepo, _ := makeRenameEnv(t)
+	writeRenameConfig(t, mainRepo, "myapp")
+
+	// Set up a real git repo with an initial commit so we can add a worktree.
+	gitCmds := [][]string{
+		{"init", "--initial-branch=main"},
+		{"config", "user.email", "test@example.com"},
+		{"config", "user.name", "Test"},
+		{"add", ".treeline.yml"},
+		{"commit", "-m", "init"},
+	}
+	for _, args := range gitCmds {
+		cmd := exec.Command("git", args...)
+		cmd.Dir = mainRepo
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %s", args, out)
+		}
+	}
+
+	// Add a linked worktree.
+	worktreeDir := filepath.Join(t.TempDir(), "feat-branch")
+	cmd := exec.Command("git", "worktree", "add", "-b", "feat-branch", worktreeDir)
+	cmd.Dir = mainRepo
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git worktree add: %s", out)
+	}
+
+	// Write a stale .treeline.yml with the old (invalid) name to the worktree.
+	writeRenameConfig(t, worktreeDir, "myapp-old")
+
+	t.Chdir(worktreeDir)
+	renameYes = true
+	t.Cleanup(func() { renameYes = false })
+
+	out := captureStdout(t, func() {
+		if err := renameCmd.RunE(renameCmd, []string{"myapp"}); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	if !strings.Contains(out, "Updated") {
+		t.Errorf("expected 'Updated' message for stale worktree, got: %q", out)
+	}
+	if strings.Contains(out, "Nothing to do") {
+		t.Errorf("expected worktree to be updated, not 'Nothing to do', got: %q", out)
+	}
+
+	wpc := config.LoadProjectConfig(worktreeDir)
+	if wpc.Project() != "myapp" {
+		t.Errorf("expected worktree project to be 'myapp', got %q", wpc.Project())
+	}
+	// Main repo should still be myapp.
+	mpc := config.LoadProjectConfig(mainRepo)
+	if mpc.Project() != "myapp" {
+		t.Errorf("expected main repo project to still be 'myapp', got %q", mpc.Project())
 	}
 }
 


### PR DESCRIPTION
When a project is renamed in the main repo and a linked worktree's branch predates the rename, the worktree's own `.treeline.yml` still has the old (potentially invalid) name. Running `gtl rename <new-name>` from that worktree would find the main repo already correct and exit with "Nothing to do" — leaving the worktree's stale file untouched, causing `gtl setup` and `gtl install` to keep failing with the invalid-name validation error.

Now when the main repo already has the target name, `rename` checks if we're in a linked worktree with a different name in its own `.treeline.yml` and updates it.