### PR TITLE
fix: prevent hang when reconnecting to a running supervisor after terminal loss

### DIFF
--- a/cmd/server.go
+++ b/cmd/server.go
@@ -108,10 +108,17 @@ resumes the server in the original terminal. Ctrl+C exits the supervisor.`,
 					}
 					return cliErr(cmd, restartViaSupervisor(sockPath))
 				case runningActionMove:
+					fmt.Println(style.Dimf("Stopping server in the other terminal..."))
 					if err := stopOtherSupervisor(sockPath, 15*time.Second); err != nil {
-						return cliErr(cmd, err)
+						// Graceful shutdown timed out — force-kill the supervisor and its child.
+						killed, ferr := forceKillSupervisor(sockPath)
+						if ferr != nil || !killed {
+							return cliErr(cmd, err)
+						}
+						fmt.Println(style.Dimf("Force-stopped unresponsive server — starting fresh here."))
+					} else {
+						fmt.Println(style.Dimf("Stopped the server in the other terminal — starting fresh here."))
 					}
-					fmt.Println(style.Dimf("Stopped the server in the other terminal — starting fresh here."))
 					// Fall through to the fresh-start path below.
 				}
 			} else {

--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -163,11 +163,11 @@ func (s *Supervisor) startChildLocked() error {
 
 	go func() {
 		_ = cmd.Wait()
-		_ = os.Remove(ChildPidPath(s.SocketPath))
 		close(done)
 		s.mu.Lock()
 		if s.child == cmd {
 			s.child = nil
+			_ = os.Remove(ChildPidPath(s.SocketPath))
 		}
 		s.mu.Unlock()
 	}()
@@ -202,7 +202,11 @@ func (s *Supervisor) stopChildLocked() {
 	case <-time.After(10 * time.Second):
 		s.Log("==> Process didn't exit in 10s, sending SIGKILL")
 		_ = syscall.Kill(-child.Process.Pid, syscall.SIGKILL)
-		<-waitCh
+		select {
+		case <-waitCh:
+		case <-time.After(5 * time.Second):
+			s.Log("==> Process did not exit after SIGKILL — proceeding")
+		}
 	}
 
 	s.mu.Lock()


### PR DESCRIPTION
## Summary

- Prints "Stopping server in the other terminal..." immediately when option [1] is selected, so there's visible feedback during what can be a 15-30s silent wait
- Auto-falls back to `forceKillSupervisor` if `stopOtherSupervisor` times out (15s) — previously this errored and told the user to run `gtl stop --kill` manually
- Caps the post-SIGKILL wait in `stopChildLocked` at 5s so a D-state process after macOS sleep/wake can't block the supervisor indefinitely (was an uncapped `<-waitCh`)
- Guards `ChildPidPath` removal inside `if s.child == cmd` — prevents a late-returning `cmd.Wait()` goroutine from deleting the *new* child's sidecar after `restart()` has already started a replacement (new race introduced by the SIGKILL cap)

## Test plan

- [ ] Run `gtl start` in one terminal, open a new terminal and run `gtl start` again — confirm "Stopping server..." message appears immediately on option [1]
- [ ] Confirm the fresh start proceeds without requiring `gtl stop --kill`
- [ ] Reproduce morning-reconnect scenario: close the original terminal, open new terminal, run `gtl start`, select [1] — should complete cleanly