### PR TITLE
feat: gtl provision — bring a host up to a repo's declared baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,11 @@ See [Framework examples](#framework-examples) for complete examples. Available f
 | `hooks.<name>.auto` | `true` to run this hook on every fresh `gtl start` (default: `false`, requires `--with`) |
 | `hooks.<name>.pre_start` | Shell command(s) run before the supervisor launches — string or array of strings |
 | `hooks.<name>.post_stop` | Shell command(s) run in reverse order when the supervisor exits (Ctrl+C) — string or array |
+| `provision.apt` | System packages a host needs before setup (Linux; installed with `sudo apt-get`). Skipped on macOS |
+| `provision.services` | Service packages to apt-install and `systemctl enable --now` (Linux). Skipped on macOS |
+| `provision.database.source` | A `database.sources.<env>` name to hydrate the template database from (preferred — real data) |
+| `provision.database.hydrate` | Fallback shell command, run in the repo dir, to fill the template when no `source` is set (e.g. `bin/rails db:schema:load db:seed`) |
+| `provision.database.template` | Template database name to create (defaults to `database.template` — the DB gtl clones worktree DBs from) |
 
 ### Interpolation tokens
 
@@ -722,6 +727,42 @@ Once a worktree is allocated, the `project` name is stored in the registry and u
 `gtl start`, `gtl setup`, and `gtl env sync` detect this mismatch and prompt to revert `.treeline.yml` to the registry name. `gtl doctor` reports drift diagnostically.
 
 To actually rename a project: release all worktrees (`gtl release --all --project <old-name>`), update `.treeline.yml`, then run `gtl setup`.
+
+## Provisioning a host (optional)
+
+`gtl setup` assumes the host already has what the project needs — Postgres with a
+template database, the right language runtime, system libraries. On your own Mac
+that's usually true. On a fresh box (a cloud VPS, a new machine, CI) it isn't.
+
+`gtl provision` reads a `provision:` section from `.treeline.yml` and brings the
+host up to that declared baseline. Every step checks before acting, so it's safe
+to re-run:
+
+```yaml
+database:
+  template: salt_development         # the DB gtl clones worktree DBs from
+provision:
+  apt: [libvips, imagemagick]        # system packages (Linux; needs sudo)
+  services: [redis-server]           # apt-install + systemctl enable --now
+  database:
+    source: production               # hydrate the template from real data…
+    hydrate: "bin/rails db:schema:load db:seed"   # …or this, if no source
+```
+
+- **apt / services** are Linux-only and are skipped with a note on macOS.
+- **Runtimes** install via `mise` when the repo pins one (`.ruby-version`,
+  `.tool-versions`, `mise.toml`, …) and `mise` is on `PATH`.
+- **Template database**: if the template doesn't exist, it's created from
+  `source` (reusing the `gtl db pull` machinery), else via the `hydrate`
+  command, else empty (with a warning).
+
+```bash
+gtl provision --dry-run   # print the plan without acting
+gtl provision             # apply it
+```
+
+Run it once when you first put a repo on a new host — after cloning, before
+`gtl setup`. `gtl setup` and `gtl new` do **not** invoke it automatically.
 
 ## Database cloning (optional)
 
@@ -813,6 +854,7 @@ gtl db name --json         # {"database": "myapp_feature_xyz"}
 | `gtl review <PR#>` | `--path` `--start` `--open` | Check out a GitHub PR into a worktree with full setup (requires `gh`) |
 | `gtl switch <branch-or-PR#>` | `--setup` `--restart` | Switch worktree to a different branch or PR — fetches, checks out, refreshes env |
 | `gtl setup [PATH]` | `--main-repo` `--dry-run` | Allocate resources and configure a worktree (idempotent) |
