### PR TITLE
fix: resolve origin/HEAD for db template update instead of hardcoding main

### DIFF
--- a/cmd/db_template.go
+++ b/cmd/db_template.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/git-treeline/cli/internal/config"
 	"github.com/git-treeline/cli/internal/worktree"
@@ -49,7 +50,7 @@ updated template.`,
 
 		mergeTarget := pc.MergeTarget()
 		if mergeTarget == "" {
-			mergeTarget = "main"
+			mergeTarget = resolveRemoteDefaultBranch(mainRepo)
 		}
 
 		if err := checkCleanWorktree(mainRepo); err != nil {
@@ -80,6 +81,25 @@ updated template.`,
 		fmt.Println("==> Template database updated. Run 'gtl db reset' in any worktree to re-clone.")
 		return nil
 	},
+}
+
+// resolveRemoteDefaultBranch reads origin/HEAD to find the remote's default
+// branch name. Falls back to "main" if the symbolic ref is absent or unset
+// (e.g. remote added manually, shallow clone, or stale after a branch rename).
+func resolveRemoteDefaultBranch(dir string) string {
+	cmd := exec.Command("git", "symbolic-ref", "refs/remotes/origin/HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		return "main"
+	}
+	// output is "refs/remotes/origin/<branch>\n"
+	ref := strings.TrimSpace(string(out))
+	const prefix = "refs/remotes/origin/"
+	if strings.HasPrefix(ref, prefix) {
+		return ref[len(prefix):]
+	}
+	return "main"
 }
 
 // checkCleanWorktree returns an error if the git working tree at dir has

--- a/cmd/db_template_test.go
+++ b/cmd/db_template_test.go
@@ -70,3 +70,52 @@ func TestCheckCleanWorktree_UntrackedFilesIgnored(t *testing.T) {
 		t.Errorf("expected untracked files to be ignored, got error: %v", err)
 	}
 }
+
+func TestResolveRemoteDefaultBranch_NoRemote(t *testing.T) {
+	dir := t.TempDir()
+	gitInit(t, dir)
+
+	// No remote configured — must fall back to "main"
+	if got := resolveRemoteDefaultBranch(dir); got != "main" {
+		t.Errorf("expected \"main\" with no remote, got %q", got)
+	}
+}
+
+func TestResolveRemoteDefaultBranch_Main(t *testing.T) {
+	remote := t.TempDir()
+	gitInit(t, remote)
+
+	local := t.TempDir()
+	if out, err := exec.Command("git", "clone", remote, local).CombinedOutput(); err != nil {
+		t.Fatalf("git clone: %s", out)
+	}
+
+	if got := resolveRemoteDefaultBranch(local); got != "master" && got != "main" {
+		t.Errorf("unexpected branch %q", got)
+	}
+}
+
+func TestResolveRemoteDefaultBranch_NonMainBranch(t *testing.T) {
+	remote := t.TempDir()
+	// Init remote with "trunk" as the default branch
+	cmds := [][]string{
+		{"git", "init", "--initial-branch=trunk", remote},
+		{"git", "-C", remote, "config", "user.email", "test@example.com"},
+		{"git", "-C", remote, "config", "user.name", "Test"},
+		{"git", "-C", remote, "commit", "--allow-empty", "-m", "init"},
+	}
+	for _, args := range cmds {
+		if out, err := exec.Command(args[0], args[1:]...).CombinedOutput(); err != nil {
+			t.Skipf("git does not support --initial-branch: %s", out)
+		}
+	}
+
+	local := t.TempDir()
+	if out, err := exec.Command("git", "clone", remote, local).CombinedOutput(); err != nil {
+		t.Fatalf("git clone: %s", out)
+	}
+
+	if got := resolveRemoteDefaultBranch(local); got != "trunk" {
+		t.Errorf("expected \"trunk\", got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

- `gtl db template update` was hardcoding `"main"` as the pull target when no `merge_target` is set in `.treeline.yml`
- This broke repos whose default branch is `master`, `trunk`, etc.
- Now reads `git symbolic-ref refs/remotes/origin/HEAD` to discover the remote's actual default branch; falls back to `"main"` only when that ref is absent (manual remote add, shallow clone, stale after rename)

## Test plan

- [ ] `TestResolveRemoteDefaultBranch_NoRemote` — no remote configured → falls back to `"main"`
- [ ] `TestResolveRemoteDefaultBranch_Main` — cloned repo → resolves to the real default branch
- [ ] `TestResolveRemoteDefaultBranch_NonMainBranch` — remote initialized with `trunk` → resolves to `"trunk"`