### PR TITLE
feat: accept optional leading '#' on PR numbers in review/switch

### DIFF
--- a/cmd/review.go
+++ b/cmd/review.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/git-treeline/cli/internal/config"
 	"github.com/git-treeline/cli/internal/confirm"
@@ -21,6 +22,12 @@ import (
 var reviewPath string
 var reviewStart bool
 var reviewOpen bool
+
+// parsePRNumber parses a PR number argument, accepting an optional leading '#'
+// (e.g. both "473" and "#473").
+func parsePRNumber(arg string) (int, error) {
+	return strconv.Atoi(strings.TrimPrefix(arg, "#"))
+}
 
 func init() {
 	reviewCmd.Flags().StringVar(&reviewPath, "path", "", "Custom worktree path (default: ../<project>-pr-<number>)")
@@ -39,7 +46,7 @@ resources, and run setup. Requires the gh CLI (https://cli.github.com).`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		warnServeNotInstalled()
 
-		prNumber, err := strconv.Atoi(args[0])
+		prNumber, err := parsePRNumber(args[0])
 		if err != nil {
 			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Invalid PR number: %s", args[0]),

--- a/cmd/review.go
+++ b/cmd/review.go
@@ -24,9 +24,17 @@ var reviewStart bool
 var reviewOpen bool
 
 // parsePRNumber parses a PR number argument, accepting an optional leading '#'
-// (e.g. both "473" and "#473").
+// (e.g. both "473" and "#473"). PR numbers are positive, so zero and negative
+// values are rejected.
 func parsePRNumber(arg string) (int, error) {
-	return strconv.Atoi(strings.TrimPrefix(arg, "#"))
+	n, err := strconv.Atoi(strings.TrimPrefix(arg, "#"))
+	if err != nil {
+		return 0, err
+	}
+	if n < 1 {
+		return 0, fmt.Errorf("PR number must be positive: %s", arg)
+	}
+	return n, nil
 }
 
 func init() {

--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -18,6 +18,10 @@ func TestParsePRNumber(t *testing.T) {
 		{name: "empty", arg: "", wantErr: true},
 		{name: "hash with non-numeric", arg: "#abc", wantErr: true},
 		{name: "double hash", arg: "##473", wantErr: true},
+		{name: "zero", arg: "0", wantErr: true},
+		{name: "zero with hash", arg: "#0", wantErr: true},
+		{name: "negative", arg: "-1", wantErr: true},
+		{name: "negative with hash", arg: "#-1", wantErr: true},
 	}
 
 	for _, tt := range tests {

--- a/cmd/review_test.go
+++ b/cmd/review_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import "testing"
+
+func TestParsePRNumber(t *testing.T) {
+	tests := []struct {
+		name    string
+		arg     string
+		want    int
+		wantErr bool
+	}{
+		{name: "bare number", arg: "473", want: 473},
+		{name: "leading hash", arg: "#473", want: 473},
+		{name: "single digit", arg: "5", want: 5},
+		{name: "single digit with hash", arg: "#5", want: 5},
+		{name: "non-numeric", arg: "abc", wantErr: true},
+		{name: "hash only", arg: "#", wantErr: true},
+		{name: "empty", arg: "", wantErr: true},
+		{name: "hash with non-numeric", arg: "#abc", wantErr: true},
+		{name: "double hash", arg: "##473", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parsePRNumber(tt.arg)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parsePRNumber(%q) = %d, want error", tt.arg, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parsePRNumber(%q) unexpected error: %v", tt.arg, err)
+			}
+			if got != tt.want {
+				t.Errorf("parsePRNumber(%q) = %d, want %d", tt.arg, got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/switch.go
+++ b/cmd/switch.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strconv"
 
 	"github.com/git-treeline/cli/internal/config"
 	"github.com/git-treeline/cli/internal/github"
@@ -50,7 +49,7 @@ Must be run from inside a worktree (not the main repo).`,
 		}
 
 		branch := target
-		if prNum, err := strconv.Atoi(target); err == nil {
+		if prNum, err := parsePRNumber(target); err == nil {
 			fmt.Println(style.Actionf("Looking up PR #%d...", prNum))
 			pr, err := github.LookupPR(prNum)
 			if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/git-treeline/cli
 
-go 1.26.4
+go 1.26.5
 
 require (
 	charm.land/bubbles/v2 v2.1.0


### PR DESCRIPTION
## Summary

`gtl review #473` and `gtl switch #473` previously failed with `Invalid PR number: #473`. Users naturally type the `#` prefix when copying a PR reference, so both forms should work.

Adds a shared `parsePRNumber()` helper that strips an optional leading `#` before parsing, so both `#473` and `473` resolve to the same PR.

Also bumps the Go toolchain to resolve a CI vulnerability-check failure (unrelated to the parsing change — see below).

## Changes

- `cmd/review.go` — add `parsePRNumber()`; `review` uses it.
- `cmd/switch.go` — use `parsePRNumber()` for its PR-number path; drop now-unused `strconv`/`strings` imports.
- `cmd/review_test.go` — table-driven test covering `473`, `#473`, single digits, and error cases (`abc`, `#`, empty, `#abc`, `##473`).
- `go.mod` — bump Go `1.26.4` → `1.26.5` (see Vulnerability fix).

Non-numeric branch names in `switch` are unaffected: `TrimPrefix` only strips a single leading `#`, and anything not all-digits still falls through to being treated as a branch name.

## Vulnerability fix

CI's `govulncheck` step failed on `GO-2026-5856` (Encrypted Client Hello privacy leak in `crypto/tls`), a Go **standard-library** vulnerability present in `go1.26.4` and fixed in `go1.26.5`. Since CI installs Go via `go-version-file: go.mod`, bumping the `go` directive to `1.26.5` pulls the patched toolchain. `govulncheck ./...` now reports no vulnerabilities.

## Testing

- `go build ./...`
- `go test ./cmd/ -run TestParsePRNumber` (passes)
- `govulncheck ./...` — no vulnerabilities found (exit 0)
- CI green: both `ci` and `ci-macos` jobs pass