+| `gtl provision [PATH]` | `--dry-run` | Make a host meet a repo's declared prerequisites (apt/services/runtimes/template DB) before setup (idempotent) |
 | `gtl release [PATH]` | `--drop-db` `--remove-worktree` `--project` `--all` `--force`/`-f` `--dry-run` | Free allocated resources (confirms before releasing unless `--force`) |
 | `gtl port` | `--json` | Print the allocated port for the current worktree |
 | `gtl refresh` | `--dry-run` `--force`/`-f` | Re-allocate all worktrees with current reservations; restarts supervised servers |

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -1,0 +1,218 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/git-treeline/cli/internal/config"
+	"github.com/git-treeline/cli/internal/database"
+	"github.com/git-treeline/cli/internal/dbsource"
+	"github.com/git-treeline/cli/internal/provision"
+	"github.com/git-treeline/cli/internal/style"
+	"github.com/spf13/cobra"
+)
+
+var provisionDryRun bool
+
+func init() {
+	provisionCmd.Flags().BoolVar(&provisionDryRun, "dry-run", false, "Print the provisioning plan without making changes")
+	rootCmd.AddCommand(provisionCmd)
+}
+
+var provisionCmd = &cobra.Command{
+	Use:   "provision [PATH]",
+	Short: "Make a host meet a repo's declared prerequisites for setup",
+	Long: `Bring the current host up to the baseline a repo needs before 'gtl setup'
+can succeed, from the provision: section of .treeline.yml:
+
+  provision:
+    apt: [libvips, imagemagick]      # system packages (Linux; needs sudo)
+    services: [redis-server]         # apt-install + systemctl enable --now
+    database:
+      source: production             # hydrate the template from real data
+      hydrate: "bin/rails db:schema:load db:seed"   # fallback command
+
+Every step checks before acting, so provision is safe to re-run. apt and
+services are Linux-only and are skipped with a note on macOS. The template
+database is the same one gtl clones worktree databases from (database.template);
+provision creates it from a configured source, or via the hydrate command, or
+empty as a last resort.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		path := "."
+		if len(args) > 0 {
+			path = args[0]
+		}
+		abs, _ := filepath.Abs(path)
+		pc := config.LoadProjectConfig(abs)
+
+		if !pc.Exists() {
+			fmt.Println(style.Actionf("Nothing to provision — no %s here.", config.ProjectConfigFile))
+			return nil
+		}
+		cfg := pc.Provision()
+		if !cfg.Present {
+			fmt.Println(style.Actionf("Nothing to provision — no 'provision:' section in %s.", config.ProjectConfigFile))
+			return nil
+		}
+
+		actions := provision.BuildPlan(cfg, abs, runtime.GOOS, fileExists)
+		actions = guardDatabaseAdapter(actions, pc)
+
+		if provisionDryRun {
+			provision.PrintPlan(os.Stdout, actions)
+			return nil
+		}
+
+		if len(actions) == 0 {
+			fmt.Println(style.Actionf("Nothing to provision."))
+			return nil
+		}
+
+		deps := provisionDeps(pc, abs)
+		if err := provision.Run(actions, abs, deps); err != nil {
+			return cliErr(cmd, err)
+		}
+		fmt.Println()
+		fmt.Println(style.Successf("Provisioning complete."))
+		return nil
+	},
+}
+
+// guardDatabaseAdapter drops the database action when the adapter isn't
+// postgresql — provision's database step drives createdb/psql/pg tooling.
+func guardDatabaseAdapter(actions []provision.Action, pc *config.ProjectConfig) []provision.Action {
+	if pc.DatabaseAdapter() == "postgresql" {
+		return actions
+	}
+	var out []provision.Action
+	for _, a := range actions {
+		if a.Kind == provision.ActionDatabase {
+			fmt.Fprintln(os.Stderr, style.Warnf("Skipping database provisioning — adapter %q is not postgresql.", pc.DatabaseAdapter()))
+			continue
+		}
+		out = append(out, a)
+	}
+	return out
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// provisionDeps wires the executor's seams to real system effects.
+func provisionDeps(pc *config.ProjectConfig, repoDir string) provision.Deps {
+	connArgs := pc.DatabaseConnArgs()
+	adapter, _ := database.ForAdapter(pc.DatabaseAdapter(), connArgs)
+	return provision.Deps{
+		GOOS:             runtime.GOOS,
+		FileExists:       fileExists,
+		LookPath:         exec.LookPath,
+		PackageInstalled: dpkgInstalled,
+		AptInstall:       aptInstall,
+		ServiceEnable:    systemctlEnableNow,
+		RunInDir:         runShellInDir,
+		DBExists: func(name string) (bool, error) {
+			if adapter == nil {
+				return false, fmt.Errorf("no database adapter")
+			}
+			return adapter.Exists(name)
+		},
+		CreateDB: func(name string) error { return createDB(connArgs, name) },
+		HydrateFromSource: func(template, env string) error {
+			return hydrateTemplateFromSource(pc, template, env)
+		},
+		Log: func(format string, a ...any) {
+			fmt.Println(style.Actionf(format, a...))
+		},
+		Warn: func(format string, a ...any) {
+			fmt.Fprintln(os.Stderr, style.Warnf(format, a...))
+		},
+	}
+}
+
+// dpkgInstalled reports whether an apt package is installed. An unknown package
+// makes dpkg-query exit non-zero, which we treat as "not installed".
+func dpkgInstalled(pkg string) (bool, error) {
+	out, err := exec.Command("dpkg-query", "-W", "-f=${Status}", pkg).Output()
+	if err != nil {
+		return false, nil
+	}
+	return strings.Contains(string(out), "install ok installed"), nil
+}
+
+func aptInstall(pkgs []string) error {
+	args := append([]string{"apt-get", "install", "-y"}, pkgs...)
+	return streamCommand("sudo", args...)
+}
+
+func systemctlEnableNow(name string) error {
+	return streamCommand("sudo", "systemctl", "enable", "--now", name)
+}
+
+func createDB(connArgs []string, name string) error {
+	args := append(append([]string{}, connArgs...), name)
+	return streamCommand("createdb", args...)
+}
+
+func runShellInDir(dir, command string) error {
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Dir = dir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func streamCommand(name string, args ...string) error {
+	cmd := exec.Command(name, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// hydrateTemplateFromSource dumps a configured source env and restores it into
+// the template database, creating it. Reuses the gtl db pull machinery
+// (dbsource resolution + Puller) so provision and pull share one path.
+func hydrateTemplateFromSource(pc *config.ProjectConfig, template, env string) error {
+	spec, err := buildSourceSpec(pc, env)
+	if err != nil {
+		return err
+	}
+	src, err := dbsource.New(spec, dbsource.DefaultDeps())
+	if err != nil {
+		return classifySourceError(spec, err)
+	}
+	conn, err := src.Resolve()
+	if err != nil {
+		return classifySourceError(spec, err)
+	}
+
+	dir, err := os.MkdirTemp("", "gtl-provision-*")
+	if err != nil {
+		return fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+
+	dump := filepath.Join(dir, env+".dump")
+	toc := filepath.Join(dir, env+".toc")
+
+	p := database.NewPuller(pc.DatabaseConnArgs())
+	fmt.Printf("==> Dumping %s from %s\n", env, conn.Host)
+	if err := p.Dump(toRemoteConn(conn), dump); err != nil {
+		return classifyPullError(err, conn.Host, template)
+	}
+	exts := database.Extensions{
+		Require: pc.DatabaseExtensionsRequire(),
+		Strip:   pc.DatabaseExtensionsStrip(),
+	}
+	fmt.Printf("==> Restoring into template %s\n", template)
+	if err := p.Refresh(template, dump, toc, exts); err != nil {
+		return classifyPullError(err, conn.Host, template)
+	}
+	return nil
+}

--- a/cmd/provision.go
+++ b/cmd/provision.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -108,18 +109,22 @@ func fileExists(path string) bool {
 // provisionDeps wires the executor's seams to real system effects.
 func provisionDeps(pc *config.ProjectConfig, repoDir string) provision.Deps {
 	connArgs := pc.DatabaseConnArgs()
-	adapter, _ := database.ForAdapter(pc.DatabaseAdapter(), connArgs)
+	adapter, adapterErr := database.ForAdapter(pc.DatabaseAdapter(), connArgs)
 	return provision.Deps{
 		GOOS:             runtime.GOOS,
 		FileExists:       fileExists,
 		LookPath:         exec.LookPath,
 		PackageInstalled: dpkgInstalled,
+		AptUpdate:        aptUpdate,
 		AptInstall:       aptInstall,
 		ServiceEnable:    systemctlEnableNow,
 		RunInDir:         runShellInDir,
 		DBExists: func(name string) (bool, error) {
 			if adapter == nil {
-				return false, fmt.Errorf("no database adapter")
+				if adapterErr != nil {
+					return false, fmt.Errorf("database adapter %q: %w", pc.DatabaseAdapter(), adapterErr)
+				}
+				return false, fmt.Errorf("no database adapter for %q", pc.DatabaseAdapter())
 			}
 			return adapter.Exists(name)
 		},
@@ -146,13 +151,17 @@ func dpkgInstalled(pkg string) (bool, error) {
 	return strings.Contains(string(out), "install ok installed"), nil
 }
 
+func aptUpdate() error {
+	return sudoCommand("apt-get", "update")
+}
+
 func aptInstall(pkgs []string) error {
 	args := append([]string{"apt-get", "install", "-y"}, pkgs...)
-	return streamCommand("sudo", args...)
+	return sudoCommand(args...)
 }
 
 func systemctlEnableNow(name string) error {
-	return streamCommand("sudo", "systemctl", "enable", "--now", name)
+	return sudoCommand("systemctl", "enable", "--now", name)
 }
 
 func createDB(connArgs []string, name string) error {
@@ -160,16 +169,39 @@ func createDB(connArgs []string, name string) error {
 	return streamCommand("createdb", args...)
 }
 
+// sudoCommand runs a privileged provision command non-interactively. On failure
+// it annotates the error with the passwordless-sudo expectation: provision is
+// meant to run over SSH with no tty (see streamCommand), so a sudo that wants a
+// password can't be answered and surfaces here.
+func sudoCommand(args ...string) error {
+	if err := streamCommand("sudo", args...); err != nil {
+		return fmt.Errorf("%w (provision runs non-interactively; the host user is expected to have passwordless sudo)", err)
+	}
+	return nil
+}
+
 func runShellInDir(dir, command string) error {
 	cmd := exec.Command("sh", "-c", command)
 	cmd.Dir = dir
+	// Non-interactive by contract (see streamCommand): a hydrate command that
+	// reads stdin gets a clean EOF, not an inherited fd.
+	cmd.Stdin = bytes.NewReader(nil)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 
+// streamCommand runs an external command, streaming its stdout/stderr onto the
+// process's own. Stdin is wired to an empty reader (EOF on first read) rather
+// than inherited: provision commands are non-interactive by design. The primary
+// consumer is Treeline invoking `gtl provision` over SSH with no controlling
+// tty, where the box user has passwordless sudo — so sudo never needs to
+// prompt. Wiring /dev/null semantics means any subcommand that reads stdin gets
+// a deterministic EOF instead of an arbitrary inherited fd. Interactive sudo
+// (password prompts) is unsupported: there is no channel to answer them.
 func streamCommand(name string, args ...string) error {
 	cmd := exec.Command(name, args...)
+	cmd.Stdin = bytes.NewReader(nil)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -531,6 +531,83 @@ func (pc *ProjectConfig) MigrateCommand() string {
 	return ""
 }
 
+// ProvisionConfig is the parsed provision: section — the declared, executable
+// answer to "what must be true on a host before gtl setup can succeed for this
+// repo." Present reports whether the section exists at all (absent = no-op).
+type ProvisionConfig struct {
+	Present  bool
+	Apt      []string
+	Services []string
+	Database ProvisionDatabase
+}
+
+// ProvisionDatabase declares how to bring the template database into existence
+// on a fresh host. Template defaults to the top-level database.template — the
+// same database gtl clones worktree databases from — so provision creates THAT
+// database rather than a parallel one. Source names a database.sources.<env>
+// to hydrate from (preferred); Hydrate is a fallback shell command run in the
+// repo dir to build+fill the template when no source is configured.
+type ProvisionDatabase struct {
+	Template string
+	Source   string
+	Hydrate  string
+}
+
+// Provision returns the parsed provision: section. The returned config's
+// Database.Template falls back to the top-level database.template when the
+// provision block doesn't override it, keeping a single source of truth for the
+// name gtl clones worktree databases from.
+func (pc *ProjectConfig) Provision() ProvisionConfig {
+	raw, present := pc.Data["provision"].(map[string]any)
+	cfg := ProvisionConfig{Present: pc.hasProvisionKey()}
+	if !present {
+		// Section present but not a map (or absent): still resolve the template
+		// fallback so callers can provision a top-level template on its own.
+		cfg.Database.Template = pc.DatabaseTemplate()
+		return cfg
+	}
+	cfg.Apt = stringListFromAny(raw["apt"])
+	cfg.Services = stringListFromAny(raw["services"])
+	if db, ok := raw["database"].(map[string]any); ok {
+		if t, ok := db["template"].(string); ok && t != "" {
+			cfg.Database.Template = t
+		}
+		if s, ok := db["source"].(string); ok {
+			cfg.Database.Source = s
+		}
+		if h, ok := db["hydrate"].(string); ok {
+			cfg.Database.Hydrate = h
+		}
+	}
+	if cfg.Database.Template == "" {
+		cfg.Database.Template = pc.DatabaseTemplate()
+	}
+	return cfg
+}
+
+// hasProvisionKey reports whether the provision: key is present in the file at
+// all — used to distinguish "nothing to provision" from a misconfigured block.
+func (pc *ProjectConfig) hasProvisionKey() bool {
+	_, ok := pc.Data["provision"]
+	return ok
+}
+
+// stringListFromAny coerces a YAML sequence into a []string, dropping non-string
+// entries. Returns nil for anything that isn't a sequence.
+func stringListFromAny(v any) []string {
+	raw, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, item := range raw {
+		if s, ok := item.(string); ok && s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
 func (pc *ProjectConfig) DatabaseSyncOnCreate() bool {
 	v, ok := Dig(pc.Data, "database", "sync_on_create").(bool)
 	return ok && v
@@ -830,6 +907,7 @@ var projectKnownKeys = map[string]bool{
 	"project": true, "port_count": true, "env_file": true, "database": true,
 	"copy_files": true, "env": true, "hooks": true, "commands": true,
 	"editor": true, "merge_target": true, "aliases": true, "related_repos": true,
+	"provision": true,
 	// Legacy keys accepted during migration
 	"default_branch": true, "setup_commands": true, "start_command": true,
 	"ports_needed": true,

--- a/internal/config/provision_test.go
+++ b/internal/config/provision_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"slices"
 	"testing"
 )
 
@@ -40,10 +41,10 @@ provision:
 	if !cfg.Present {
 		t.Fatal("expected Present=true")
 	}
-	if got, want := cfg.Apt, []string{"libvips", "imagemagick"}; !equalStrs(got, want) {
+	if got, want := cfg.Apt, []string{"libvips", "imagemagick"}; !slices.Equal(got, want) {
 		t.Errorf("apt = %v, want %v", got, want)
 	}
-	if got, want := cfg.Services, []string{"redis-server"}; !equalStrs(got, want) {
+	if got, want := cfg.Services, []string{"redis-server"}; !slices.Equal(got, want) {
 		t.Errorf("services = %v, want %v", got, want)
 	}
 	// Template falls back to top-level database.template.
@@ -82,16 +83,4 @@ provision:
 	if cfg.Database.Template != "" {
 		t.Errorf("template = %q, want empty (no top-level template)", cfg.Database.Template)
 	}
-}
-
-func equalStrs(a, b []string) bool {
-	if len(a) != len(b) {
-		return false
-	}
-	for i := range a {
-		if a[i] != b[i] {
-			return false
-		}
-	}
-	return true
 }

--- a/internal/config/provision_test.go
+++ b/internal/config/provision_test.go
@@ -1,0 +1,97 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func loadProvision(t *testing.T, yml string) ProvisionConfig {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(yml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return LoadProjectConfig(dir).Provision()
+}
+
+func TestProvision_AbsentSection_NotPresent(t *testing.T) {
+	cfg := loadProvision(t, "project: test\n")
+	if cfg.Present {
+		t.Error("expected Present=false when no provision: section")
+	}
+	if len(cfg.Apt) != 0 || len(cfg.Services) != 0 {
+		t.Error("expected empty apt/services")
+	}
+}
+
+func TestProvision_FullSection(t *testing.T) {
+	cfg := loadProvision(t, `
+project: salt
+database:
+  template: salt_development
+provision:
+  apt: [libvips, imagemagick]
+  services: [redis-server]
+  database:
+    source: production
+    hydrate: "bin/rails db:schema:load db:seed"
+`)
+	if !cfg.Present {
+		t.Fatal("expected Present=true")
+	}
+	if got, want := cfg.Apt, []string{"libvips", "imagemagick"}; !equalStrs(got, want) {
+		t.Errorf("apt = %v, want %v", got, want)
+	}
+	if got, want := cfg.Services, []string{"redis-server"}; !equalStrs(got, want) {
+		t.Errorf("services = %v, want %v", got, want)
+	}
+	// Template falls back to top-level database.template.
+	if cfg.Database.Template != "salt_development" {
+		t.Errorf("template = %q, want salt_development", cfg.Database.Template)
+	}
+	if cfg.Database.Source != "production" {
+		t.Errorf("source = %q, want production", cfg.Database.Source)
+	}
+	if cfg.Database.Hydrate != "bin/rails db:schema:load db:seed" {
+		t.Errorf("hydrate = %q", cfg.Database.Hydrate)
+	}
+}
+
+func TestProvision_TemplateOverride(t *testing.T) {
+	cfg := loadProvision(t, `
+database:
+  template: top_level_tmpl
+provision:
+  database:
+    template: override_tmpl
+`)
+	if cfg.Database.Template != "override_tmpl" {
+		t.Errorf("template = %q, want override_tmpl (provision block wins)", cfg.Database.Template)
+	}
+}
+
+func TestProvision_PresentButEmpty(t *testing.T) {
+	cfg := loadProvision(t, `
+provision:
+  apt: [libvips]
+`)
+	if !cfg.Present {
+		t.Fatal("expected Present=true")
+	}
+	if cfg.Database.Template != "" {
+		t.Errorf("template = %q, want empty (no top-level template)", cfg.Database.Template)
+	}
+}
+
+func equalStrs(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/provision/execute.go
+++ b/internal/provision/execute.go
@@ -1,0 +1,249 @@
+package provision
+
+import (
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/git-treeline/cli/internal/config"
+)
+
+// versionFiles are the repo-pinned runtime files mise auto-reads. Their presence
+// triggers `mise install` (which installs whatever the repo pins) — runtime
+// provisioning is driven by these files, not by the provision: config.
+var versionFiles = []string{
+	".mise.toml",
+	"mise.toml",
+	".tool-versions",
+	".ruby-version",
+	".node-version",
+	".nvmrc",
+	".python-version",
+}
+
+// Deps are the injectable effect/probe seams the executor runs actions through.
+// The command layer wires these to real implementations; tests supply fakes.
+// Every probe is consulted before its effect so each step is idempotent.
+type Deps struct {
+	GOOS string
+
+	// FileExists reports whether a path exists (used for runtime detection).
+	FileExists func(path string) bool
+	// LookPath reports whether a binary is on PATH (nil error = found).
+	LookPath func(bin string) (string, error)
+
+	// PackageInstalled reports whether an apt package is installed (dpkg -s).
+	PackageInstalled func(pkg string) (bool, error)
+	// AptInstall installs the given apt packages (sudo apt-get install -y).
+	AptInstall func(pkgs []string) error
+	// ServiceEnable enables and starts a systemd unit (systemctl enable --now).
+	ServiceEnable func(name string) error
+
+	// RunInDir runs a shell command in dir, streaming its output.
+	RunInDir func(dir, command string) error
+
+	// DBExists reports whether a local database exists.
+	DBExists func(name string) (bool, error)
+	// CreateDB creates an empty local database.
+	CreateDB func(name string) error
+	// HydrateFromSource dumps a configured source env and restores it into the
+	// named template database, creating it. Reuses the gtl db pull machinery.
+	HydrateFromSource func(template, sourceEnv string) error
+
+	// Log writes a top-level "==>" step line; Warn writes a warning line.
+	Log  func(format string, args ...any)
+	Warn func(format string, args ...any)
+}
+
+// RuntimeAction returns a runtime-provisioning Action when the repo pins any
+// language runtime via a version file, or nil when there's nothing to do. It is
+// the one non-config-driven step, so it lives here rather than in PlanConfig.
+func RuntimeAction(repoDir string, fileExists func(string) bool) *Action {
+	var found []string
+	for _, f := range versionFiles {
+		if fileExists(filepath.Join(repoDir, f)) {
+			found = append(found, f)
+		}
+	}
+	if len(found) == 0 {
+		return nil
+	}
+	return &Action{Kind: ActionRuntime, VersionFiles: found}
+}
+
+// BuildPlan assembles the full ordered plan for a repo: config-driven actions
+// (apt, services, database) followed by the runtime action when the repo pins a
+// runtime. GOOS gates platform-specific actions.
+func BuildPlan(cfg config.ProvisionConfig, repoDir string, goos string, fileExists func(string) bool) []Action {
+	configActions := PlanConfig(cfg, goos)
+	rt := RuntimeAction(repoDir, fileExists)
+	if rt == nil {
+		return configActions
+	}
+	// Runtime runs after packages/services and before the database step,
+	// matching the documented order: apt -> services -> runtimes -> database.
+	out := make([]Action, 0, len(configActions)+1)
+	inserted := false
+	for _, a := range configActions {
+		if a.Kind == ActionDatabase && !inserted {
+			out = append(out, *rt)
+			inserted = true
+		}
+		out = append(out, a)
+	}
+	if !inserted {
+		out = append(out, *rt)
+	}
+	return out
+}
+
+// Run executes the plan in order, checking before acting. It returns on the
+// first real failure (platform skips and idempotent no-ops are not failures).
+func Run(actions []Action, repoDir string, d Deps) error {
+	for _, a := range actions {
+		if err := runAction(a, repoDir, d); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runAction(a Action, repoDir string, d Deps) error {
+	switch a.Kind {
+	case ActionApt:
+		return runApt(a, d)
+	case ActionService:
+		return runServices(a, d)
+	case ActionRuntime:
+		return runRuntime(a, repoDir, d)
+	case ActionDatabase:
+		return runDatabase(a, repoDir, d)
+	}
+	return nil
+}
+
+func runApt(a Action, d Deps) error {
+	d.Log("apt: %s", join(a.Packages))
+	if a.PlatformSkip {
+		d.Warn("%s", a.SkipNote)
+		return nil
+	}
+	missing, err := missingPackages(a.Packages, d)
+	if err != nil {
+		return err
+	}
+	if len(missing) == 0 {
+		d.Log("all apt packages already installed")
+		return nil
+	}
+	d.Log("installing: %s", join(missing))
+	return d.AptInstall(missing)
+}
+
+func runServices(a Action, d Deps) error {
+	d.Log("services: %s", join(a.Packages))
+	if a.PlatformSkip {
+		d.Warn("%s", a.SkipNote)
+		return nil
+	}
+	missing, err := missingPackages(a.Packages, d)
+	if err != nil {
+		return err
+	}
+	if len(missing) > 0 {
+		d.Log("installing service packages: %s", join(missing))
+		if err := d.AptInstall(missing); err != nil {
+			return err
+		}
+	}
+	for _, svc := range a.Packages {
+		d.Log("enabling service: %s", svc)
+		if err := d.ServiceEnable(svc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runRuntime(a Action, repoDir string, d Deps) error {
+	d.Log("runtimes: pinned by %s", join(a.VersionFiles))
+	if _, err := d.LookPath("mise"); err != nil {
+		d.Warn("mise not found on PATH — skipping runtime install (repo pins %s)", join(a.VersionFiles))
+		return nil
+	}
+	d.Log("running: mise install")
+	if err := d.RunInDir(repoDir, "mise install"); err != nil {
+		return fmt.Errorf("mise install failed: %w", err)
+	}
+	return nil
+}
+
+func runDatabase(a Action, repoDir string, d Deps) error {
+	d.Log("database: template %q", a.DBTemplate)
+	exists, err := d.DBExists(a.DBTemplate)
+	if err != nil {
+		return err
+	}
+	if exists {
+		d.Log("template %q already exists — skipping", a.DBTemplate)
+		return nil
+	}
+
+	switch a.DBMode {
+	case DBModeSource:
+		d.Log("hydrating %q from source %q", a.DBTemplate, a.DBSource)
+		return d.HydrateFromSource(a.DBTemplate, a.DBSource)
+	case DBModeHydrate:
+		d.Log("creating empty template %q", a.DBTemplate)
+		if err := d.CreateDB(a.DBTemplate); err != nil {
+			return err
+		}
+		d.Log("running: %s", a.DBHydrate)
+		if err := d.RunInDir(repoDir, a.DBHydrate); err != nil {
+			return fmt.Errorf("hydrate command failed: %s: %w", a.DBHydrate, err)
+		}
+		return nil
+	default:
+		d.Log("creating empty template %q", a.DBTemplate)
+		if err := d.CreateDB(a.DBTemplate); err != nil {
+			return err
+		}
+		d.Warn("template %q created empty — worktree databases will be empty until a schema is loaded (set provision.database.source or provision.database.hydrate)", a.DBTemplate)
+		return nil
+	}
+}
+
+// missingPackages returns the subset of pkgs not already installed.
+func missingPackages(pkgs []string, d Deps) ([]string, error) {
+	var missing []string
+	for _, p := range pkgs {
+		ok, err := d.PackageInstalled(p)
+		if err != nil {
+			return nil, err
+		}
+		if !ok {
+			missing = append(missing, p)
+		}
+	}
+	return missing, nil
+}
+
+// PrintPlan writes the ordered plan without acting (--dry-run).
+func PrintPlan(w io.Writer, actions []Action) {
+	if len(actions) == 0 {
+		_, _ = fmt.Fprintln(w, "Nothing to provision.")
+		return
+	}
+	_, _ = fmt.Fprintln(w, "Provision plan (dry run):")
+	for _, a := range actions {
+		line := "  - " + a.Summary()
+		if a.PlatformSkip {
+			line += "  [skip: " + a.SkipNote + "]"
+		}
+		_, _ = fmt.Fprintln(w, line)
+	}
+	_, _ = fmt.Fprintln(w, "  (no changes made)")
+}
+
+func join(s []string) string { return strings.Join(s, " ") }

--- a/internal/provision/execute.go
+++ b/internal/provision/execute.go
@@ -35,6 +35,10 @@ type Deps struct {
 
 	// PackageInstalled reports whether an apt package is installed (dpkg -s).
 	PackageInstalled func(pkg string) (bool, error)
+	// AptUpdate refreshes the apt package indexes (sudo apt-get update). The
+	// executor calls it lazily, exactly once, immediately before the first real
+	// install of a run — see withLazyAptUpdate.
+	AptUpdate func() error
 	// AptInstall installs the given apt packages (sudo apt-get install -y).
 	AptInstall func(pkgs []string) error
 	// ServiceEnable enables and starts a systemd unit (systemctl enable --now).
@@ -101,12 +105,40 @@ func BuildPlan(cfg config.ProvisionConfig, repoDir string, goos string, fileExis
 // Run executes the plan in order, checking before acting. It returns on the
 // first real failure (platform skips and idempotent no-ops are not failures).
 func Run(actions []Action, repoDir string, d Deps) error {
+	d = withLazyAptUpdate(d)
 	for _, a := range actions {
 		if err := runAction(a, repoDir, d); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// withLazyAptUpdate wraps d.AptInstall so `apt-get update` runs exactly once
+// per provision run, lazily — immediately before the first real package
+// install (apt packages or service packages both route through AptInstall). A
+// fresh host has stale/empty package indexes, so without this the first install
+// fails with "Unable to locate package". A fully-idempotent re-run installs
+// nothing, so it never triggers the update: no-op runs stay fast and sudo-free.
+func withLazyAptUpdate(d Deps) Deps {
+	if d.AptInstall == nil {
+		return d
+	}
+	install := d.AptInstall
+	update := d.AptUpdate
+	updated := false
+	d.AptInstall = func(pkgs []string) error {
+		if !updated {
+			if update != nil {
+				if err := update(); err != nil {
+					return err
+				}
+			}
+			updated = true
+		}
+		return install(pkgs)
+	}
+	return d
 }
 
 func runAction(a Action, repoDir string, d Deps) error {

--- a/internal/provision/execute_test.go
+++ b/internal/provision/execute_test.go
@@ -1,0 +1,222 @@
+package provision
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/git-treeline/cli/internal/config"
+)
+
+// fakeSys records effect calls and answers probes from configured state.
+type fakeSys struct {
+	installed map[string]bool // apt packages present
+	dbs       map[string]bool // existing databases
+	misePath  bool
+
+	calls []string
+}
+
+func newFakeSys() *fakeSys {
+	return &fakeSys{installed: map[string]bool{}, dbs: map[string]bool{}}
+}
+
+func (f *fakeSys) deps(goos string) Deps {
+	return Deps{
+		GOOS:       goos,
+		FileExists: func(string) bool { return false },
+		LookPath: func(bin string) (string, error) {
+			if bin == "mise" && f.misePath {
+				return "/usr/bin/mise", nil
+			}
+			return "", errors.New("not found")
+		},
+		PackageInstalled: func(pkg string) (bool, error) { return f.installed[pkg], nil },
+		AptInstall: func(pkgs []string) error {
+			f.calls = append(f.calls, "apt-install:"+strings.Join(pkgs, ","))
+			for _, p := range pkgs {
+				f.installed[p] = true
+			}
+			return nil
+		},
+		ServiceEnable: func(name string) error {
+			f.calls = append(f.calls, "enable:"+name)
+			return nil
+		},
+		RunInDir: func(dir, command string) error {
+			f.calls = append(f.calls, "run:"+command)
+			return nil
+		},
+		DBExists: func(name string) (bool, error) { return f.dbs[name], nil },
+		CreateDB: func(name string) error {
+			f.calls = append(f.calls, "createdb:"+name)
+			f.dbs[name] = true
+			return nil
+		},
+		HydrateFromSource: func(template, env string) error {
+			f.calls = append(f.calls, "hydrate-source:"+template+"<-"+env)
+			f.dbs[template] = true
+			return nil
+		},
+		Log:  func(string, ...any) {},
+		Warn: func(string, ...any) {},
+	}
+}
+
+func (f *fakeSys) called(sub string) bool {
+	for _, c := range f.calls {
+		if c == sub {
+			return true
+		}
+	}
+	return false
+}
+
+func TestRun_Apt_InstallsOnlyMissing(t *testing.T) {
+	f := newFakeSys()
+	f.installed["libvips"] = true // already installed
+	actions := []Action{{Kind: ActionApt, Packages: []string{"libvips", "imagemagick"}}}
+	if err := Run(actions, "/repo", f.deps("linux")); err != nil {
+		t.Fatal(err)
+	}
+	if !f.called("apt-install:imagemagick") {
+		t.Errorf("expected only imagemagick installed, calls=%v", f.calls)
+	}
+	if f.called("apt-install:libvips,imagemagick") {
+		t.Errorf("should not reinstall libvips, calls=%v", f.calls)
+	}
+}
+
+func TestRun_Apt_AllInstalled_NoOp(t *testing.T) {
+	f := newFakeSys()
+	f.installed["libvips"] = true
+	actions := []Action{{Kind: ActionApt, Packages: []string{"libvips"}}}
+	if err := Run(actions, "/repo", f.deps("linux")); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.calls) != 0 {
+		t.Errorf("expected no effects, got %v", f.calls)
+	}
+}
+
+func TestRun_Apt_DarwinSkip_NoEffects(t *testing.T) {
+	f := newFakeSys()
+	actions := PlanConfig(config.ProvisionConfig{Present: true, Apt: []string{"libvips"}}, "darwin")
+	if err := Run(actions, "/repo", f.deps("darwin")); err != nil {
+		t.Fatal(err)
+	}
+	if len(f.calls) != 0 {
+		t.Errorf("darwin apt should make no effects, got %v", f.calls)
+	}
+}
+
+func TestRun_Services_InstallThenEnable(t *testing.T) {
+	f := newFakeSys()
+	actions := []Action{{Kind: ActionService, Packages: []string{"redis-server"}}}
+	if err := Run(actions, "/repo", f.deps("linux")); err != nil {
+		t.Fatal(err)
+	}
+	if !f.called("apt-install:redis-server") || !f.called("enable:redis-server") {
+		t.Errorf("expected install+enable, calls=%v", f.calls)
+	}
+	// enable must come after install.
+	if idxOf(f.calls, "enable:redis-server") < idxOf(f.calls, "apt-install:redis-server") {
+		t.Errorf("enable before install: %v", f.calls)
+	}
+}
+
+func TestRun_Services_AlreadyInstalled_EnableOnly(t *testing.T) {
+	f := newFakeSys()
+	f.installed["redis-server"] = true
+	actions := []Action{{Kind: ActionService, Packages: []string{"redis-server"}}}
+	if err := Run(actions, "/repo", f.deps("linux")); err != nil {
+		t.Fatal(err)
+	}
+	if f.called("apt-install:redis-server") {
+		t.Errorf("should not reinstall, calls=%v", f.calls)
+	}
+	if !f.called("enable:redis-server") {
+		t.Errorf("expected enable, calls=%v", f.calls)
+	}
+}
+
+func TestRun_Runtime_MisePresent_RunsInstall(t *testing.T) {
+	f := newFakeSys()
+	f.misePath = true
+	actions := []Action{{Kind: ActionRuntime, VersionFiles: []string{".ruby-version"}}}
+	if err := Run(actions, "/repo", f.deps("linux")); err != nil {
+		t.Fatal(err)
+	}
+	if !f.called("run:mise install") {
+		t.Errorf("expected mise install, calls=%v", f.calls)
+	}
+}
+
+func TestRun_Runtime_NoMise_Warns_NoError(t *testing.T) {
+	f := newFakeSys()
+	f.misePath = false
+	actions := []Action{{Kind: ActionRuntime, VersionFiles: []string{".ruby-version"}}}
+	if err := Run(actions, "/repo", f.deps("linux")); err != nil {
+		t.Fatal(err)
+	}
+	if f.called("run:mise install") {
+		t.Errorf("should not run mise when absent, calls=%v", f.calls)
+	}
+}
+
+func TestRun_Database_Exists_Skips(t *testing.T) {
+	f := newFakeSys()
+	f.dbs["app_dev"] = true
+	actions := []Action{{Kind: ActionDatabase, DBTemplate: "app_dev", DBMode: DBModeEmpty}}
+	if err := Run(actions, "/repo", f.deps("linux")); err != nil {
+		t.Fatal(err)
+	}
+	if f.called("createdb:app_dev") {
+		t.Errorf("should not create existing db, calls=%v", f.calls)
+	}
+}
+
+func TestRun_Database_SourceMode(t *testing.T) {
+	f := newFakeSys()
+	actions := []Action{{Kind: ActionDatabase, DBTemplate: "app_dev", DBMode: DBModeSource, DBSource: "production"}}
+	if err := Run(actions, "/repo", f.deps("linux")); err != nil {
+		t.Fatal(err)
+	}
+	if !f.called("hydrate-source:app_dev<-production") {
+		t.Errorf("expected source hydration, calls=%v", f.calls)
+	}
+}
+
+func TestRun_Database_HydrateMode_CreateThenCommand(t *testing.T) {
+	f := newFakeSys()
+	actions := []Action{{Kind: ActionDatabase, DBTemplate: "app_dev", DBMode: DBModeHydrate, DBHydrate: "bin/rails db:schema:load"}}
+	if err := Run(actions, "/repo", f.deps("linux")); err != nil {
+		t.Fatal(err)
+	}
+	if !f.called("createdb:app_dev") || !f.called("run:bin/rails db:schema:load") {
+		t.Errorf("expected create+hydrate, calls=%v", f.calls)
+	}
+	if idxOf(f.calls, "run:bin/rails db:schema:load") < idxOf(f.calls, "createdb:app_dev") {
+		t.Errorf("hydrate before create: %v", f.calls)
+	}
+}
+
+func TestRun_Database_EmptyMode_CreatesEmpty(t *testing.T) {
+	f := newFakeSys()
+	actions := []Action{{Kind: ActionDatabase, DBTemplate: "app_dev", DBMode: DBModeEmpty}}
+	if err := Run(actions, "/repo", f.deps("linux")); err != nil {
+		t.Fatal(err)
+	}
+	if !f.called("createdb:app_dev") {
+		t.Errorf("expected createdb, calls=%v", f.calls)
+	}
+}
+
+func idxOf(s []string, v string) int {
+	for i, x := range s {
+		if x == v {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/provision/execute_test.go
+++ b/internal/provision/execute_test.go
@@ -32,6 +32,10 @@ func (f *fakeSys) deps(goos string) Deps {
 			return "", errors.New("not found")
 		},
 		PackageInstalled: func(pkg string) (bool, error) { return f.installed[pkg], nil },
+		AptUpdate: func() error {
+			f.calls = append(f.calls, "apt-update")
+			return nil
+		},
 		AptInstall: func(pkgs []string) error {
 			f.calls = append(f.calls, "apt-install:"+strings.Join(pkgs, ","))
 			for _, p := range pkgs {
@@ -107,6 +111,44 @@ func TestRun_Apt_DarwinSkip_NoEffects(t *testing.T) {
 	}
 	if len(f.calls) != 0 {
 		t.Errorf("darwin apt should make no effects, got %v", f.calls)
+	}
+}
+
+func TestRun_AptUpdate_RunsOnceBeforeFirstInstall(t *testing.T) {
+	f := newFakeSys()
+	// Two install-triggering steps (apt packages + a service package) on a fresh
+	// host: update must run exactly once, before the first install.
+	actions := []Action{
+		{Kind: ActionApt, Packages: []string{"libvips"}},
+		{Kind: ActionService, Packages: []string{"redis-server"}},
+	}
+	if err := Run(actions, "/repo", f.deps("linux")); err != nil {
+		t.Fatal(err)
+	}
+	if got := count(f.calls, "apt-update"); got != 1 {
+		t.Fatalf("expected apt-update exactly once, got %d: %v", got, f.calls)
+	}
+	first := idxOf(f.calls, "apt-install:libvips")
+	if first < 0 || idxOf(f.calls, "apt-update") > first {
+		t.Errorf("apt-update must precede the first install: %v", f.calls)
+	}
+}
+
+func TestRun_AptUpdate_SkippedWhenNothingToInstall(t *testing.T) {
+	f := newFakeSys()
+	f.installed["libvips"] = true
+	f.installed["redis-server"] = true
+	// Everything already present: an idempotent re-run installs nothing, so the
+	// lazy update must never fire — no-op runs stay fast and sudo-free.
+	actions := []Action{
+		{Kind: ActionApt, Packages: []string{"libvips"}},
+		{Kind: ActionService, Packages: []string{"redis-server"}},
+	}
+	if err := Run(actions, "/repo", f.deps("linux")); err != nil {
+		t.Fatal(err)
+	}
+	if f.called("apt-update") {
+		t.Errorf("apt-update should not run when nothing is installed: %v", f.calls)
 	}
 }
 
@@ -219,4 +261,14 @@ func idxOf(s []string, v string) int {
 		}
 	}
 	return -1
+}
+
+func count(s []string, v string) int {
+	n := 0
+	for _, x := range s {
+		if x == v {
+			n++
+		}
+	}
+	return n
 }

--- a/internal/provision/plan.go
+++ b/internal/provision/plan.go
@@ -1,0 +1,135 @@
+// Package provision implements `gtl provision`: the repo-level, idempotent
+// answer to "what must be true on a host before gtl setup can succeed for this
+// repo." It reads the provision: section of .treeline.yml and brings a host up
+// to that declared baseline — system packages, services, language runtimes, and
+// the template database gtl clones worktree databases from.
+//
+// The package splits into a pure planner (config -> ordered actions, testable
+// as data) and an executor that runs each action through injectable seams
+// (Deps), checking before acting so every step is safe to re-run.
+package provision
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/git-treeline/cli/internal/config"
+)
+
+// ActionKind identifies what an Action provisions.
+type ActionKind string
+
+const (
+	ActionApt      ActionKind = "apt"
+	ActionService  ActionKind = "service"
+	ActionRuntime  ActionKind = "runtime"
+	ActionDatabase ActionKind = "database"
+)
+
+// DBMode describes how a template database is brought into existence.
+type DBMode string
+
+const (
+	// DBModeSource hydrates the template from a configured database.sources env
+	// (real data), reusing the same dump/restore path as `gtl db pull`.
+	DBModeSource DBMode = "source"
+	// DBModeHydrate creates an empty template then runs a shell command in the
+	// repo dir to fill it (e.g. bin/rails db:schema:load db:seed).
+	DBModeHydrate DBMode = "hydrate"
+	// DBModeEmpty creates an empty template with no data — worktree databases
+	// cloned from it will be empty until a schema is loaded.
+	DBModeEmpty DBMode = "empty"
+)
+
+// Action is one planned provisioning step. The pure planner fills the intent
+// (kind, payload, platform applicability); the executor decides at run time
+// whether the action is already satisfied and can be skipped.
+type Action struct {
+	Kind ActionKind
+
+	// Packages carries apt package names (ActionApt) or service package names
+	// (ActionService).
+	Packages []string
+
+	// Runtime fields.
+	VersionFiles []string // version files that triggered runtime provisioning
+
+	// Database fields.
+	DBTemplate string
+	DBMode     DBMode
+	DBSource   string // env name under database.sources (DBModeSource)
+	DBHydrate  string // shell command (DBModeHydrate)
+
+	// PlatformSkip is true when the current OS can't perform this action (apt
+	// and services are Linux-only). The executor prints the intent and moves on.
+	PlatformSkip bool
+	SkipNote     string
+}
+
+// Summary renders a one-line human description of the action's intent, used by
+// --dry-run and as the leading log line for each step.
+func (a Action) Summary() string {
+	switch a.Kind {
+	case ActionApt:
+		return "apt packages: " + strings.Join(a.Packages, " ")
+	case ActionService:
+		return "services: " + strings.Join(a.Packages, " ")
+	case ActionRuntime:
+		return "language runtimes via mise (" + strings.Join(a.VersionFiles, ", ") + ")"
+	case ActionDatabase:
+		switch a.DBMode {
+		case DBModeSource:
+			return fmt.Sprintf("template database %q from source %q", a.DBTemplate, a.DBSource)
+		case DBModeHydrate:
+			return fmt.Sprintf("template database %q via: %s", a.DBTemplate, a.DBHydrate)
+		default:
+			return fmt.Sprintf("template database %q (empty)", a.DBTemplate)
+		}
+	}
+	return string(a.Kind)
+}
+
+// PlanConfig derives the config-driven actions (apt, services, database) from a
+// parsed provision section, in execution order, marking platform-gated actions
+// for the given GOOS. It is pure: no filesystem, no probes. Runtime provisioning
+// is not config-driven (it follows the repo's version files) and is appended by
+// the executor via RuntimeAction.
+func PlanConfig(cfg config.ProvisionConfig, goos string) []Action {
+	var actions []Action
+	linux := goos == "linux"
+
+	if len(cfg.Apt) > 0 {
+		a := Action{Kind: ActionApt, Packages: cfg.Apt}
+		if !linux {
+			a.PlatformSkip = true
+			a.SkipNote = "apt is Linux-only; install these with your Mac package manager if needed"
+		}
+		actions = append(actions, a)
+	}
+
+	if len(cfg.Services) > 0 {
+		a := Action{Kind: ActionService, Packages: cfg.Services}
+		if !linux {
+			a.PlatformSkip = true
+			a.SkipNote = "systemd services are Linux-only; skipping on this host"
+		}
+		actions = append(actions, a)
+	}
+
+	if cfg.Database.Template != "" {
+		a := Action{Kind: ActionDatabase, DBTemplate: cfg.Database.Template}
+		switch {
+		case cfg.Database.Source != "":
+			a.DBMode = DBModeSource
+			a.DBSource = cfg.Database.Source
+		case cfg.Database.Hydrate != "":
+			a.DBMode = DBModeHydrate
+			a.DBHydrate = cfg.Database.Hydrate
+		default:
+			a.DBMode = DBModeEmpty
+		}
+		actions = append(actions, a)
+	}
+
+	return actions
+}

--- a/internal/provision/plan_test.go
+++ b/internal/provision/plan_test.go
@@ -1,0 +1,121 @@
+package provision
+
+import (
+	"testing"
+
+	"github.com/git-treeline/cli/internal/config"
+)
+
+func kinds(actions []Action) []ActionKind {
+	out := make([]ActionKind, len(actions))
+	for i, a := range actions {
+		out[i] = a.Kind
+	}
+	return out
+}
+
+func TestPlanConfig_OrderAptServicesDatabase(t *testing.T) {
+	cfg := config.ProvisionConfig{
+		Present:  true,
+		Apt:      []string{"libvips"},
+		Services: []string{"redis-server"},
+		Database: config.ProvisionDatabase{Template: "app_dev", Source: "production"},
+	}
+	got := kinds(PlanConfig(cfg, "linux"))
+	want := []ActionKind{ActionApt, ActionService, ActionDatabase}
+	if len(got) != len(want) {
+		t.Fatalf("kinds = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("kinds = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestPlanConfig_DarwinSkipsAptAndServices(t *testing.T) {
+	cfg := config.ProvisionConfig{
+		Present:  true,
+		Apt:      []string{"libvips"},
+		Services: []string{"redis-server"},
+	}
+	actions := PlanConfig(cfg, "darwin")
+	for _, a := range actions {
+		if a.Kind == ActionApt || a.Kind == ActionService {
+			if !a.PlatformSkip {
+				t.Errorf("%s should be PlatformSkip on darwin", a.Kind)
+			}
+		}
+	}
+}
+
+func TestPlanConfig_DatabaseModeSelection(t *testing.T) {
+	cases := []struct {
+		name string
+		db   config.ProvisionDatabase
+		want DBMode
+	}{
+		{"source wins", config.ProvisionDatabase{Template: "t", Source: "prod", Hydrate: "cmd"}, DBModeSource},
+		{"hydrate fallback", config.ProvisionDatabase{Template: "t", Hydrate: "cmd"}, DBModeHydrate},
+		{"empty last resort", config.ProvisionDatabase{Template: "t"}, DBModeEmpty},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actions := PlanConfig(config.ProvisionConfig{Present: true, Database: tc.db}, "linux")
+			if len(actions) != 1 || actions[0].Kind != ActionDatabase {
+				t.Fatalf("expected one database action, got %v", kinds(actions))
+			}
+			if actions[0].DBMode != tc.want {
+				t.Errorf("mode = %q, want %q", actions[0].DBMode, tc.want)
+			}
+		})
+	}
+}
+
+func TestPlanConfig_NoTemplateNoDatabaseAction(t *testing.T) {
+	cfg := config.ProvisionConfig{Present: true, Apt: []string{"x"}}
+	for _, a := range PlanConfig(cfg, "linux") {
+		if a.Kind == ActionDatabase {
+			t.Error("no database action expected without a template")
+		}
+	}
+}
+
+func TestBuildPlan_RuntimeInsertedBeforeDatabase(t *testing.T) {
+	cfg := config.ProvisionConfig{
+		Present:  true,
+		Apt:      []string{"libvips"},
+		Database: config.ProvisionDatabase{Template: "app_dev"},
+	}
+	fe := func(p string) bool { return hasSuffix(p, ".ruby-version") }
+	got := kinds(BuildPlan(cfg, "/repo", "linux", fe))
+	want := []ActionKind{ActionApt, ActionRuntime, ActionDatabase}
+	if len(got) != len(want) {
+		t.Fatalf("kinds = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("kinds = %v, want %v", got, want)
+		}
+	}
+}
+
+func TestBuildPlan_RuntimeAppendedWhenNoDatabase(t *testing.T) {
+	cfg := config.ProvisionConfig{Present: true, Apt: []string{"libvips"}}
+	fe := func(p string) bool { return hasSuffix(p, ".tool-versions") }
+	got := kinds(BuildPlan(cfg, "/repo", "linux", fe))
+	want := []ActionKind{ActionApt, ActionRuntime}
+	if len(got) != len(want) || got[1] != ActionRuntime {
+		t.Fatalf("kinds = %v, want %v", got, want)
+	}
+}
+
+func TestRuntimeAction_NoVersionFile_Nil(t *testing.T) {
+	if RuntimeAction("/repo", func(string) bool { return false }) != nil {
+		t.Error("expected nil runtime action when no version files present")
+	}
+}
+
+func hasSuffix(s, suffix string) bool {
+	return len(s) >= len(suffix) && s[len(s)-len(suffix):] == suffix
+}


### PR DESCRIPTION
## Summary

Adds `gtl provision`: the repo-level, idempotent answer to "what must be true on a host before `gtl setup` can succeed for this repo." Reads a new `provision:` section of `.treeline.yml` and brings a host up to that baseline — apt packages, systemd services, language runtimes (via mise), and the template database `gtl` clones worktree databases from.

```yaml
provision:
  apt: [libvips, imagemagick]      # system packages (Linux; needs sudo)
  services: [redis-server]         # apt-install + systemctl enable --now
  database:
    source: production             # hydrate the template from real data
    hydrate: "bin/rails db:schema:load db:seed"   # fallback command
```

## Design

- **Pure planner / injected executor split.** `PlanConfig`/`BuildPlan` turn config into an ordered list of `Action` data with zero I/O; the executor runs each action through injectable `Deps` seams (probes + effects), fully faked in tests.
- **Idempotent by construction.** Every step probes before acting (dpkg check, `DBExists`, mise-on-PATH), so re-running is a genuine no-op.
- **Reuses `gtl db pull` machinery** (`dbsource` resolution + `Puller`) for source hydration, so provision and pull share one path.
- Template database defaults to the top-level `database.template`, keeping a single source of truth for the name worktree DBs are cloned from.
- apt/services are Linux-only and skipped with a note on macOS. `--dry-run` prints the ordered plan without acting.

## Robustness

- `apt-get update` runs lazily before the first install so fresh hosts don't fail on stale package indexes.
- Non-interactive stdin wired for `sudo`/subcommands.
- Database provisioning is skipped for non-postgresql adapters; adapter-construction errors are surfaced.

## Tests

Planner ordering + platform gating, and executor coverage for install-only-missing, all-installed no-op, darwin skip, service install-then-enable, runtime present/absent, and all three DB modes (source / hydrate / empty) plus db-exists skip.