### PR TITLE
fix: harden supervisor lifecycle against orphaned processes and dead PTYs

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -3,10 +3,13 @@ package cmd
 import (
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/git-treeline/cli/internal/config"
@@ -111,29 +114,23 @@ resumes the server in the original terminal. Ctrl+C exits the supervisor.`,
 					// Fall through to the fresh-start path below.
 				}
 			} else {
-				if len(activeHooks) > 0 {
-					fmt.Fprintln(os.Stderr, style.Warnf("--with ignored: supervisor already running. Hooks only run on fresh start."))
+				// Supervisor alive but server stopped — the original terminal is
+				// likely gone (e.g. app restart). Kill the orphaned supervisor and
+				// start fresh here so output appears in the current terminal.
+				if err := stopOtherSupervisor(sockPath, 15*time.Second); err != nil {
+					return cliErr(cmd, err)
 				}
-				resp, err = supervisor.Send(sockPath, "start")
-				if err != nil {
-					return err
-				}
-				if strings.HasPrefix(resp, "error") {
-					return cliErr(cmd, &CliError{
-						Message: fmt.Sprintf("Server error: %s", resp),
-						Hint:    "Check the server logs, or run 'gtl stop' and try again.",
-					})
-				}
-				fmt.Println("Server resumed.")
-				if startAwait {
-					return cliErr(cmd, awaitReady(sockPath))
-				}
-				return nil
+				fmt.Println(style.Dimf("Restarting in this terminal..."))
+				// Fall through to fresh start below.
 			}
 		}
 
 		// Fresh start — check for project name drift before proceeding
 		if err := checkDriftOrAbort(absPath); err != nil {
+			return cliErr(cmd, err)
+		}
+
+		if err := clearOrphanedPortProcess(port, absPath); err != nil {
 			return cliErr(cmd, err)
 		}
 
@@ -663,4 +660,78 @@ func awaitReady(sockPath string) error {
 		Message: fmt.Sprintf("Server not ready: %s", resp),
 		Hint:    "The server started but isn't accepting connections. Check commands.start output.",
 	}
+}
+
+// clearOrphanedPortProcess checks whether the worktree's allocated port is
+// already occupied by a previous server that escaped cleanup. When a PID file
+// in tmp/pids/server.pid identifies the owner and that process is alive, the
+// user is prompted to kill it before the fresh start proceeds.
+func clearOrphanedPortProcess(port int, worktreeDir string) error {
+	if port == 0 {
+		return nil
+	}
+
+	conn, err := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 300*time.Millisecond)
+	if err != nil {
+		return nil // port is free
+	}
+	_ = conn.Close()
+
+	// Port is occupied. Check for a server PID file written by a previous run
+	// of this worktree's server (Rails, Django, etc. write these on startup).
+	pidFile := filepath.Join(worktreeDir, "tmp", "pids", "server.pid")
+	raw, err := os.ReadFile(pidFile)
+	if err != nil {
+		// No PID file — port is occupied by something we can't identify.
+		fmt.Fprintln(os.Stderr, style.Warnf("Port %d is in use by an unknown process. Stop it manually, then run 'gtl start'.", port))
+		return &CliError{
+			Message: fmt.Sprintf("Port %d is already in use.", port),
+			Hint:    "Another process is listening on this port. Stop it and try again.",
+		}
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
+	if err != nil || pid <= 0 {
+		return nil
+	}
+
+	// Confirm the PID is still alive before offering to kill it.
+	if err := syscall.Kill(pid, 0); err != nil {
+		// Stale PID file pointing to a dead process; remove it so the next
+		// server can start cleanly.
+		_ = os.Remove(pidFile)
+		return nil
+	}
+
+	// Live process identified from this worktree's PID file — safe to offer a kill.
+	if !stdinIsTTY() {
+		return &CliError{
+			Message: fmt.Sprintf("Port %d is occupied by a previous server (pid: %d).", port, pid),
+			Hint:    fmt.Sprintf("Kill it with: kill %d", pid),
+		}
+	}
+
+	fmt.Fprintln(os.Stderr, style.Warnf("A previous server is still running on port %d (pid: %d).", port, pid))
+	if !confirm.Prompt(fmt.Sprintf("Kill pid %d and continue?", pid), true, nil) {
+		return &CliError{
+			Message: "Aborted.",
+			Hint:    fmt.Sprintf("Kill manually with: kill %d", pid),
+		}
+	}
+
+	// SIGTERM first, escalate to SIGKILL if the port doesn't free in 2s.
+	_ = syscall.Kill(pid, syscall.SIGTERM)
+	for i := 0; i < 20; i++ {
+		time.Sleep(100 * time.Millisecond)
+		c, dialErr := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 100*time.Millisecond)
+		if dialErr != nil {
+			_ = os.Remove(pidFile)
+			return nil
+		}
+		_ = c.Close()
+	}
+	_ = syscall.Kill(pid, syscall.SIGKILL)
+	time.Sleep(200 * time.Millisecond)
+	_ = os.Remove(pidFile)
+	return nil
 }

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -622,7 +622,7 @@ func TestClearOrphanedPortProcess_PortFree(t *testing.T) {
 
 func TestClearOrphanedPortProcess_OccupiedNoPidFile(t *testing.T) {
 	ln, port := listenFreePort(t)
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	err := clearOrphanedPortProcess(port, t.TempDir())
 	if err == nil {
@@ -636,7 +636,7 @@ func TestClearOrphanedPortProcess_OccupiedNoPidFile(t *testing.T) {
 func TestClearOrphanedPortProcess_StalePidFile(t *testing.T) {
 	// Port is occupied but PID file points to a dead process.
 	ln, port := listenFreePort(t)
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	dir := t.TempDir()
 	pidFile := writePidFile(t, dir, 999999999) // guaranteed dead
@@ -651,7 +651,7 @@ func TestClearOrphanedPortProcess_StalePidFile(t *testing.T) {
 
 func TestClearOrphanedPortProcess_InvalidPidFile(t *testing.T) {
 	ln, port := listenFreePort(t)
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	dir := t.TempDir()
 	pidDir := filepath.Join(dir, "tmp", "pids")
@@ -674,7 +674,7 @@ func TestClearOrphanedPortProcess_LivePidNonTTY(t *testing.T) {
 	livePid := proc.Process.Pid
 
 	ln, port := listenFreePort(t)
-	defer ln.Close()
+	defer func() { _ = ln.Close() }()
 
 	dir := t.TempDir()
 	writePidFile(t, dir, livePid)

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -2,10 +2,13 @@ package cmd
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -580,5 +583,128 @@ func TestInterpolateCommand(t *testing.T) {
 				t.Errorf("interpolateCommand(%q, %d) = %q, want %q", tt.cmd, tt.port, got, tt.want)
 			}
 		})
+	}
+}
+
+// --- clearOrphanedPortProcess tests ---
+
+// listenFreePort opens a TCP listener on a random free port and returns
+// the listener (caller must Close) and the chosen port number.
+func listenFreePort(t *testing.T) (net.Listener, int) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen free port: %v", err)
+	}
+	return ln, ln.Addr().(*net.TCPAddr).Port
+}
+
+// writePidFile creates tmp/pids/server.pid under dir with the given pid.
+func writePidFile(t *testing.T, dir string, pid int) string {
+	t.Helper()
+	pidDir := filepath.Join(dir, "tmp", "pids")
+	if err := os.MkdirAll(pidDir, 0o755); err != nil {
+		t.Fatalf("mkdir pids: %v", err)
+	}
+	p := filepath.Join(pidDir, "server.pid")
+	if err := os.WriteFile(p, []byte(strconv.Itoa(pid)), 0o644); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+	return p
+}
+
+func TestClearOrphanedPortProcess_PortFree(t *testing.T) {
+	// port == 0 exits immediately; any free port also exits with nil.
+	if err := clearOrphanedPortProcess(0, t.TempDir()); err != nil {
+		t.Fatalf("expected nil for port 0, got %v", err)
+	}
+}
+
+func TestClearOrphanedPortProcess_OccupiedNoPidFile(t *testing.T) {
+	ln, port := listenFreePort(t)
+	defer ln.Close()
+
+	err := clearOrphanedPortProcess(port, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when port is occupied and no PID file exists")
+	}
+	if !strings.Contains(err.Error(), "already in use") {
+		t.Errorf("expected 'already in use' in error, got: %v", err)
+	}
+}
+
+func TestClearOrphanedPortProcess_StalePidFile(t *testing.T) {
+	// Port is occupied but PID file points to a dead process.
+	ln, port := listenFreePort(t)
+	defer ln.Close()
+
+	dir := t.TempDir()
+	pidFile := writePidFile(t, dir, 999999999) // guaranteed dead
+
+	if err := clearOrphanedPortProcess(port, dir); err != nil {
+		t.Fatalf("expected nil for stale PID, got %v", err)
+	}
+	if _, err := os.Stat(pidFile); !os.IsNotExist(err) {
+		t.Error("expected stale PID file to be removed")
+	}
+}
+
+func TestClearOrphanedPortProcess_InvalidPidFile(t *testing.T) {
+	ln, port := listenFreePort(t)
+	defer ln.Close()
+
+	dir := t.TempDir()
+	pidDir := filepath.Join(dir, "tmp", "pids")
+	_ = os.MkdirAll(pidDir, 0o755)
+	_ = os.WriteFile(filepath.Join(pidDir, "server.pid"), []byte("not-a-number"), 0o644)
+
+	// Unreadable PID → skip silently (don't block startup).
+	if err := clearOrphanedPortProcess(port, dir); err != nil {
+		t.Fatalf("expected nil for unreadable PID file, got %v", err)
+	}
+}
+
+func TestClearOrphanedPortProcess_LivePidNonTTY(t *testing.T) {
+	// Start a real background process so we have a live, non-current PID.
+	proc := exec.Command("sleep", "30")
+	if err := proc.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() { _ = proc.Process.Kill(); _ = proc.Wait() })
+	livePid := proc.Process.Pid
+
+	ln, port := listenFreePort(t)
+	defer ln.Close()
+
+	dir := t.TempDir()
+	writePidFile(t, dir, livePid)
+
+	// stdinIsTTY() checks os.Stdin — swap it for a pipe so the non-TTY
+	// code path is taken regardless of whether the test runs in a terminal.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() {
+		os.Stdin = orig
+		_ = r.Close()
+		_ = w.Close()
+	})
+
+	got := clearOrphanedPortProcess(port, dir)
+	if got == nil {
+		t.Fatal("expected error for live PID in non-TTY context")
+	}
+	ce, ok := got.(*CliError)
+	if !ok {
+		t.Fatalf("expected *CliError, got %T: %v", got, got)
+	}
+	if !strings.Contains(ce.Message, fmt.Sprintf("pid: %d", livePid)) {
+		t.Errorf("expected PID in message, got: %q", ce.Message)
+	}
+	if !strings.Contains(ce.Hint, fmt.Sprintf("kill %d", livePid)) {
+		t.Errorf("expected kill hint, got: %q", ce.Hint)
 	}
 }

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -33,6 +33,9 @@ type Supervisor struct {
 	Port       int
 	Env        map[string]string // extra env vars injected into the child process
 	Log        func(format string, args ...any)
+	// ConnWriteDeadline caps how long handleConn waits to write a response.
+	// Defaults to 15s. Override in tests to avoid slow-test hangs.
+	ConnWriteDeadline time.Duration
 
 	mu           sync.Mutex
 	child        *exec.Cmd
@@ -44,11 +47,12 @@ type Supervisor struct {
 
 func New(command, dir, socketPath string) *Supervisor {
 	return &Supervisor{
-		Command:    command,
-		Dir:        dir,
-		SocketPath: socketPath,
-		Log:        func(f string, a ...any) { fmt.Fprintf(os.Stderr, f+"\n", a...) },
-		done:       make(chan struct{}),
+		Command:           command,
+		Dir:               dir,
+		SocketPath:        socketPath,
+		Log:               func(f string, a ...any) { fmt.Fprintf(os.Stderr, f+"\n", a...) },
+		ConnWriteDeadline: 15 * time.Second,
+		done:              make(chan struct{}),
 	}
 }
 
@@ -72,7 +76,7 @@ func (s *Supervisor) Run() error {
 	}()
 
 	sigs := make(chan os.Signal, 1)
-	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
 	go s.acceptLoop()
 
@@ -196,10 +200,19 @@ func (s *Supervisor) handleConn(conn net.Conn) {
 	if err != nil {
 		return
 	}
+	_ = conn.SetReadDeadline(time.Time{})
 
 	raw := strings.TrimSpace(string(buf[:n]))
 	parts := strings.SplitN(raw, ":", 2)
 	cmd := parts[0]
+
+	// wait-ready manages its own deadline via the timeout embedded in the command.
+	// All other commands must respond quickly — cap the write side to prevent a
+	// hung goroutine from holding s.mu indefinitely if the client disappears.
+	if cmd != "wait-ready" {
+		_ = conn.SetWriteDeadline(time.Now().Add(s.ConnWriteDeadline))
+	}
+
 	switch cmd {
 	case "restart":
 		if err := s.restart(); err != nil {

--- a/internal/supervisor/supervisor_test.go
+++ b/internal/supervisor/supervisor_test.go
@@ -1,9 +1,11 @@
 package supervisor
 
 import (
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 )
@@ -286,6 +288,85 @@ func waitForFile(t *testing.T, path string, timeout time.Duration) {
 		time.Sleep(50 * time.Millisecond)
 	}
 	t.Fatalf("file %s not created within %s", path, timeout)
+}
+
+func TestSupervisor_SIGHUPShutdown(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "test.sock")
+
+	sv := New("sleep 60", dir, sock)
+	sv.Log = func(f string, a ...any) {}
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- sv.Run() }()
+
+	waitForSocket(t, sock, 2*time.Second)
+
+	// SIGHUP should trigger graceful shutdown identical to SIGINT/SIGTERM.
+	_ = syscall.Kill(syscall.Getpid(), syscall.SIGHUP)
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Errorf("supervisor returned error on SIGHUP: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("supervisor didn't exit after SIGHUP")
+	}
+
+	if _, err := os.Stat(sock); !os.IsNotExist(err) {
+		t.Error("expected socket to be cleaned up after SIGHUP")
+	}
+}
+
+// TestSupervisor_WriteDeadlineUnblocksLock verifies that a hung client
+// (connects, sends a command, never reads the response) doesn't hold the
+// supervisor's mutex indefinitely. A subsequent "status" query must succeed
+// once the write deadline fires on the stuck connection.
+func TestSupervisor_WriteDeadlineUnblocksLock(t *testing.T) {
+	dir := t.TempDir()
+	// macOS caps unix socket paths at ~104 bytes; t.TempDir() paths exceed that.
+	f, err := os.CreateTemp("/tmp", "gtl-test-*.sock")
+	if err != nil {
+		t.Fatalf("create temp sock: %v", err)
+	}
+	sock := f.Name()
+	_ = f.Close()
+	_ = os.Remove(sock)
+	t.Cleanup(func() { _ = os.Remove(sock) })
+
+	sv := New("sleep 60", dir, sock)
+	sv.Log = func(f string, a ...any) {}
+	sv.ConnWriteDeadline = 200 * time.Millisecond // fast deadline for the test
+
+	errCh := make(chan error, 1)
+	go func() { errCh <- sv.Run() }()
+	waitForSocket(t, sock, 2*time.Second)
+
+	// Connect and send "restart" but never read the response — simulates a
+	// client that disappears mid-command (e.g. gtl stop timing out).
+	hung, err := net.Dial("unix", sock)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer func() { _ = hung.Close() }()
+	_, _ = hung.Write([]byte("restart"))
+	// Deliberately not reading the response.
+
+	// Wait for the write deadline to fire and the handleConn goroutine to exit.
+	time.Sleep(400 * time.Millisecond)
+
+	// The mutex must be free now — status should respond immediately.
+	resp, err := SendWithTimeout(sock, "status", 2*time.Second)
+	if err != nil {
+		t.Fatalf("status after hung client: %v", err)
+	}
+	if resp != "running" && resp != "stopped" {
+		t.Errorf("unexpected status response: %q", resp)
+	}
+
+	_, _ = Send(sock, "shutdown")
+	<-errCh
 }
 
 func splitNonEmpty(s string) []string {


### PR DESCRIPTION
## Summary

- **SIGHUP handling** — supervisor now shuts down cleanly when Conductor closes its terminal (previously survived as a zombie holding the socket, making all subsequent `gtl start`/`gtl stop` commands hang)
- **Write deadline on socket responses** — adds `ConnWriteDeadline` (default 15s) to all `handleConn` responses except `wait-ready`, preventing a hung client from holding `s.mu` indefinitely and deadlocking the supervisor
- **Orphaned supervisor cleanup on `gtl start`** — when a supervisor is alive but its server is stopped (original terminal gone after app restart), kill it and start fresh in the current terminal so output appears where the user is looking
- **Port pre-flight check** — before launching the supervisor, detect if the allocated port is occupied by a previous server identified via `tmp/pids/server.pid`; prompt to kill it with SIGTERM→SIGKILL escalation rather than letting `bin/dev` fail 10 seconds in with a cryptic framework error

## Test plan

- `TestSupervisor_SIGHUPShutdown` — sends real SIGHUP, verifies clean shutdown and socket removal
- `TestSupervisor_WriteDeadlineUnblocksLock` — hung client never reads response, verifies mutex frees after deadline and subsequent commands succeed
- `TestClearOrphanedPortProcess_PortFree` — no-op when port is unoccupied
- `TestClearOrphanedPortProcess_OccupiedNoPidFile` — errors with guidance when port is taken by an unidentifiable process
- `TestClearOrphanedPortProcess_StalePidFile` — silently removes stale PID file pointing to dead process
- `TestClearOrphanedPortProcess_InvalidPidFile` — skips gracefully on unreadable PID
- `TestClearOrphanedPortProcess_LivePidNonTTY` — returns structured error with kill hint in non-TTY context