### PR TITLE
fix: make router lifecycle operations reliable instead of adding verification layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.51.0]
+
+- **`gtl serve install` and `gtl serve restart` no longer report failure on healthy routers.** Two structural fixes to the service lifecycle (macOS + Linux). Install now compares the rendered service definition against what's on disk: when unchanged (the Homebrew-upgrade case) it restarts via `kickstart`/`systemctl restart` instead of `bootout`+`bootstrap`, sidestepping launchd's asynchronous deregistration race that produced false `exit status 5` failures. When the definition did change, the reload waits for launchd to actually drop the old registration (polling, not fixed sleeps) before bootstrapping, and bootstrap failures now carry launchd's reason string instead of a bare exit code. Success everywhere — install, restart, and doctor's auto-fix — is now gated on the router answering health checks, not merely its process starting, with the deadline sized to real TLS/route-hydration startup (30s interactive, 10s under `--if-installed` so the Homebrew hook still fails fast).
+
 ## [0.50.0]
 
 - **`worktree_base` config field sets the default base branch for `gtl new`.** Repos whose start-from branch differs from their merge-into branch (e.g. `develop` vs `main`) can now declare `worktree_base: develop` in `.treeline.yml` and skip `--base` on every `gtl new`. Resolution order: `--base` flag → `worktree_base` config → current branch → `main`. Distinct from `merge_target`, which controls what `gtl prune --merged` checks against.

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -467,7 +467,7 @@ func runAutoFix(a doctor.FixAction) error { return runAutoFixFn(a) }
 func runAutoFixDefault(a doctor.FixAction) error {
 	switch a {
 	case doctor.FixServeRestart:
-		return service.Bounce(service.DefaultBounceTimeout)
+		return service.Bounce(config.LoadUserConfig("").RouterPort(), service.DefaultReadyTimeout)
 	case doctor.FixReloadPF:
 		return service.ReloadPortForward()
 	case doctor.FixPrune:

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -9,7 +9,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/git-treeline/cli/internal/config"
 	"github.com/git-treeline/cli/internal/confirm"
@@ -89,17 +88,17 @@ should not be an error).`,
 			return nil
 		}
 		fmt.Println(style.Actionf("Restarting router service..."))
-		if err := service.Bounce(service.DefaultBounceTimeout); err != nil {
+		routerPort := config.LoadUserConfig("").RouterPort()
+		// Tooling callers (Homebrew post_install) should fail fast rather
+		// than block the package manager on a genuinely broken start.
+		wait := service.DefaultReadyTimeout
+		if serveRestartIfInstalled {
+			wait = service.HookReadyTimeout
+		}
+		if err := service.Bounce(routerPort, wait); err != nil {
 			return cliErr(cmd, &CliError{
 				Message: fmt.Sprintf("Could not restart router: %v", err),
 				Hint:    "If this persists, run 'gtl serve install' for a full reset.",
-			})
-		}
-		routerPort := config.LoadUserConfig("").RouterPort()
-		if err := service.WaitRouterResponding(routerPort, 5*time.Second); err != nil {
-			return cliErr(cmd, &CliError{
-				Message: fmt.Sprintf("Router restarted but is not answering health checks: %v", err),
-				Hint:    "Check the router logs, or run 'gtl serve install' for a full reset.",
 			})
 		}
 		fmt.Println(style.Dimf("Router restarted and responding (running %s).", Version))

--- a/internal/service/bounce_test.go
+++ b/internal/service/bounce_test.go
@@ -36,9 +36,25 @@ func withFakeRunCmd(t *testing.T, runErr map[string]error) *[]string {
 		return nil
 	}
 	runCmdOutput = func(name string, args ...string) ([]byte, error) {
+		joined := name + " " + strings.Join(args, " ")
+		calls = append(calls, joined)
+		for prefix, err := range runErr {
+			if strings.HasPrefix(joined, prefix) {
+				return nil, err
+			}
+		}
 		return nil, nil
 	}
 	return &calls
+}
+
+// withFakeHealth stubs the health-poll seam so lifecycle tests don't need a
+// live HTTP listener answering /_treeline/health.
+func withFakeHealth(t *testing.T) {
+	t.Helper()
+	orig := waitRouterRespondingFn
+	t.Cleanup(func() { waitRouterRespondingFn = orig })
+	waitRouterRespondingFn = func(int, time.Duration) error { return nil }
 }
 
 // withFakeClock replaces nowFn / sleepFn so wait loops complete without real
@@ -80,6 +96,7 @@ func TestBounce_LaunchAgent_Kickstart_Success(t *testing.T) {
 	}
 	versionPath := withTempVersionFile(t)
 	withFakeClock(t)
+	withFakeHealth(t)
 
 	// Pre-populate version file with a known mtime, set to "before" the
 	// fake clock so any later write counts as fresh.
@@ -104,7 +121,7 @@ func TestBounce_LaunchAgent_Kickstart_Success(t *testing.T) {
 		return err
 	}
 
-	if err := Bounce(2 * time.Second); err != nil {
+	if err := Bounce(3001, 2*time.Second); err != nil {
 		t.Fatalf("Bounce: %v", err)
 	}
 
@@ -143,30 +160,32 @@ func TestBounce_LaunchAgent_FallsBackToBootstrap_WhenNotLoaded(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	withFakeHealth(t)
 	// `launchctl print` returns error → not loaded; bootstrap path runs.
+	// `launchctl list` returns error → label already deregistered, so the
+	// bootout poll exits immediately.
 	calls := withFakeRunCmd(t, map[string]error{
 		"launchctl print": errors.New("service not loaded"),
+		"launchctl list":  errors.New("could not find service"),
 	})
 
 	// Have bootstrap "succeed" and write the version file.
-	origRun := runCmd
-	runCmd = func(name string, args ...string) error {
-		if err := origRun(name, args...); err != nil {
-			return err
-		}
-		if len(args) > 0 && args[0] == "bootstrap" {
+	origOut := runCmdOutput
+	runCmdOutput = func(name string, args ...string) ([]byte, error) {
+		out, err := origOut(name, args...)
+		if err == nil && len(args) > 0 && args[0] == "bootstrap" {
 			t := nowFn().Add(50 * time.Millisecond)
 			_ = os.WriteFile(versionPath, []byte("9.9.9"), 0o644)
 			_ = os.Chtimes(versionPath, t, t)
 		}
-		return nil
+		return out, err
 	}
 
-	if err := Bounce(2 * time.Second); err != nil {
+	if err := Bounce(3001, 2*time.Second); err != nil {
 		t.Fatalf("Bounce: %v", err)
 	}
 
-	wantSeq := []string{"launchctl print", "launchctl bootout", "launchctl bootstrap"}
+	wantSeq := []string{"launchctl print", "launchctl bootout", "launchctl list", "launchctl bootstrap"}
 	for i, want := range wantSeq {
 		if i >= len(*calls) || !strings.Contains((*calls)[i], want) {
 			t.Fatalf("call %d: want prefix %q, got %v", i, want, *calls)
@@ -188,7 +207,7 @@ func TestBounce_LaunchAgent_Times_Out_When_Version_Not_Updated(t *testing.T) {
 	withFakeClock(t)
 	withFakeRunCmd(t, nil) // print + kickstart both succeed; nothing writes version file
 
-	err := Bounce(500 * time.Millisecond)
+	err := Bounce(3001, 500*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected timeout error, got nil")
 	}
@@ -207,7 +226,7 @@ func TestBounce_LaunchAgent_Surfaces_Kickstart_Failure(t *testing.T) {
 		"launchctl kickstart": errors.New("Could not find service"),
 	})
 
-	err := Bounce(2 * time.Second)
+	err := Bounce(3001, 2*time.Second)
 	if err == nil {
 		t.Fatal("expected error, got nil")
 	}
@@ -222,6 +241,7 @@ func TestBounce_Systemd_RestartUnit(t *testing.T) {
 	}
 	versionPath := withTempVersionFile(t)
 	withFakeClock(t)
+	withFakeHealth(t)
 
 	calls := withFakeRunCmd(t, nil)
 	origRun := runCmd
@@ -235,7 +255,7 @@ func TestBounce_Systemd_RestartUnit(t *testing.T) {
 		return err
 	}
 
-	if err := Bounce(2 * time.Second); err != nil {
+	if err := Bounce(3001, 2*time.Second); err != nil {
 		t.Fatalf("Bounce: %v", err)
 	}
 	if len(*calls) == 0 || !strings.Contains((*calls)[0], "systemctl --user restart") {
@@ -258,29 +278,31 @@ func TestReload_LaunchAgent_BootoutThenBootstrap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	calls := withFakeRunCmd(t, nil)
-	origRun := runCmd
-	runCmd = func(name string, args ...string) error {
-		err := origRun(name, args...)
+	withFakeHealth(t)
+	// Label deregisters immediately, so the bootout poll exits on its first
+	// probe.
+	calls := withFakeRunCmd(t, map[string]error{
+		"launchctl list": errors.New("could not find service"),
+	})
+	origOut := runCmdOutput
+	runCmdOutput = func(name string, args ...string) ([]byte, error) {
+		out, err := origOut(name, args...)
 		if err == nil && len(args) > 0 && args[0] == "bootstrap" {
 			t := nowFn().Add(50 * time.Millisecond)
 			_ = os.WriteFile(versionPath, []byte("9.9.9"), 0o644)
 			_ = os.Chtimes(versionPath, t, t)
 		}
-		return err
+		return out, err
 	}
 
-	if err := Reload(2 * time.Second); err != nil {
+	if err := Reload(3001, 2*time.Second); err != nil {
 		t.Fatalf("Reload: %v", err)
 	}
-	if len(*calls) < 2 {
-		t.Fatalf("expected at least 2 calls (bootout, bootstrap), got %d", len(*calls))
-	}
-	if !strings.Contains((*calls)[0], "bootout") {
-		t.Errorf("first call should be bootout, got %q", (*calls)[0])
-	}
-	if !strings.Contains((*calls)[1], "bootstrap") {
-		t.Errorf("second call should be bootstrap, got %q", (*calls)[1])
+	wantSeq := []string{"launchctl bootout", "launchctl list", "launchctl bootstrap"}
+	for i, want := range wantSeq {
+		if i >= len(*calls) || !strings.Contains((*calls)[i], want) {
+			t.Fatalf("call %d: want prefix %q, got %v", i, want, *calls)
+		}
 	}
 }
 
@@ -293,7 +315,7 @@ func TestReload_LaunchAgent_FailsWhenPlistMissing(t *testing.T) {
 	// Do NOT create the plist.
 	withFakeRunCmd(t, nil)
 
-	err := Reload(time.Second)
+	err := Reload(3001, time.Second)
 	if err == nil {
 		t.Fatal("expected error when plist is missing")
 	}
@@ -354,5 +376,39 @@ func TestRunningPIDDarwin_ZeroOnError(t *testing.T) {
 	}
 	if got := RunningPID(); got != 0 {
 		t.Errorf("RunningPID() = %d, want 0", got)
+	}
+}
+
+func TestBounceLaunchAgent_FailsWhenHealthCheckFails(t *testing.T) {
+	versionPath := withTempVersionFile(t)
+	withFakeClock(t)
+
+	// Kickstart succeeds and a new process writes the version file, but the
+	// router never answers health checks — a fresh version file alone must
+	// not count as ready.
+	orig := waitRouterRespondingFn
+	t.Cleanup(func() { waitRouterRespondingFn = orig })
+	waitRouterRespondingFn = func(int, time.Duration) error {
+		return errors.New("liveness probe failed: connection refused")
+	}
+
+	withFakeRunCmd(t, nil)
+	origRun := runCmd
+	runCmd = func(name string, args ...string) error {
+		err := origRun(name, args...)
+		if err == nil && len(args) > 0 && args[0] == "kickstart" {
+			ts := nowFn().Add(50 * time.Millisecond)
+			_ = os.WriteFile(versionPath, []byte("9.9.9"), 0o644)
+			_ = os.Chtimes(versionPath, ts, ts)
+		}
+		return err
+	}
+
+	err := bounceLaunchAgent(3001, 2*time.Second)
+	if err == nil {
+		t.Fatal("expected error when health check never passes")
+	}
+	if !strings.Contains(err.Error(), "health checks") {
+		t.Errorf("expected health-check error, got: %v", err)
 	}
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -48,9 +48,26 @@ var (
 	sleepFn = time.Sleep
 )
 
-// DefaultBounceTimeout is the default deadline for verifying that a bounced
-// router has come back up (i.e. written its version file).
-const DefaultBounceTimeout = 5 * time.Second
+// DefaultReadyTimeout is the default deadline for verifying that a restarted
+// router is ready: a fresh version file (a new process started) AND the
+// health endpoint answering (it is actually serving). Generous because TLS
+// setup and route hydration can take several seconds on large registries —
+// it's a deadline, not a sleep, so the happy path returns as soon as the
+// router answers.
+const DefaultReadyTimeout = 30 * time.Second
+
+// HookReadyTimeout is the readiness deadline for non-interactive tooling
+// paths (e.g. the Homebrew post_install hook running
+// `gtl serve restart --if-installed`), where blocking a package manager for
+// 30 seconds on a genuinely broken start is worse than failing fast.
+const HookReadyTimeout = 10 * time.Second
+
+// deregisterTimeout bounds the wait for launchd to drop a booted-out
+// service registration. bootout of a running KeepAlive service is
+// asynchronous — the label stays registered until the old process exits,
+// which can take many seconds while it drains live connections (SIGTERM,
+// then SIGKILL only after launchd's grace window).
+const deregisterTimeout = 20 * time.Second
 
 // StableExecutablePath returns a path suitable for embedding in a service
 // definition (launchd plist, systemd unit). On Homebrew installs,
@@ -233,16 +250,16 @@ func launchDomain() string {
 // `systemctl --user restart`.
 //
 // Bounce verifies the restart by waiting for the router to write a fresh
-// `router.version` file. Returns an error if no new write is observed
+// `router.version` file and then answer health checks on `routerPort`,
 // within `wait`.
 //
 // Use Reload (not Bounce) when the service definition itself changed.
-func Bounce(wait time.Duration) error {
+func Bounce(routerPort int, wait time.Duration) error {
 	switch runtime.GOOS {
 	case "darwin":
-		return bounceLaunchAgent(wait)
+		return bounceLaunchAgent(routerPort, wait)
 	case "linux":
-		return bounceSystemd(wait)
+		return bounceSystemd(routerPort, wait)
 	default:
 		return fmt.Errorf("bounce not supported on %s", runtime.GOOS)
 	}
@@ -254,12 +271,12 @@ func Bounce(wait time.Duration) error {
 //
 // On macOS that's `launchctl bootout` followed by `launchctl bootstrap`.
 // On Linux that's `systemctl --user daemon-reload` followed by `restart`.
-func Reload(wait time.Duration) error {
+func Reload(routerPort int, wait time.Duration) error {
 	switch runtime.GOOS {
 	case "darwin":
-		return reloadLaunchAgent(wait)
+		return reloadLaunchAgent(routerPort, wait)
 	case "linux":
-		return reloadSystemd(wait)
+		return reloadSystemd(routerPort, wait)
 	default:
 		return fmt.Errorf("reload not supported on %s", runtime.GOOS)
 	}
@@ -289,6 +306,27 @@ func waitForFreshVersion(before time.Time, wait time.Duration) error {
 		sleepFn(100 * time.Millisecond)
 	}
 	return fmt.Errorf("router did not record a new version within %s — check logs: %s", wait, logHint())
+}
+
+// waitRouterRespondingFn is the health-poll seam, overridable in tests so
+// lifecycle tests don't need a live HTTP listener.
+var waitRouterRespondingFn = WaitRouterResponding
+
+// waitRouterReady gates a lifecycle operation on the router actually coming
+// back, in two stages: a fresh router.version write proves a new process
+// started (the mtime comparison distinguishes a new process even across
+// same-version restarts), then the health endpoint answering proves it is
+// serving — the version file is written at process start, before TLS setup
+// and port binding, so it alone is not a readiness signal.
+func waitRouterReady(routerPort int, before time.Time, wait time.Duration) error {
+	deadline := nowFn().Add(wait)
+	if err := waitForFreshVersion(before, wait); err != nil {
+		return err
+	}
+	if err := waitRouterRespondingFn(routerPort, deadline.Sub(nowFn())); err != nil {
+		return fmt.Errorf("router process started but did not answer health checks: %w — check logs: %s", err, logHint())
+	}
+	return nil
 }
 
 // logHint returns the platform-appropriate way to view router logs. On Linux
@@ -336,24 +374,24 @@ func nonSystemdInstallMessage(wsl bool) string {
 		"or run the router in the foreground with 'gtl serve run'."
 }
 
-func bounceLaunchAgent(wait time.Duration) error {
+func bounceLaunchAgent(routerPort int, wait time.Duration) error {
 	target := launchTarget()
 	before := versionFileMtime()
 	// If the agent isn't loaded yet (e.g. fresh install), kickstart will
 	// fail. Fall back to bootstrap so first-time callers don't hit a wall.
 	if err := runCmd("launchctl", "print", target); err != nil {
-		return reloadLaunchAgent(wait)
+		return reloadLaunchAgent(routerPort, wait)
 	}
 	if err := runCmd("launchctl", "kickstart", "-k", target); err != nil {
 		return fmt.Errorf("launchctl kickstart: %w", err)
 	}
-	return waitForFreshVersion(before, wait)
+	return waitRouterReady(routerPort, before, wait)
 }
 
 // plistPathFn returns the plist path. Overridable in tests.
 var plistPathFn = PlistPath
 
-func reloadLaunchAgent(wait time.Duration) error {
+func reloadLaunchAgent(routerPort int, wait time.Duration) error {
 	plist := plistPathFn()
 	if _, err := os.Stat(plist); err != nil {
 		return fmt.Errorf("plist not found at %s — run 'gtl serve install' first", plist)
@@ -365,9 +403,19 @@ func reloadLaunchAgent(wait time.Duration) error {
 	// loaded — that's fine, we're about to bootstrap.
 	_ = runCmd("launchctl", "bootout", target)
 
-	// On some macOS versions launchd needs a moment to settle after bootout
-	// before it will accept a bootstrap for the same label. Retry a few times
-	// on exit 5 ("already loaded / I/O error"), re-running bootout each time.
+	// bootout of a running KeepAlive service is asynchronous: launchd keeps
+	// the label registered until the old process exits, and bootstrapping
+	// while it's still live fails with exit 5. `launchctl list <label>` keys
+	// on registration and exits non-zero once the label is gone, so poll for
+	// that instead of guessing with fixed sleeps.
+	deregisterDeadline := nowFn().Add(deregisterTimeout)
+	for runCmd("launchctl", "list", LaunchLabel()) == nil && nowFn().Before(deregisterDeadline) {
+		sleepFn(200 * time.Millisecond)
+	}
+
+	// Backstop for launchd still settling after the label disappears. Retry
+	// a few times on exit 5 ("already loaded / I/O error"), re-running
+	// bootout each time.
 	const maxRetries = 3
 	var bootstrapErr error
 	for i := 0; i < maxRetries; i++ {
@@ -375,7 +423,14 @@ func reloadLaunchAgent(wait time.Duration) error {
 			sleepFn(500 * time.Millisecond)
 			_ = runCmd("launchctl", "bootout", target)
 		}
-		bootstrapErr = runCmd("launchctl", "bootstrap", launchDomain(), plist)
+		// CombinedOutput, not Run: exit codes alone are ambiguous (exit 5
+		// covers both "already loaded" and I/O errors) — launchd's reason
+		// string on stderr is the real diagnostic.
+		out, err := runCmdOutput("launchctl", "bootstrap", launchDomain(), plist)
+		if msg := strings.TrimSpace(string(out)); err != nil && msg != "" {
+			err = fmt.Errorf("%w: %s", err, msg)
+		}
+		bootstrapErr = err
 		if bootstrapErr == nil || launchctlExitCode(bootstrapErr) != 5 {
 			break
 		}
@@ -383,18 +438,18 @@ func reloadLaunchAgent(wait time.Duration) error {
 	if bootstrapErr != nil {
 		return fmt.Errorf("launchctl bootstrap %s: %w", plist, bootstrapErr)
 	}
-	return waitForFreshVersion(before, wait)
+	return waitRouterReady(routerPort, before, wait)
 }
 
-func bounceSystemd(wait time.Duration) error {
+func bounceSystemd(routerPort int, wait time.Duration) error {
 	before := versionFileMtime()
 	if err := runCmd("systemctl", "--user", "restart", SystemdUnit()); err != nil {
 		return fmt.Errorf("systemctl restart: %w", err)
 	}
-	return waitForFreshVersion(before, wait)
+	return waitRouterReady(routerPort, before, wait)
 }
 
-func reloadSystemd(wait time.Duration) error {
+func reloadSystemd(routerPort int, wait time.Duration) error {
 	before := versionFileMtime()
 	if err := runCmd("systemctl", "--user", "daemon-reload"); err != nil {
 		return fmt.Errorf("systemctl daemon-reload: %w", err)
@@ -402,7 +457,7 @@ func reloadSystemd(wait time.Duration) error {
 	if err := runCmd("systemctl", "--user", "restart", SystemdUnit()); err != nil {
 		return fmt.Errorf("systemctl restart: %w", err)
 	}
-	return waitForFreshVersion(before, wait)
+	return waitRouterReady(routerPort, before, wait)
 }
 
 // RouterVersionFile returns the path to the file where the running router
@@ -473,37 +528,36 @@ func RouterLogFiles() (stdout, stderr string) {
 	return filepath.Join(dir, "router.log"), filepath.Join(dir, "router.err")
 }
 
-func installLaunchAgent(gtlPath string, _ int) (string, error) {
+func installLaunchAgent(gtlPath string, routerPort int) (string, error) {
 	path := PlistPath()
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	content, err := GeneratePlist(gtlPath)
+	if err != nil {
 		return "", err
 	}
 	if err := os.MkdirAll(logDir(), 0o755); err != nil {
 		return "", err
 	}
 
-	f, err := os.Create(path)
-	if err != nil {
+	// When the service definition is unchanged (e.g. Homebrew swapped the
+	// binary behind the stable symlink path), kickstart is sufficient — it
+	// re-execs from the loaded definition. Reload would bootout+bootstrap,
+	// which races against launchd's asynchronous deregistration of the still
+	// running old process. Only pay that cost when the plist really changed.
+	if existing, readErr := os.ReadFile(path); readErr == nil && string(existing) == content {
+		if err := Bounce(routerPort, DefaultReadyTimeout); err != nil {
+			return path, fmt.Errorf("service definition unchanged but restart failed: %w", err)
+		}
+		return path, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		return "", err
 	}
 
-	err = plistTemplate.Execute(f, struct {
-		Label   string
-		GtlPath string
-		LogDir  string
-	}{
-		Label:   LaunchLabel(),
-		GtlPath: gtlPath,
-		LogDir:  logDir(),
-	})
-	if closeErr := f.Close(); err == nil {
-		err = closeErr
-	}
-	if err != nil {
-		return "", err
-	}
-
-	if err := Reload(DefaultBounceTimeout); err != nil {
+	if err := Reload(routerPort, DefaultReadyTimeout); err != nil {
 		return path, fmt.Errorf("wrote plist but service did not come up: %w", err)
 	}
 	return path, nil
@@ -598,7 +652,7 @@ func UnitPath() string {
 	return filepath.Join(configDir, "systemd", "user", SystemdUnit())
 }
 
-func installSystemd(gtlPath string, _ int) (string, error) {
+func installSystemd(gtlPath string, routerPort int) (string, error) {
 	// Fail with actionable guidance before touching disk when systemd isn't
 	// running (non-systemd distro, or WSL2 without systemd) — otherwise the
 	// user just sees a raw `systemctl` connection error.
@@ -606,20 +660,24 @@ func installSystemd(gtlPath string, _ int) (string, error) {
 		return "", fmt.Errorf("%s", nonSystemdInstallMessage(isWSL()))
 	}
 	path := UnitPath()
+	content, err := GenerateUnit(gtlPath)
+	if err != nil {
+		return "", err
+	}
+
+	// Unit unchanged (e.g. binary swapped behind the same ExecStart path) —
+	// a plain restart picks up the new binary; no daemon-reload needed.
+	if existing, readErr := os.ReadFile(path); readErr == nil && string(existing) == content {
+		if err := Bounce(routerPort, DefaultReadyTimeout); err != nil {
+			return path, fmt.Errorf("service definition unchanged but restart failed: %w", err)
+		}
+		return path, nil
+	}
+
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return "", err
 	}
-
-	f, err := os.Create(path)
-	if err != nil {
-		return "", err
-	}
-
-	err = unitTemplate.Execute(f, struct{ GtlPath string }{GtlPath: gtlPath})
-	if closeErr := f.Close(); err == nil {
-		err = closeErr
-	}
-	if err != nil {
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		return "", err
 	}
 
@@ -629,7 +687,7 @@ func installSystemd(gtlPath string, _ int) (string, error) {
 	if err := runCmd("systemctl", "--user", "enable", "--now", SystemdUnit()); err != nil {
 		return path, fmt.Errorf("wrote unit but failed to enable: %w", err)
 	}
-	if err := Reload(DefaultBounceTimeout); err != nil {
+	if err := Reload(routerPort, DefaultReadyTimeout); err != nil {
 		return path, fmt.Errorf("wrote unit but service did not come up: %w", err)
 	}
 	return path, nil
@@ -645,7 +703,7 @@ func uninstallSystemd() error {
 	return nil
 }
 
-// GeneratePlist returns the plist XML content as a string (for testing).
+// GeneratePlist returns the plist XML content as a string.
 func GeneratePlist(gtlPath string) (string, error) {
 	var b strings.Builder
 	err := plistTemplate.Execute(&b, struct {
@@ -660,7 +718,7 @@ func GeneratePlist(gtlPath string) (string, error) {
 	return b.String(), err
 }
 
-// GenerateUnit returns the systemd unit content as a string (for testing).
+// GenerateUnit returns the systemd unit content as a string.
 func GenerateUnit(gtlPath string) (string, error) {
 	var b strings.Builder
 	err := unitTemplate.Execute(&b, struct{ GtlPath string }{GtlPath: gtlPath})

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -139,17 +140,30 @@ func setupReloadTest(t *testing.T) (versionFile string, cleanup func()) {
 
 	origPlistFn := plistPathFn
 	origRunCmd := runCmd
+	origRunCmdOutput := runCmdOutput
 	origSleep := sleepFn
+	origHealth := waitRouterRespondingFn
 
 	plistPathFn = func() string { return plist }
 	sleepFn = func(time.Duration) {}
+	waitRouterRespondingFn = func(int, time.Duration) error { return nil }
+	// Default: the label is already deregistered, so the bootout poll exits
+	// on its first probe. Tests override runCmd to model a lingering label.
+	runCmd = func(name string, args ...string) error {
+		if name == "launchctl" && len(args) > 0 && args[0] == "list" {
+			return errors.New("could not find service")
+		}
+		return nil
+	}
 
 	versionFile = RouterVersionFile()
 
 	return versionFile, func() {
 		plistPathFn = origPlistFn
 		runCmd = origRunCmd
+		runCmdOutput = origRunCmdOutput
 		sleepFn = origSleep
+		waitRouterRespondingFn = origHealth
 	}
 }
 
@@ -158,20 +172,20 @@ func TestReloadLaunchAgent_BootstrapRetry_SucceedsAfterExit5(t *testing.T) {
 	defer cleanup()
 
 	bootstrapCalls := 0
-	runCmd = func(name string, args ...string) error {
+	runCmdOutput = func(name string, args ...string) ([]byte, error) {
 		if name == "launchctl" && len(args) > 0 && args[0] == "bootstrap" {
 			bootstrapCalls++
 			if bootstrapCalls < 3 {
-				return fakeExitErr(t, 5)
+				return nil, fakeExitErr(t, 5)
 			}
 			// Simulate the router writing its version file on successful start.
 			_ = os.WriteFile(versionFile, []byte("v1"), 0o644)
-			return nil
+			return nil, nil
 		}
-		return nil
+		return nil, nil
 	}
 
-	if err := reloadLaunchAgent(2 * time.Second); err != nil {
+	if err := reloadLaunchAgent(3001, 2*time.Second); err != nil {
 		t.Fatalf("expected success after retries, got: %v", err)
 	}
 	if bootstrapCalls != 3 {
@@ -184,15 +198,15 @@ func TestReloadLaunchAgent_BootstrapRetry_StopsAtMaxRetries(t *testing.T) {
 	defer cleanup()
 
 	bootstrapCalls := 0
-	runCmd = func(name string, args ...string) error {
+	runCmdOutput = func(name string, args ...string) ([]byte, error) {
 		if name == "launchctl" && len(args) > 0 && args[0] == "bootstrap" {
 			bootstrapCalls++
-			return fakeExitErr(t, 5)
+			return nil, fakeExitErr(t, 5)
 		}
-		return nil
+		return nil, nil
 	}
 
-	err := reloadLaunchAgent(100 * time.Millisecond)
+	err := reloadLaunchAgent(3001, 100*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected error after exhausting retries")
 	}
@@ -206,19 +220,190 @@ func TestReloadLaunchAgent_BootstrapRetry_NoRetryOnNonFiveError(t *testing.T) {
 	defer cleanup()
 
 	bootstrapCalls := 0
-	runCmd = func(name string, args ...string) error {
+	runCmdOutput = func(name string, args ...string) ([]byte, error) {
 		if name == "launchctl" && len(args) > 0 && args[0] == "bootstrap" {
 			bootstrapCalls++
-			return fakeExitErr(t, 1) // non-5 failure
+			return nil, fakeExitErr(t, 1) // non-5 failure
 		}
-		return nil
+		return nil, nil
 	}
 
-	err := reloadLaunchAgent(100 * time.Millisecond)
+	err := reloadLaunchAgent(3001, 100*time.Millisecond)
 	if err == nil {
 		t.Fatal("expected error")
 	}
 	if bootstrapCalls != 1 {
 		t.Errorf("expected exactly 1 bootstrap attempt for non-5 error, got %d", bootstrapCalls)
+	}
+}
+
+func TestReloadLaunchAgent_WaitsForLingeringLabel(t *testing.T) {
+	versionFile, cleanup := setupReloadTest(t)
+	defer cleanup()
+
+	// Model bootout's asynchronous deregistration: the label stays
+	// registered for the first few polls, then disappears.
+	listCalls := 0
+	runCmd = func(name string, args ...string) error {
+		if name == "launchctl" && len(args) > 0 && args[0] == "list" {
+			listCalls++
+			if listCalls < 4 {
+				return nil // still registered
+			}
+			return errors.New("could not find service")
+		}
+		return nil
+	}
+	bootstrapCalls := 0
+	runCmdOutput = func(name string, args ...string) ([]byte, error) {
+		if name == "launchctl" && len(args) > 0 && args[0] == "bootstrap" {
+			if listCalls < 4 {
+				t.Error("bootstrap fired while the label was still registered")
+			}
+			bootstrapCalls++
+			_ = os.WriteFile(versionFile, []byte("v1"), 0o644)
+		}
+		return nil, nil
+	}
+
+	if err := reloadLaunchAgent(3001, 2*time.Second); err != nil {
+		t.Fatalf("reloadLaunchAgent: %v", err)
+	}
+	if listCalls != 4 {
+		t.Errorf("expected 4 list polls, got %d", listCalls)
+	}
+	if bootstrapCalls != 1 {
+		t.Errorf("expected 1 bootstrap call, got %d", bootstrapCalls)
+	}
+}
+
+func TestReloadLaunchAgent_DeregistrationTimeout_StillAttemptsBootstrap(t *testing.T) {
+	_, cleanup := setupReloadTest(t)
+	defer cleanup()
+	withFakeClock(t)
+
+	// Label never deregisters: the poll must give up at its deadline and
+	// bootstrap must still be attempted (and surface launchd's failure).
+	listCalls := 0
+	runCmd = func(name string, args ...string) error {
+		if name == "launchctl" && len(args) > 0 && args[0] == "list" {
+			listCalls++
+			return nil // registered forever
+		}
+		return nil
+	}
+	bootstrapCalls := 0
+	runCmdOutput = func(name string, args ...string) ([]byte, error) {
+		if name == "launchctl" && len(args) > 0 && args[0] == "bootstrap" {
+			bootstrapCalls++
+			return []byte("Bootstrap failed: 5: Input/output error"), fakeExitErr(t, 5)
+		}
+		return nil, nil
+	}
+
+	err := reloadLaunchAgent(3001, time.Second)
+	if err == nil {
+		t.Fatal("expected error when label never deregisters and bootstrap fails")
+	}
+	if listCalls < 2 {
+		t.Errorf("expected repeated list polls before giving up, got %d", listCalls)
+	}
+	if bootstrapCalls != 3 {
+		t.Errorf("expected 3 bootstrap attempts (retry backstop), got %d", bootstrapCalls)
+	}
+	// launchd's reason string must survive into the error — a bare
+	// "exit status 5" is ambiguous.
+	if !strings.Contains(err.Error(), "Input/output error") {
+		t.Errorf("expected launchctl output in error, got: %v", err)
+	}
+}
+
+func TestInstallLaunchAgent_UnchangedPlist_UsesKickstart(t *testing.T) {
+	versionFile := withTempVersionFile(t)
+	withFakeHealth(t)
+
+	gtlPath := "/opt/homebrew/bin/gtl"
+	content, err := GeneratePlist(gtlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(PlistPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(PlistPath(), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := withFakeRunCmd(t, nil)
+	origRun := runCmd
+	runCmd = func(name string, args ...string) error {
+		err := origRun(name, args...)
+		if err == nil && len(args) > 0 && args[0] == "kickstart" {
+			_ = os.WriteFile(versionFile, []byte("v1"), 0o644)
+		}
+		return err
+	}
+
+	if _, err := installLaunchAgent(gtlPath, 3001); err != nil {
+		t.Fatalf("installLaunchAgent: %v", err)
+	}
+	var sawKickstart bool
+	for _, c := range *calls {
+		if strings.Contains(c, "kickstart") {
+			sawKickstart = true
+		}
+		if strings.Contains(c, "bootout") || strings.Contains(c, "bootstrap") {
+			t.Errorf("unchanged plist must not bootout/bootstrap, got: %v", *calls)
+		}
+	}
+	if !sawKickstart {
+		t.Errorf("expected kickstart for unchanged plist, got: %v", *calls)
+	}
+}
+
+func TestInstallLaunchAgent_ChangedPlist_WritesAndReloads(t *testing.T) {
+	versionFile := withTempVersionFile(t)
+	withFakeHealth(t)
+
+	gtlPath := "/opt/homebrew/bin/gtl"
+	if err := os.MkdirAll(filepath.Dir(PlistPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// On-disk plist points at a stale Cellar path → content differs.
+	if err := os.WriteFile(PlistPath(), []byte("<plist>stale</plist>"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := withFakeRunCmd(t, map[string]error{
+		"launchctl list": errors.New("could not find service"),
+	})
+	origOut := runCmdOutput
+	runCmdOutput = func(name string, args ...string) ([]byte, error) {
+		out, err := origOut(name, args...)
+		if err == nil && len(args) > 0 && args[0] == "bootstrap" {
+			_ = os.WriteFile(versionFile, []byte("v1"), 0o644)
+		}
+		return out, err
+	}
+
+	if _, err := installLaunchAgent(gtlPath, 3001); err != nil {
+		t.Fatalf("installLaunchAgent: %v", err)
+	}
+	want, _ := GeneratePlist(gtlPath)
+	got, err := os.ReadFile(PlistPath())
+	if err != nil || string(got) != want {
+		t.Errorf("plist not rewritten with new content (err=%v)", err)
+	}
+	var sawBootstrap bool
+	for _, c := range *calls {
+		if strings.Contains(c, "bootstrap") {
+			sawBootstrap = true
+		}
+		if strings.Contains(c, "kickstart") {
+			t.Errorf("changed plist must reload, not kickstart, got: %v", *calls)
+		}
+	}
+	if !sawBootstrap {
+		t.Errorf("expected bootstrap for changed plist, got: %v", *calls)
 	}
 }

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -319,6 +320,9 @@ func TestReloadLaunchAgent_DeregistrationTimeout_StillAttemptsBootstrap(t *testi
 }
 
 func TestInstallLaunchAgent_UnchangedPlist_UsesKickstart(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only: installLaunchAgent restarts via the Bounce/Reload dispatchers")
+	}
 	versionFile := withTempVersionFile(t)
 	withFakeHealth(t)
 
@@ -362,6 +366,9 @@ func TestInstallLaunchAgent_UnchangedPlist_UsesKickstart(t *testing.T) {
 }
 
 func TestInstallLaunchAgent_ChangedPlist_WritesAndReloads(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("darwin-only: installLaunchAgent restarts via the Bounce/Reload dispatchers")
+	}
 	versionFile := withTempVersionFile(t)
 	withFakeHealth(t)
 
@@ -405,5 +412,101 @@ func TestInstallLaunchAgent_ChangedPlist_WritesAndReloads(t *testing.T) {
 	}
 	if !sawBootstrap {
 		t.Errorf("expected bootstrap for changed plist, got: %v", *calls)
+	}
+}
+
+func TestInstallSystemd_UnchangedUnit_UsesRestart(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only: installSystemd restarts via the Bounce/Reload dispatchers")
+	}
+	if !systemdAvailable() {
+		t.Skip("systemd not available")
+	}
+	versionFile := withTempVersionFile(t)
+	withFakeHealth(t)
+
+	gtlPath := "/usr/local/bin/gtl"
+	content, err := GenerateUnit(gtlPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(UnitPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(UnitPath(), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := withFakeRunCmd(t, nil)
+	origRun := runCmd
+	runCmd = func(name string, args ...string) error {
+		err := origRun(name, args...)
+		if err == nil && len(args) > 1 && args[1] == "restart" {
+			_ = os.WriteFile(versionFile, []byte("v1"), 0o644)
+		}
+		return err
+	}
+
+	if _, err := installSystemd(gtlPath, 3001); err != nil {
+		t.Fatalf("installSystemd: %v", err)
+	}
+	var sawRestart bool
+	for _, c := range *calls {
+		if strings.Contains(c, "restart") {
+			sawRestart = true
+		}
+		if strings.Contains(c, "daemon-reload") {
+			t.Errorf("unchanged unit must not daemon-reload, got: %v", *calls)
+		}
+	}
+	if !sawRestart {
+		t.Errorf("expected restart for unchanged unit, got: %v", *calls)
+	}
+}
+
+func TestInstallSystemd_ChangedUnit_WritesAndReloads(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("linux-only: installSystemd restarts via the Bounce/Reload dispatchers")
+	}
+	if !systemdAvailable() {
+		t.Skip("systemd not available")
+	}
+	versionFile := withTempVersionFile(t)
+	withFakeHealth(t)
+
+	gtlPath := "/usr/local/bin/gtl"
+	if err := os.MkdirAll(filepath.Dir(UnitPath()), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(UnitPath(), []byte("[Service]\nExecStart=/stale/gtl serve run\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	calls := withFakeRunCmd(t, nil)
+	origRun := runCmd
+	runCmd = func(name string, args ...string) error {
+		err := origRun(name, args...)
+		if err == nil && len(args) > 1 && args[1] == "restart" {
+			_ = os.WriteFile(versionFile, []byte("v1"), 0o644)
+		}
+		return err
+	}
+
+	if _, err := installSystemd(gtlPath, 3001); err != nil {
+		t.Fatalf("installSystemd: %v", err)
+	}
+	want, _ := GenerateUnit(gtlPath)
+	got, err := os.ReadFile(UnitPath())
+	if err != nil || string(got) != want {
+		t.Errorf("unit not rewritten with new content (err=%v)", err)
+	}
+	var sawReload bool
+	for _, c := range *calls {
+		if strings.Contains(c, "daemon-reload") {
+			sawReload = true
+		}
+	}
+	if !sawReload {
+		t.Errorf("expected daemon-reload for changed unit, got: %v", *calls)
 	}
 }


### PR DESCRIPTION
## Problem

After every few upgrades, `gtl serve install` and `gtl serve restart` report failure while the router is actually healthy (July 15 incident: `bootstrap ... exit status 5`, then `liveness probe ... context deadline exceeded`). Five prior commits (d5dcfde, fa8043c, a3146c3, 1a720f9, ba40432) each added a verification layer without fixing the two structural defects. Root-cause analysis and the audited fix plan are recorded in the workspace `.context/` notes; the plan was reviewed by three independent audit passes (launchd semantics, codebase fit, adversarial scope) before implementation.

## Fixes

1. **Install diffs the rendered plist/unit against disk.** Unchanged definition (the Homebrew-upgrade case — the plist embeds the stable symlink) → `kickstart` / `systemctl restart`, which never touches the bootout/bootstrap deregistration race. Only a real definition change pays the full reload.
2. **Reload waits for launchd to actually drop the old label** — polls `launchctl list` exit code (up to 20s; launchd's SIGKILL grace can exceed 10s) instead of fixed 500ms sleeps. The exit-5 retry remains as backstop. Bootstrap failures now include launchd's stderr reason string instead of a bare `exit status 5`.
3. **One readiness gate everywhere**: fresh `router.version` mtime (a new process started) AND the health endpoint answering (it is serving) — used by Bounce, Reload, and both install paths on macOS and Linux. Previously install never health-checked at all, and restart's bolt-on 5s health poll lost to real TLS/route-hydration startup (2–7s observed). Deadlines: 30s interactive, 10s for `--if-installed` so the Homebrew post_install hook still fails fast.

Deliberately **not** included (audit finding): a "report success if the router answers health checks despite a failed lifecycle op" fallback — it would convert an honest false negative into a silent loss of launchd/KeepAlive supervision (orphan process answers health, nothing registered, router dies on next reboot).

## Tests

New coverage: lingering-label deregistration poll, never-deregisters timeout (bootstrap still attempted, launchd output surfaced), unchanged-plist→kickstart routing, changed-plist→rewrite+reload routing, health-gate failure after successful kickstart. Test fakes extended so `runCmdOutput` is recorded/stubbed alongside `runCmd`.

Follow-ups (not in this PR): env-gated integration test against real launchd; lazy route/TLS hydration to cut the 2–7s startup cost that makes generous deadlines necessary.