### PR TITLE
fix: restrict lsof port scan to TCP listeners to avoid killing unrelated processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## [0.43.14]
 
+- **`gtl start` uses `lsof` to identify and offer to kill unidentified processes blocking the allocated port.** Previously, when a process was occupying the port but had no `tmp/pids/server.pid` to attribute it, `gtl start` refused and required manual intervention. Now it finds the blocking listener's PID via `lsof`, shows the process name, and prompts to kill it before starting.
 - **`gtl stop --kill` now escapes the stuck-supervisor state when the socket is unresponsive.** The supervisor writes its PID to a `.pid` file alongside its socket on startup. When `stop --kill` times out waiting for a response (e.g. the supervisor accepted the connection but is hung in shutdown), it falls back to reading that PID file, SIGKILLs the process directly, and cleans up the socket and PID files — printing "Supervisor force-killed (was unresponsive)" rather than leaving the user permanently blocked.
 
 ## [0.43.13]

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -716,17 +716,12 @@ func clearOrphanedPortProcess(port int, worktreeDir string) error {
 	pidFile := filepath.Join(worktreeDir, "tmp", "pids", "server.pid")
 	raw, err := os.ReadFile(pidFile)
 	if err != nil {
-		// No PID file — port is occupied by something we can't identify.
-		fmt.Fprintln(os.Stderr, style.Warnf("Port %d is in use by an unknown process. Stop it manually, then run 'gtl start'.", port))
-		return &CliError{
-			Message: fmt.Sprintf("Port %d is already in use.", port),
-			Hint:    "Another process is listening on this port. Stop it and try again.",
-		}
+		return clearUnknownPortProcess(port)
 	}
 
 	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
 	if err != nil || pid <= 0 {
-		return nil
+		return clearUnknownPortProcess(port)
 	}
 
 	// Confirm the PID is still alive before offering to kill it.
@@ -768,4 +763,104 @@ func clearOrphanedPortProcess(port int, worktreeDir string) error {
 	time.Sleep(200 * time.Millisecond)
 	_ = os.Remove(pidFile)
 	return nil
+}
+
+// clearUnknownPortProcess is called when the port is occupied but there is no
+// server.pid to identify the owner. It uses lsof to discover the blocking
+// process(es), shows what they are, and offers to kill them.
+func clearUnknownPortProcess(port int) error {
+	pids := lsofPortPIDs(port)
+	if len(pids) == 0 {
+		fmt.Fprintln(os.Stderr, style.Warnf("Port %d is in use by an unknown process. Stop it manually, then run 'gtl start'.", port))
+		return &CliError{
+			Message: fmt.Sprintf("Port %d is already in use.", port),
+			Hint:    "Another process is listening on this port. Stop it and try again.",
+		}
+	}
+
+	// Build a human-readable description of the blocking processes.
+	var descs []string
+	for _, pid := range pids {
+		name := processCommandName(pid)
+		if name != "" {
+			descs = append(descs, fmt.Sprintf("%s (pid: %d)", name, pid))
+		} else {
+			descs = append(descs, fmt.Sprintf("pid: %d", pid))
+		}
+	}
+	desc := strings.Join(descs, ", ")
+
+	if !stdinIsTTY() {
+		return &CliError{
+			Message: fmt.Sprintf("Port %d is occupied by: %s.", port, desc),
+			Hint:    fmt.Sprintf("Kill it with: kill -9 %s", joinPIDs(pids)),
+		}
+	}
+
+	fmt.Fprintln(os.Stderr, style.Warnf("Port %d is in use by: %s.", port, desc))
+	if !confirm.Prompt(fmt.Sprintf("Kill %s and continue?", joinPIDs(pids)), true, nil) {
+		return &CliError{
+			Message: "Aborted.",
+			Hint:    fmt.Sprintf("Kill manually with: kill -9 %s", joinPIDs(pids)),
+		}
+	}
+
+	for _, pid := range pids {
+		_ = syscall.Kill(pid, syscall.SIGTERM)
+	}
+	for i := 0; i < 20; i++ {
+		time.Sleep(100 * time.Millisecond)
+		c, dialErr := net.DialTimeout("tcp", fmt.Sprintf("127.0.0.1:%d", port), 100*time.Millisecond)
+		if dialErr != nil {
+			return nil
+		}
+		_ = c.Close()
+	}
+	for _, pid := range pids {
+		_ = syscall.Kill(pid, syscall.SIGKILL)
+	}
+	time.Sleep(200 * time.Millisecond)
+	return nil
+}
+
+// lsofPortPIDs returns the PIDs of processes listening on the given TCP port
+// using lsof. Returns nil if lsof is unavailable or finds nothing.
+func lsofPortPIDs(port int) []int {
+	out, err := exec.Command("lsof", "-ti", fmt.Sprintf("tcp:%d", port), "-sTCP:LISTEN").Output()
+	if err != nil {
+		return nil
+	}
+	var pids []int
+	seen := map[int]bool{}
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		pid, err := strconv.Atoi(strings.TrimSpace(line))
+		if err != nil || pid <= 0 || seen[pid] {
+			continue
+		}
+		seen[pid] = true
+		pids = append(pids, pid)
+	}
+	return pids
+}
+
+// processCommandName returns the short command name for a PID via ps.
+func processCommandName(pid int) string {
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "comm=").Output()
+	if err != nil {
+		return ""
+	}
+	// ps returns the full path; trim to basename for readability.
+	name := strings.TrimSpace(string(out))
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return name
+}
+
+func joinPIDs(pids []int) string {
+	parts := make([]string, len(pids))
+	for i, pid := range pids {
+		parts[i] = strconv.Itoa(pid)
+	}
+	return strings.Join(parts, " ")
 }

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -721,7 +721,10 @@ func clearOrphanedPortProcess(port int, worktreeDir string) error {
 
 	pid, err := strconv.Atoi(strings.TrimSpace(string(raw)))
 	if err != nil || pid <= 0 {
-		return clearUnknownPortProcess(port)
+		// Unreadable PID file — we can't confirm who owns the port, so don't
+		// try to kill an unknown process. Let startup proceed; if the port is
+		// truly occupied the server will fail to bind with a clear message.
+		return nil
 	}
 
 	// Confirm the PID is still alive before offering to kill it.

--- a/cmd/server_test.go
+++ b/cmd/server_test.go
@@ -624,12 +624,19 @@ func TestClearOrphanedPortProcess_OccupiedNoPidFile(t *testing.T) {
 	ln, port := listenFreePort(t)
 	defer func() { _ = ln.Close() }()
 
-	err := clearOrphanedPortProcess(port, t.TempDir())
-	if err == nil {
-		t.Fatal("expected error when port is occupied and no PID file exists")
+	// Force non-TTY so clearUnknownPortProcess returns an error instead of
+	// prompting (which could auto-kill the test binary itself via lsof).
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
 	}
-	if !strings.Contains(err.Error(), "already in use") {
-		t.Errorf("expected 'already in use' in error, got: %v", err)
+	orig := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = orig; _ = r.Close(); _ = w.Close() })
+
+	gotErr := clearOrphanedPortProcess(port, t.TempDir())
+	if gotErr == nil {
+		t.Fatal("expected error when port is occupied and no PID file exists")
 	}
 }
 


### PR DESCRIPTION
`lsof -ti :PORT` matches any file whose local or foreign port equals the number — TCP, UDP, established connections included. Since `clearUnknownPortProcess` kills every returned PID, a process with an established outbound connection to the same port number (e.g. 8080) could be killed even though it's not the listener.

Fixes by restricting to `tcp:PORT -sTCP:LISTEN`, which matches only processes with a TCP socket in the LISTEN state on that port.

Also adds a CHANGELOG entry for the `lsof`-based port fallback behavior introduced in the same diff (was missing from the 0.43.14 entry).