### PR TITLE
fix: load project config from worktree path in db template update

### DIFF
--- a/cmd/db_template.go
+++ b/cmd/db_template.go
@@ -37,7 +37,7 @@ updated template.`,
 		}
 
 		mainRepo := worktree.DetectMainRepo(cwd)
-		pc := config.LoadProjectConfig(mainRepo)
+		pc := config.LoadProjectConfig(cwd)
 
 		migrateCmd := pc.MigrateCommand()
 		if migrateCmd == "" {


### PR DESCRIPTION
`gtl db template update` was loading `.treeline.yml` from the main repo path (root git checkout) rather than the current worktree. Since `.treeline.yml` is branch-specific, the main repo's branch often didn't have `commands.migrate` configured yet — even when the worktree's branch did — causing a spurious "No migrate command configured" error.

Fix: load config from `cwd` (the worktree) to read the correct branch's config, while still running the git pull and migration against `mainRepo`. This matches how `setup.go` already handles the same config lookup.