### PR TITLE
docs: cut 0.48.0 changelog heading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## [0.48.0]
 
 Follow-up hardening from the post-remediation deep audit:
 


### PR DESCRIPTION
Release prep for v0.48.0: rolls the Unreleased section (audit remediation #97 + post-audit hardening #98) under the 0.48.0 heading, per the MAINTAINING.md rule that the CHANGELOG stays in step with tags. Tag to follow once merged.