### PR TITLE
fix: force-kill supervisor via PID file when socket is unresponsive

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -217,6 +217,17 @@ supervisor entirely.`,
 
 		resp, err := supervisor.Send(sockPath, command)
 		if err != nil {
+			if stopKill {
+				if killed, killErr := forceKillSupervisor(sockPath); killed {
+					fmt.Println("Supervisor force-killed (was unresponsive).")
+					return nil
+				} else if killErr != nil {
+					return cliErr(cmd, &CliError{
+						Message: fmt.Sprintf("Could not force-kill supervisor: %s", killErr),
+						Hint:    "Find the supervisor PID manually and kill it.",
+					})
+				}
+			}
 			return err
 		}
 		if strings.HasPrefix(resp, "error") {
@@ -598,6 +609,29 @@ func promptRunningElsewhere(reader io.Reader) runningAction {
 	default:
 		return runningActionCancel
 	}
+}
+
+// forceKillSupervisor reads the supervisor's PID file and SIGKILLs the
+// process, then cleans up the socket and PID files. Used as a fallback when
+// the supervisor is alive enough to hold the socket but too hung to respond.
+// Returns (true, nil) on success, (false, nil) if no PID file exists,
+// (false, err) if the kill fails.
+func forceKillSupervisor(sockPath string) (bool, error) {
+	pidPath := supervisor.PidPath(sockPath)
+	data, err := os.ReadFile(pidPath)
+	if err != nil {
+		return false, nil
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || pid <= 0 {
+		return false, nil
+	}
+	if err := syscall.Kill(pid, syscall.SIGKILL); err != nil && err != syscall.ESRCH {
+		return false, err
+	}
+	_ = os.Remove(sockPath)
+	_ = os.Remove(pidPath)
+	return true, nil
 }
 
 // stopOtherSupervisor shuts the existing supervisor down and waits for its

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -26,6 +26,11 @@ func SocketPath(worktreePath string) string {
 	return fmt.Sprintf("/tmp/gtl-%x.sock", h[:8])
 }
 
+// PidPath returns the supervisor PID file path corresponding to a socket path.
+func PidPath(socketPath string) string {
+	return strings.TrimSuffix(socketPath, ".sock") + ".pid"
+}
+
 type Supervisor struct {
 	Command    string
 	Dir        string
@@ -70,9 +75,13 @@ func (s *Supervisor) Run() error {
 	}
 	_ = os.Chmod(s.SocketPath, 0600)
 	s.listener = ln
+
+	pidPath := PidPath(s.SocketPath)
+	_ = os.WriteFile(pidPath, []byte(strconv.Itoa(os.Getpid())), 0600)
 	defer func() {
 		_ = ln.Close()
 		_ = os.Remove(s.SocketPath)
+		_ = os.Remove(pidPath)
 	}()
 
 	sigs := make(chan os.Signal, 1)


### PR DESCRIPTION
When the supervisor is alive enough to accept socket connections but too hung to respond (e.g. stuck in `stopChildLocked` after a Ctrl+C mid-shutdown), `gtl stop --kill` would timeout on the read and leave the user permanently stuck.

Two changes:

- **Supervisor writes a PID file** (`/tmp/gtl-<hash>.pid`) alongside the socket on startup, removed on clean exit.
- **`stop --kill` falls back to SIGKILL** via the PID file when `Send("shutdown")` errors. Reads the PID, kills the process, cleans up socket + PID files, and prints "Supervisor force-killed (was unresponsive)."