### PR TITLE
fix: run release hooks on every release path; --force overrides hook failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.49.0]
+
+- **`pre_release`/`post_release` hooks now fire on every release path.** Previously only `gtl release <path>` ran them; `gtl release --project`, `gtl release --all`, and `gtl prune --merged` skipped hooks entirely, so teardown tasks declared in `.treeline.yml` silently didn't run. Batch paths now run both hooks per worktree, before any destructive step and after teardown respectively. A failing `pre_release` hook skips only that worktree's release (with a warning) instead of blocking the rest of the batch; `post_release` failures warn, matching single-release semantics. Under `--force`, a `pre_release` failure warns and the release proceeds anyway (on all paths, single included) — hooks stay best-effort on the aggressive/non-interactive paths so a broken script can't hold resources hostage.
+
 ## [0.48.0]
 
 Follow-up hardening from the post-remediation deep audit:

--- a/README.md
+++ b/README.md
@@ -688,8 +688,8 @@ See [Framework examples](#framework-examples) for complete examples. Available f
 | `editor.theme` | Full IDE theme override (e.g. `"Monokai"`, `"GitHub Dark"`) |
 | `hooks.pre_setup` | Commands run before `commands.setup` — abort setup on failure |
 | `hooks.post_setup` | Commands run after all setup — warn on failure |
-| `hooks.pre_release` | Commands run before resource release — abort release on failure |
-| `hooks.post_release` | Commands run after resource release — warn on failure |
+| `hooks.pre_release` | Commands run before resource release, on every release path (`release`, `release --project/--all`, `prune --merged`) — a failure aborts that worktree's release, unless `--force` (warn and release anyway) |
+| `hooks.post_release` | Commands run after resource release, on every release path — warn on failure |
 | `hooks.<name>.auto` | `true` to run this hook on every fresh `gtl start` (default: `false`, requires `--with`) |
 | `hooks.<name>.pre_start` | Shell command(s) run before the supervisor launches — string or array of strings |
 | `hooks.<name>.post_stop` | Shell command(s) run in reverse order when the supervisor exits (Ctrl+C) — string or array |

--- a/cmd/release.go
+++ b/cmd/release.go
@@ -139,14 +139,12 @@ func runReleaseSingle(args []string) error {
 		return nil
 	}
 
-	pc := config.LoadProjectConfig(absPath)
-	hooks := pc.Hooks()
-	if cmds, ok := hooks["pre_release"]; ok && len(cmds) > 0 {
-		if err := setup.RunHookCommands("pre_release", cmds, absPath, func(f string, a ...any) {
-			fmt.Printf("==> "+f+"\n", a...)
-		}); err != nil {
+	hooks := config.LoadProjectConfig(absPath).Hooks()
+	if err := runReleaseHook("pre_release", hooks["pre_release"], absPath); err != nil {
+		if !releaseForce {
 			return fmt.Errorf("%w — release aborted", err)
 		}
+		fmt.Fprintf(os.Stderr, "Warning: %s — continuing (--force)\n", err)
 	}
 
 	if releaseDropDB {
@@ -178,12 +176,8 @@ func runReleaseSingle(args []string) error {
 		removeWorktreeDir(absPath, releaseForce)
 	}
 
-	if cmds, ok := hooks["post_release"]; ok && len(cmds) > 0 {
-		if err := setup.RunHookCommands("post_release", cmds, absPath, func(f string, a ...any) {
-			fmt.Printf("==> "+f+"\n", a...)
-		}); err != nil {
-			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
-		}
+	if err := runReleaseHook("post_release", hooks["post_release"], absPath); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
 	}
 
 	return nil
@@ -273,13 +267,18 @@ func runReleaseBatch(project string, all bool) error {
 }
 
 // releaseAndTeardown is the shared destructive tail of every batch release
-// path (release --project/--all, prune --merged): optional DB drop, registry
-// removal, runtime teardown (supervisor + hosts), and optional worktree dir
-// removal. Kept in one place so the two commands cannot drift on ordering —
-// DBs drop while the registry entries still exist (their metadata identifies
-// the DBs), and teardown runs after removal so the hosts re-sync reflects the
-// new route set.
+// path (release --project/--all, prune --merged): pre_release hooks, optional
+// DB drop, registry removal, runtime teardown (supervisor + hosts), optional
+// worktree dir removal, then post_release hooks. Kept in one place so the two
+// commands cannot drift on ordering — DBs drop while the registry entries
+// still exist (their metadata identifies the DBs), and teardown runs after
+// removal so the hosts re-sync reflects the new route set.
 func releaseAndTeardown(reg *registry.Registry, allocs []registry.Allocation, dropDB, removeWT, force bool) (int, error) {
+	allocs, postHooks := runPreReleaseHooks(allocs, force, runReleaseHook)
+	if len(allocs) == 0 {
+		return 0, nil
+	}
+
 	if dropDB {
 		formatAllocs := make([]format.Allocation, len(allocs))
 		for i, a := range allocs {
@@ -309,7 +308,65 @@ func releaseAndTeardown(reg *registry.Registry, allocs []registry.Allocation, dr
 			removeWorktreeDir(p, force)
 		}
 	}
+
+	for _, h := range postHooks {
+		if err := runReleaseHook("post_release", h.cmds, h.worktree); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: %s\n", err)
+		}
+	}
 	return count, nil
+}
+
+// releaseHookEntry pairs a worktree with its post_release commands, captured
+// before the release runs — the worktree dir (and the .treeline.yml declaring
+// the hook) may be gone by the time post_release fires.
+type releaseHookEntry struct {
+	worktree string
+	cmds     []string
+}
+
+// runPreReleaseHooks runs each allocation's pre_release hook before the batch
+// tail does anything destructive, matching single-release semantics where the
+// hook gates the release. A failing hook drops only that allocation from the
+// batch (its resources stay allocated) so one bad hook can't block the other
+// teardowns — unless force is set, in which case a hook failure warns and the
+// release proceeds anyway (a broken hook must not hold resources hostage on
+// the aggressive paths). The hook runner is injected so tests can observe
+// calls without spawning shells.
+func runPreReleaseHooks(allocs []registry.Allocation, force bool, runHook func(name string, cmds []string, dir string) error) ([]registry.Allocation, []releaseHookEntry) {
+	kept := make([]registry.Allocation, 0, len(allocs))
+	var post []releaseHookEntry
+	for _, a := range allocs {
+		wt := format.GetStr(format.Allocation(a), "worktree")
+		if wt == "" {
+			kept = append(kept, a)
+			continue
+		}
+		hooks := config.LoadProjectConfig(wt).Hooks()
+		if err := runHook("pre_release", hooks["pre_release"], wt); err != nil {
+			if !force {
+				fmt.Fprintf(os.Stderr, "Warning: %s — skipping release of %s\n", err, filepath.Base(wt))
+				continue
+			}
+			fmt.Fprintf(os.Stderr, "Warning: %s — continuing (--force)\n", err)
+		}
+		if cmds := hooks["post_release"]; len(cmds) > 0 {
+			post = append(post, releaseHookEntry{worktree: wt, cmds: cmds})
+		}
+		kept = append(kept, a)
+	}
+	return kept, post
+}
+
+// runReleaseHook runs one release lifecycle hook's commands in dir. An empty
+// command list is a no-op.
+func runReleaseHook(name string, cmds []string, dir string) error {
+	if len(cmds) == 0 {
+		return nil
+	}
+	return setup.RunHookCommands(name, cmds, dir, func(f string, a ...any) {
+		fmt.Printf("==> "+f+"\n", a...)
+	})
 }
 
 // teardownRuntimeState cleans up the non-registry runtime state left behind

--- a/cmd/release_test.go
+++ b/cmd/release_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/git-treeline/cli/internal/registry"
@@ -33,6 +34,115 @@ func TestTeardownRuntimeStateWith_StopsRightWorktrees(t *testing.T) {
 	}
 	if len(cleanArg) != 3 {
 		t.Errorf("hosts cleanup should receive the full released set, got %d", len(cleanArg))
+	}
+}
+
+// writeWorktreeHooks creates a temp worktree dir with a .treeline.yml
+// declaring the given release hooks and returns its path.
+func writeWorktreeHooks(t *testing.T, yml string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(yml), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// Batch releases must run each worktree's pre_release hook and capture its
+// post_release commands; allocations without a worktree pass through untouched.
+func TestRunPreReleaseHooks_RunsHooksPerWorktree(t *testing.T) {
+	wt := writeWorktreeHooks(t, "hooks:\n  pre_release:\n    - echo pre\n  post_release:\n    - echo post\n")
+	allocs := []registry.Allocation{
+		{"worktree": wt, "project": "a"},
+		{"project": "no-path"},
+	}
+
+	type call struct {
+		name string
+		cmds []string
+		dir  string
+	}
+	var calls []call
+	kept, post := runPreReleaseHooks(allocs, false, func(name string, cmds []string, dir string) error {
+		calls = append(calls, call{name, cmds, dir})
+		return nil
+	})
+
+	if len(kept) != 2 {
+		t.Fatalf("expected both allocations kept, got %d", len(kept))
+	}
+	if len(calls) != 1 || calls[0].name != "pre_release" || calls[0].dir != wt {
+		t.Fatalf("expected one pre_release call for %s, got %+v", wt, calls)
+	}
+	if len(calls[0].cmds) != 1 || calls[0].cmds[0] != "echo pre" {
+		t.Errorf("expected pre_release commands from .treeline.yml, got %v", calls[0].cmds)
+	}
+	if len(post) != 1 || post[0].worktree != wt || len(post[0].cmds) != 1 || post[0].cmds[0] != "echo post" {
+		t.Errorf("expected post_release commands captured for %s, got %+v", wt, post)
+	}
+}
+
+// A failing pre_release hook must drop only that allocation from the batch —
+// the others still release — and its post_release hook must not be captured.
+func TestRunPreReleaseHooks_FailureSkipsOnlyThatWorktree(t *testing.T) {
+	bad := writeWorktreeHooks(t, "hooks:\n  pre_release:\n    - exit 1\n  post_release:\n    - echo post\n")
+	good := writeWorktreeHooks(t, "hooks:\n  pre_release:\n    - echo pre\n")
+	allocs := []registry.Allocation{
+		{"worktree": bad, "project": "bad"},
+		{"worktree": good, "project": "good"},
+	}
+
+	kept, post := runPreReleaseHooks(allocs, false, func(name string, cmds []string, dir string) error {
+		if dir == bad {
+			return os.ErrPermission
+		}
+		return nil
+	})
+
+	if len(kept) != 1 || kept[0]["worktree"] != good {
+		t.Fatalf("expected only the good allocation kept, got %v", kept)
+	}
+	if len(post) != 0 {
+		t.Errorf("failed worktree's post_release must not be captured, got %+v", post)
+	}
+}
+
+// With force, a failing pre_release hook must warn but not block the release —
+// the allocation stays in the batch and its post_release hook still runs.
+func TestRunPreReleaseHooks_ForceOverridesFailure(t *testing.T) {
+	bad := writeWorktreeHooks(t, "hooks:\n  pre_release:\n    - exit 1\n  post_release:\n    - echo post\n")
+	allocs := []registry.Allocation{
+		{"worktree": bad, "project": "bad"},
+	}
+
+	kept, post := runPreReleaseHooks(allocs, true, func(name string, cmds []string, dir string) error {
+		return os.ErrPermission
+	})
+
+	if len(kept) != 1 || kept[0]["worktree"] != bad {
+		t.Fatalf("force must keep the allocation despite the hook failure, got %v", kept)
+	}
+	if len(post) != 1 || post[0].worktree != bad {
+		t.Errorf("post_release must still be captured under force, got %+v", post)
+	}
+}
+
+// Worktrees with no .treeline.yml (or a missing dir) must release normally.
+func TestRunPreReleaseHooks_NoConfigIsNoop(t *testing.T) {
+	allocs := []registry.Allocation{
+		{"worktree": filepath.Join(t.TempDir(), "gone"), "project": "a"},
+	}
+	kept, post := runPreReleaseHooks(allocs, false, func(name string, cmds []string, dir string) error {
+		if len(cmds) != 0 {
+			t.Errorf("expected no hook commands without config, got %v", cmds)
+		}
+		return nil
+	})
+	if len(kept) != 1 {
+		t.Errorf("expected allocation kept, got %d", len(kept))
+	}
+	if len(post) != 0 {
+		t.Errorf("expected no post hooks, got %+v", post)
 	}
 }
 

--- a/test/e2e/lifecycle_test.go
+++ b/test/e2e/lifecycle_test.go
@@ -167,7 +167,10 @@ func main() {
 	gitInit(t, repo, env)
 
 	// --- Minimal .treeline.yml: a single port, an env file, and a start
-	// command that binds the allocated port via the compiled port binder. ---
+	// command that binds the allocated port via the compiled port binder.
+	// The release hooks leave marker files so STEP 6 can assert they fired;
+	// pre_release deliberately fails after its marker so the same step also
+	// proves --force releases anyway instead of aborting on a broken hook. ---
 	treeline := "" +
 		"project: e2elifecycle\n" +
 		"port_count: 1\n" +
@@ -176,7 +179,13 @@ func main() {
 		"  PORT: \"{port}\"\n" +
 		"  APP_URL: \"http://localhost:{port}\"\n" +
 		"commands:\n" +
-		"  start: " + binder + " {port}\n"
+		"  start: " + binder + " {port}\n" +
+		"hooks:\n" +
+		"  pre_release:\n" +
+		"    - touch pre_release.ran\n" +
+		"    - exit 7\n" +
+		"  post_release:\n" +
+		"    - touch post_release.ran\n"
 	if err := os.WriteFile(filepath.Join(repo, ".treeline.yml"), []byte(treeline), 0o644); err != nil {
 		t.Fatalf("writing .treeline.yml: %v", err)
 	}
@@ -403,7 +412,15 @@ func main() {
 	case <-time.After(15 * time.Second):
 		t.Fatalf("backgrounded gtl start did not exit after release --force shut its supervisor down")
 	}
-	t.Logf("STEP 6 ok: release --force removed allocation and stopped the supervisor")
+	// Release hooks: pre_release ran (marker exists) and its deliberate
+	// failure did not block the forced release; post_release ran after.
+	if _, statErr := os.Stat(filepath.Join(repo, "pre_release.ran")); statErr != nil {
+		t.Fatalf("pre_release hook did not run during release --force: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(repo, "post_release.ran")); statErr != nil {
+		t.Fatalf("post_release hook did not run during release --force: %v", statErr)
+	}
+	t.Logf("STEP 6 ok: release --force removed allocation, stopped the supervisor, and ran release hooks despite pre_release failure")
 }
 
 // --- helpers ---


### PR DESCRIPTION
## Summary

- `pre_release`/`post_release` hooks now fire on **every** release path. Previously only single-path `gtl release <path>` ran them; `release --project`, `release --all`, and `prune --merged` skipped hooks entirely, so teardown tasks declared in `.treeline.yml` silently didn't run.
- Batch paths run both hooks per worktree through the shared `releaseAndTeardown` tail: `pre_release` before any destructive step, `post_release` after teardown. Post commands are captured up front because `--remove-worktree` can delete the `.treeline.yml` that declares them.
- **Failure semantics:** a failing `pre_release` skips only that worktree in a batch (aborts in single mode). Under `--force`, the failure warns and the release proceeds anyway on all paths — hooks are a gate in normal use, best-effort on the aggressive/non-interactive paths (Conductor archive, forced prune), so a broken hook script can't hold resources hostage.

## Testing

- New unit tests for `runPreReleaseHooks`: per-worktree execution with commands parsed from real `.treeline.yml` files, failure-skips-only-that-worktree, force override, and the no-config case.
- The e2e lifecycle test now declares release hooks whose `pre_release` deliberately fails after leaving a marker file; STEP 6 asserts through the real binary that both hooks fired and `--force` proceeded past the failure.
- `go test ./...`, `go vet`, and the tagged e2e suite all pass.