### PR TITLE
feat: capacity-aware Redis DB allocation, fail loud on exhaustion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.43.18]
+
+- **Redis database allocation is now capacity-aware and fails loud when exhausted.** The `database` isolation strategy previously hardcoded Redis's stock 16-database limit and, once all slots were taken, silently reused db1 — so worktrees beyond the 15th collided onto a shared database with no error or warning, cross-contaminating background jobs (e.g. Sidekiq). The slot count now comes from a new `redis.databases` config key (default 16); to grow the pool, raise `databases` in `redis.conf`, restart Redis, then `gtl config set redis.databases <N>`. When every slot is in use, `gtl new` now fails with an actionable error instead of colliding, and `gtl status` reports Redis pool usage and flags any databases already shared by more than one worktree.
+
 ## [0.43.17]
 
 - **`gtl rename` now reads `.treeline.yml` from the current worktree instead of the main repo.** Running `gtl rename` from a linked worktree would fail with "no .treeline.yml found" when the main repo's branch didn't have the file. The fix mirrors the `db template update` fix from v0.43.16 — config is now loaded from the current worktree root via `DetectRepoRoot`, while `DetectMainRepo` is still used for registry lookups and the stale-name fallback.

--- a/README.md
+++ b/README.md
@@ -604,7 +604,8 @@ Controls allocation policy for your machine. Created automatically by `gtl init`
   },
   "redis": {
     "strategy": "prefixed",
-    "url": "redis://localhost:6379"
+    "url": "redis://localhost:6379",
+    "databases": 16
   },
   "router": {
     "port": 3001
@@ -738,11 +739,18 @@ Use `--drop-db` with `gtl release` to clean up cloned databases.
 
 If your project uses Redis, Treeline can assign each worktree its own namespace to prevent key collisions.
 
-**Prefixed** (default): All worktrees share Redis DB 0, keys are namespaced (`myapp:feature-x:...`). No limit on concurrent worktrees.
+**Prefixed** (default): All worktrees share Redis DB 0, keys are namespaced (`myapp:feature-x:...`). No limit on concurrent worktrees. Recommended when you run many worktrees.
 
-**Database**: Each worktree gets its own Redis DB number (1-15). Use this if your app doesn't support key prefixing.
+**Database**: Each worktree gets its own Redis DB number (1 to `databases`-1). Use this if your app doesn't support key prefixing (e.g. Sidekiq, which discourages namespacing).
 
-Configure in your user config under `redis.strategy`.
+Slot capacity comes from your Redis `databases` directive (stock Redis is 16 → indices 0–15, so 15 usable worktree slots; db0 is reserved for the main worktree). When every slot is taken, `gtl new` fails with an explicit error rather than silently sharing a database — and `gtl status` flags any worktrees that already share a DB. To grow the pool, raise `databases` in `redis.conf`, restart Redis, then mirror the value so Treeline can use the new slots:
+
+```
+gtl config set redis.databases 64
+gtl reallocate --all-registry --apply
+```
+
+Configure in your user config under `redis.strategy` and `redis.databases`.
 
 ## Use with AI agents
 

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -68,7 +68,7 @@ var configGetCmd = &cobra.Command{
 		}
 		keys := []string{
 			"port.base", "port.increment", "port.reservations",
-			"redis.strategy", "redis.url",
+			"redis.strategy", "redis.url", "redis.databases",
 			"router.port",
 			"editor.name",
 			"tunnel.default",
@@ -114,7 +114,7 @@ var configSetCmd = &cobra.Command{
 		}
 		keys := []string{
 			"port.base", "port.increment", "port.reservations",
-			"redis.strategy", "redis.url",
+			"redis.strategy", "redis.url", "redis.databases",
 			"router.port",
 			"editor.name",
 			"tunnel.default",

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/git-treeline/cli/internal/allocator"
+	"github.com/git-treeline/cli/internal/config"
 	"github.com/git-treeline/cli/internal/format"
 	"github.com/git-treeline/cli/internal/registry"
 	"github.com/git-treeline/cli/internal/supervisor"
@@ -214,5 +215,53 @@ func renderStatus() error {
 		}
 	}
 
+	renderRedisCapacity(reg)
 	return nil
+}
+
+// renderRedisCapacity surfaces Redis database usage for the "database"
+// strategy, where slots are a finite resource (1..N-1). It reports how full
+// the pool is and, crucially, flags any database shared by more than one
+// worktree — the silent collision that predates fail-loud allocation and the
+// symptom users otherwise can't see. Computed over the whole registry because
+// the DB pool is global, not per-project.
+func renderRedisCapacity(reg *registry.Registry) {
+	uc := config.LoadUserConfig("")
+	if uc.RedisStrategy() != "database" {
+		return
+	}
+
+	byDB := make(map[int][]string)
+	for _, a := range reg.Allocations() {
+		rdb, ok := a["redis_db"].(float64)
+		if !ok || int(rdb) <= 0 {
+			continue
+		}
+		byDB[int(rdb)] = append(byDB[int(rdb)], format.DisplayName(format.Allocation(a)))
+	}
+	if len(byDB) == 0 {
+		return
+	}
+
+	usable := uc.RedisDatabases() - 1
+	fmt.Printf("\nRedis (database strategy): %d/%d slots used on %s\n", len(byDB), usable, uc.RedisURL())
+
+	var shared []int
+	for db, names := range byDB {
+		if len(names) > 1 {
+			shared = append(shared, db)
+		}
+	}
+	if len(shared) == 0 {
+		return
+	}
+	sort.Ints(shared)
+	fmt.Println("  ⚠ collisions — these worktrees share a Redis DB; background jobs will cross-contaminate:")
+	for _, db := range shared {
+		names := byDB[db]
+		sort.Strings(names)
+		fmt.Printf("      db%d: %s\n", db, strings.Join(names, ", "))
+	}
+	fmt.Println("  Fix: raise `databases` in redis.conf + `gtl config set redis.databases <N>`,")
+	fmt.Println("       or `gtl config set redis.strategy prefixed`, then `gtl reallocate --all-registry --apply`.")
 }

--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -15,8 +15,6 @@ import (
 	"github.com/git-treeline/cli/internal/registry"
 )
 
-const maxRedisDbs = 16
-
 // Allocator manages resource allocation using user and project configuration.
 // It tracks used resources via the registry to avoid conflicts between worktrees.
 type Allocator struct {
@@ -256,7 +254,10 @@ func (al *Allocator) allocateNew(worktreePath, worktreeName, branch string) (*Al
 		return nil, fmt.Errorf("no available port block of size %d found (all ports in use or reserved)", count)
 	}
 
-	redisDB, redisPrefix := al.allocateRedis(worktreeName)
+	redisDB, redisPrefix, err := al.allocateRedis(worktreeName)
+	if err != nil {
+		return nil, err
+	}
 	database := al.buildDatabaseName(worktreeName)
 
 	return &Allocation{
@@ -398,25 +399,50 @@ func CheckPortsListening(ports []int) bool {
 	return false
 }
 
-func (al *Allocator) allocateRedis(worktreeName string) (int, string) {
+func (al *Allocator) allocateRedis(worktreeName string) (int, string, error) {
 	if al.UserConfig.RedisStrategy() == "database" {
-		db := al.nextAvailableRedisDB()
-		return db, ""
+		db, err := al.nextAvailableRedisDB()
+		if err != nil {
+			return 0, "", err
+		}
+		return db, "", nil
 	}
-	return 0, fmt.Sprintf("%s:%s", al.ProjectConfig.Project(), worktreeName)
+	return 0, fmt.Sprintf("%s:%s", al.ProjectConfig.Project(), worktreeName), nil
 }
 
-func (al *Allocator) nextAvailableRedisDB() int {
+// nextAvailableRedisDB returns the lowest free Redis database index in the
+// range 1..capacity-1 (db0 is reserved for the main/template worktree). It
+// fails loud when every slot is taken rather than silently colliding onto a
+// shared database — capacity exhaustion is a real error, not a fallback.
+func (al *Allocator) nextAvailableRedisDB() (int, error) {
 	usedSet := make(map[int]bool)
 	for _, db := range al.Registry.UsedRedisDbs() {
 		usedSet[db] = true
 	}
-	for db := 1; db < maxRedisDbs; db++ {
+	capacity := al.UserConfig.RedisDatabases()
+	for db := 1; db < capacity; db++ {
 		if !usedSet[db] {
-			return db
+			return db, nil
 		}
 	}
-	return 1
+	return 0, al.redisExhaustedError(capacity, len(usedSet))
+}
+
+// redisExhaustedError explains that the "database" strategy has run out of
+// Redis slots and points at the two durable fixes: grow the Redis database
+// count, or switch to key-prefix isolation (which has no such ceiling).
+func (al *Allocator) redisExhaustedError(capacity, used int) error {
+	return fmt.Errorf(
+		"no free Redis database: all %d slot(s) on %s are in use (%d worktree(s) allocated)\n\n"+
+			"  The \"database\" strategy isolates each worktree onto its own Redis DB, but\n"+
+			"  this Redis only has %d databases (indices 0–%d; db0 is reserved). Options:\n\n"+
+			"    • Grow the pool — raise `databases` in redis.conf, restart Redis, then:\n"+
+			"        gtl config set redis.databases <N>\n"+
+			"        gtl reallocate --all-registry --apply\n\n"+
+			"    • Switch to key-prefix isolation (no database ceiling):\n"+
+			"        gtl config set redis.strategy prefixed\n"+
+			"        gtl reallocate --all-registry --apply",
+		capacity-1, al.UserConfig.RedisURL(), used, capacity, capacity-1)
 }
 
 var sanitizeRe = regexp.MustCompile(`[^a-zA-Z0-9_]`)

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -2,6 +2,7 @@ package allocator
 
 import (
 	"encoding/json"
+	"fmt"
 	"net"
 	"os"
 	"path/filepath"
@@ -268,6 +269,88 @@ func TestAllocate_RedisDatabaseStrategy(t *testing.T) {
 	}
 	if alloc.RedisDB != 1 {
 		t.Errorf("expected redis db 1, got %d", alloc.RedisDB)
+	}
+}
+
+// seedRedisDBs registers placeholder allocations occupying redis DBs 1..n so
+// the next "database"-strategy allocation sees them as taken.
+func seedRedisDBs(t *testing.T, reg *registry.Registry, n int) {
+	t.Helper()
+	for i := 1; i <= n; i++ {
+		entry := registry.Allocation{
+			"worktree": fmt.Sprintf("/wt/seed-%d", i),
+			"project":  "test",
+			"port":     3000 + i,
+			"ports":    []any{3000 + i},
+			"redis_db": float64(i),
+		}
+		if err := reg.Allocate(entry); err != nil {
+			t.Fatalf("seeding redis db %d: %v", i, err)
+		}
+	}
+}
+
+func redisDBAllocator(t *testing.T, extraConfig string) (*Allocator, *registry.Registry) {
+	t.Helper()
+	dir := t.TempDir()
+	reg := registry.New(filepath.Join(dir, "registry.json"))
+
+	confPath := filepath.Join(dir, "config.json")
+	conf := fmt.Sprintf(`{"port":{"base":3000,"increment":10},"redis":{"url":"redis://localhost:6379"%s}}`, extraConfig)
+	_ = os.WriteFile(confPath, []byte(conf), 0o644)
+	uc := config.LoadUserConfig(confPath)
+
+	projDir := filepath.Join(dir, "project")
+	_ = os.MkdirAll(projDir, 0o755)
+	_ = os.WriteFile(filepath.Join(projDir, ".treeline.yml"), []byte("project: test\ndatabase:\n  adapter: postgresql\n  template: test_dev\n  pattern: \"{template}_{worktree}\"\n"), 0o644)
+	pc := config.LoadProjectConfig(projDir)
+
+	return New(uc, pc, reg), reg
+}
+
+func TestAllocate_RedisExhaustedFailsLoud(t *testing.T) {
+	al, reg := redisDBAllocator(t, `,"strategy":"database"`)
+	// Default cap of 16 → slots 1..15. Fill them all.
+	seedRedisDBs(t, reg, 15)
+
+	_, err := al.Allocate("/wt/overflow", "overflow", false)
+	if err == nil {
+		t.Fatal("expected exhaustion error when all 15 DB slots are taken, got nil (silent collision)")
+	}
+	for _, want := range []string{"redis.databases", "prefixed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q remedy; got: %v", want, err)
+		}
+	}
+}
+
+func TestAllocate_RedisDatabasesRaisesCap(t *testing.T) {
+	// Raise the pool to 64. Slots 1..15 taken → next should land on db16,
+	// which the stock 16-DB cap would have rejected (proving config is read).
+	al, reg := redisDBAllocator(t, `,"strategy":"database","databases":64`)
+	seedRedisDBs(t, reg, 15)
+
+	alloc, err := al.Allocate("/wt/sixteen", "sixteen", false)
+	if err != nil {
+		t.Fatalf("expected success with raised cap, got: %v", err)
+	}
+	if alloc.RedisDB != 16 {
+		t.Errorf("expected redis db 16 with cap 64, got %d", alloc.RedisDB)
+	}
+}
+
+func TestAllocate_PrefixedNeverExhausts(t *testing.T) {
+	al, reg := redisDBAllocator(t, `,"strategy":"prefixed"`)
+	// Even with every DB slot notionally taken, prefixed isolation ignores
+	// the ceiling entirely.
+	seedRedisDBs(t, reg, 15)
+
+	alloc, err := al.Allocate("/wt/anything", "anything", false)
+	if err != nil {
+		t.Fatalf("prefixed strategy must not exhaust, got: %v", err)
+	}
+	if alloc.RedisDB != 0 || alloc.RedisPrefix == "" {
+		t.Errorf("expected prefix isolation (db0 + prefix), got db=%d prefix=%q", alloc.RedisDB, alloc.RedisPrefix)
 	}
 }
 

--- a/internal/config/user.go
+++ b/internal/config/user.go
@@ -15,8 +15,9 @@ var UserDefaults = map[string]any{
 		"increment": float64(2),
 	},
 	"redis": map[string]any{
-		"strategy": "prefixed",
-		"url":      "redis://localhost:6379",
+		"strategy":  "prefixed",
+		"url":       "redis://localhost:6379",
+		"databases": float64(DefaultRedisDatabases),
 	},
 	"router": map[string]any{
 		"port": float64(3001),
@@ -29,6 +30,12 @@ const (
 	RouterModeDisabled = "disabled"
 	RouterModeEnabled  = "enabled"
 )
+
+// DefaultRedisDatabases matches a stock Redis build (databases 16 → indices
+// 0–15). db0 is reserved for the main/template worktree, leaving 1–15 for
+// feature worktrees under the "database" strategy. Raise `databases` in
+// redis.conf and mirror it via `gtl config set redis.databases N` to grow.
+const DefaultRedisDatabases = 16
 
 type UserConfig struct {
 	Path string
@@ -106,6 +113,20 @@ func (uc *UserConfig) RedisURL() string {
 		return s
 	}
 	return "redis://localhost:6379"
+}
+
+// RedisDatabases returns the number of databases the target Redis is
+// configured for (the `databases` directive in redis.conf). It bounds how
+// many worktrees the "database" strategy can isolate: slots 1..N-1. Values
+// below 2 (no room for a feature worktree beyond db0) fall back to the
+// stock default.
+func (uc *UserConfig) RedisDatabases() int {
+	if f, ok := Dig(uc.Data, "redis", "databases").(float64); ok {
+		if n := int(f); n >= 2 {
+			return n
+		}
+	}
+	return DefaultRedisDatabases
 }
 
 // RouterPort returns the port the subdomain router listens on. Default 3001.


### PR DESCRIPTION
## Problem

The `database` Redis isolation strategy hardcoded Redis's stock 16-database limit (`const maxRedisDbs = 16`) and, once all slots were taken, `nextAvailableRedisDB` silently did `return 1` — so every worktree past the 15th collided onto a shared database with **no error, no warning, and no registry marker**. Background jobs (e.g. Sidekiq) on those worktrees cross-contaminated, and the user had no way to see it. Raising `databases` in `redis.conf` did nothing because the cap was a compile-time constant.

## Changes

- **Config-driven capacity** — new `redis.databases` key (default 16). The cap now reflects the target Redis instead of a constant. Raise `databases` in `redis.conf`, restart, then `gtl config set redis.databases <N>` to grow the pool.
- **Fail loud on exhaustion** — `nextAvailableRedisDB` returns an actionable error (naming both remedies: grow the pool, or switch to `prefixed`) instead of colliding onto db1. Threaded through `allocateRedis` → `allocateNew`.
- **Visibility in `gtl status`** — reports Redis pool usage for the `database` strategy and flags any database already shared by more than one worktree, surfacing pre-existing silent collisions that fail-loud can't retroactively fix.
- Docs + config completion updated.

## Tests

- `TestAllocate_RedisExhaustedFailsLoud` — full pool → actionable error, not silent collision.
- `TestAllocate_RedisDatabasesRaisesCap` — `redis.databases: 64` unlocks db16, which the old cap rejected.
- `TestAllocate_PrefixedNeverExhausts` — prefixed strategy ignores the ceiling.

`go build`, `go vet`, and the full `go test ./...` suite pass.