### PR TITLE
gtl new: honor worktree_base config for default base branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.50.0]
+
+- **`worktree_base` config field sets the default base branch for `gtl new`.** Repos whose start-from branch differs from their merge-into branch (e.g. `develop` vs `main`) can now declare `worktree_base: develop` in `.treeline.yml` and skip `--base` on every `gtl new`. Resolution order: `--base` flag → `worktree_base` config → current branch → `main`. Distinct from `merge_target`, which controls what `gtl prune --merged` checks against.
+
 ## [0.49.0]
 
 - **`pre_release`/`post_release` hooks now fire on every release path.** Previously only `gtl release <path>` ran them; `gtl release --project`, `gtl release --all`, and `gtl prune --merged` skipped hooks entirely, so teardown tasks declared in `.treeline.yml` silently didn't run. Batch paths now run both hooks per worktree, before any destructive step and after teardown respectively. A failing `pre_release` hook skips only that worktree's release (with a warning) instead of blocking the rest of the batch; `post_release` failures warn, matching single-release semantics. Under `--force`, a `pre_release` failure warns and the release proceeds anyway (on all paths, single included) — hooks stay best-effort on the aggressive/non-interactive paths so a broken script can't hold resources hostage.

--- a/cmd/new.go
+++ b/cmd/new.go
@@ -133,11 +133,7 @@ Otherwise a new branch is created from --base (or the current branch).`,
 			if existing {
 				fmt.Printf("[dry-run] Would check out existing branch '%s'\n", branch)
 			} else {
-				base := newBase
-				if base == "" {
-					base = "(current branch)"
-				}
-				fmt.Printf("[dry-run] Would create new branch '%s' from %s\n", branch, base)
+				fmt.Printf("[dry-run] Would create new branch '%s' from %s\n", branch, resolveBase(pc))
 			}
 			fmt.Printf("[dry-run] Worktree path: %s\n", wtPath)
 			fmt.Println("[dry-run] Would run: gtl setup")
@@ -154,13 +150,7 @@ Otherwise a new branch is created from --base (or the current branch).`,
 				return err
 			}
 		} else {
-			base := newBase
-			if base == "" {
-				base = worktree.CurrentBranch(".")
-				if base == "" {
-					base = "main"
-				}
-			}
+			base := resolveBase(pc)
 			fmt.Println(style.Actionf("Creating branch '%s' from '%s'", branch, base))
 			if err := worktree.Create(wtPath, branch, true, base); err != nil {
 				return err
@@ -194,6 +184,22 @@ Otherwise a new branch is created from --base (or the current branch).`,
 
 		return nil
 	},
+}
+
+// resolveBase picks the base branch for a new worktree: an explicit --base
+// wins, then the repo's worktree_base config, then the current branch, then
+// "main" as a last resort.
+func resolveBase(pc *config.ProjectConfig) string {
+	if newBase != "" {
+		return newBase
+	}
+	if wb := pc.WorktreeBase(); wb != "" {
+		return wb
+	}
+	if cb := worktree.CurrentBranch("."); cb != "" {
+		return cb
+	}
+	return "main"
 }
 
 func execInWorktree(dir, command string) error {
@@ -234,11 +240,7 @@ func createWorktreeOnly(mainRepo, branch string, uc *config.UserConfig, pc *conf
 		if existing {
 			fmt.Printf("[dry-run] Would check out existing branch '%s'\n", branch)
 		} else {
-			base := newBase
-			if base == "" {
-				base = "(current branch)"
-			}
-			fmt.Printf("[dry-run] Would create new branch '%s' from %s\n", branch, base)
+			fmt.Printf("[dry-run] Would create new branch '%s' from %s\n", branch, resolveBase(pc))
 		}
 		fmt.Printf("[dry-run] Worktree path: %s\n", wtPath)
 		fmt.Println("[dry-run] No allocation (non-server project)")
@@ -252,13 +254,7 @@ func createWorktreeOnly(mainRepo, branch string, uc *config.UserConfig, pc *conf
 			return err
 		}
 	} else {
-		base := newBase
-		if base == "" {
-			base = worktree.CurrentBranch(".")
-			if base == "" {
-				base = "main"
-			}
-		}
+		base := resolveBase(pc)
 		fmt.Println(style.Actionf("Creating branch '%s' from '%s'", branch, base))
 		if err := worktree.Create(wtPath, branch, true, base); err != nil {
 			return err

--- a/internal/config/project.go
+++ b/internal/config/project.go
@@ -67,8 +67,9 @@ var ProjectDefaults = map[string]any{
 	"env":          map[string]any{},
 	"hooks":        map[string]any{},
 	"commands":     map[string]any{},
-	"editor":       map[string]any{},
-	"merge_target": "",
+	"editor":        map[string]any{},
+	"merge_target":  "",
+	"worktree_base": "",
 }
 
 type ProjectConfig struct {
@@ -626,6 +627,17 @@ func (pc *ProjectConfig) MergeTarget() string {
 	return ""
 }
 
+// WorktreeBase returns the default base branch new worktrees are created from
+// when `gtl new` is invoked without an explicit --base. Empty means fall back
+// to the current branch. This is the branch you start work from, distinct from
+// merge_target (the branch you merge back into / prune against).
+func (pc *ProjectConfig) WorktreeBase() string {
+	if v, ok := pc.Data["worktree_base"].(string); ok {
+		return v
+	}
+	return ""
+}
+
 func (pc *ProjectConfig) Exists() bool {
 	_, err := os.Stat(pc.configPath())
 	return err == nil
@@ -911,7 +923,8 @@ func (pc *ProjectConfig) configPath() string {
 var projectKnownKeys = map[string]bool{
 	"project": true, "port_count": true, "env_file": true, "database": true,
 	"copy_files": true, "env": true, "hooks": true, "commands": true,
-	"editor": true, "merge_target": true, "aliases": true, "related_repos": true,
+	"editor": true, "merge_target": true, "worktree_base": true,
+	"aliases": true, "related_repos": true,
 	"provision": true,
 	// Legacy keys accepted during migration
 	"default_branch": true, "setup_commands": true, "start_command": true,

--- a/internal/config/project_test.go
+++ b/internal/config/project_test.go
@@ -212,6 +212,28 @@ func TestProjectConfig_MergeTarget_Empty(t *testing.T) {
 	}
 }
 
+func TestProjectConfig_WorktreeBase(t *testing.T) {
+	dir := t.TempDir()
+	yml := `project: myapp
+worktree_base: develop
+`
+	_ = os.WriteFile(filepath.Join(dir, ".treeline.yml"), []byte(yml), 0o644)
+	pc := LoadProjectConfig(dir)
+
+	if pc.WorktreeBase() != "develop" {
+		t.Errorf("expected develop, got %s", pc.WorktreeBase())
+	}
+}
+
+func TestProjectConfig_WorktreeBase_Empty(t *testing.T) {
+	dir := t.TempDir()
+	pc := LoadProjectConfig(dir)
+
+	if pc.WorktreeBase() != "" {
+		t.Errorf("expected empty string, got %s", pc.WorktreeBase())
+	}
+}
+
 // --- env_file format tests ---
 
 func TestEnvFile_StringShorthand(t *testing.T) {

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -145,6 +145,7 @@ func rails(project, templateDB string, det *detect.Result) string {
 
 	if det.MergeTarget == "" {
 		b.WriteString("\n# merge_target: develop            # branch that prune --merged checks against\n")
+		b.WriteString("# worktree_base: develop          # branch new worktrees start from (default: current branch)\n")
 	}
 
 	writeHooksComment(&b)
@@ -372,6 +373,7 @@ func writeMergeTarget(b *strings.Builder, det *detect.Result) {
 	if det.MergeTarget != "" && det.MergeTarget != "main" {
 		fmt.Fprintf(b, "merge_target: %s\n", det.MergeTarget)
 	}
+	b.WriteString("# worktree_base: develop          # branch new worktrees start from (default: current branch)\n")
 }
 
 // PortHint returns framework-specific guidance on wiring the allocated PORT


### PR DESCRIPTION
## Summary

- Adds `worktree_base` project-config field to `.treeline.yml`: the default base branch `gtl new` creates worktrees from when `--base` isn't passed
- Resolution order: `--base` flag → `worktree_base` config → current branch → `main`
- Distinct from `merge_target` (merge-into / prune-against); this is the branch you *start work from*
- Adds accessor `WorktreeBase()`, default in `ProjectDefaults`, entry in `projectKnownKeys`, and template hint

## Test plan

- [ ] `worktree_base: develop` in `.treeline.yml` → `gtl new feature/foo` creates worktree from `develop`
- [ ] `--base main` overrides `worktree_base`
- [ ] No `worktree_base` set → falls back to current branch then `main` (existing behavior)
- [ ] `project_test.go` unit tests for `WorktreeBase()`