### PR TITLE
tests: pin bare fixture remotes to --initial-branch=main

### DIFF
--- a/cmd/claim_test.go
+++ b/cmd/claim_test.go
@@ -66,7 +66,7 @@ func claimFixture(t *testing.T) (mainRepo, seed string) {
 	if err := os.MkdirAll(origin, 0o755); err != nil {
 		t.Fatal(err)
 	}
-	runGit(t, origin, "init", "--bare")
+	runGit(t, origin, "init", "--bare", "--initial-branch=main")
 
 	runGit(t, seed, "remote", "add", "origin", origin)
 	runGit(t, seed, "push", "origin", "main")

--- a/internal/worktree/worktree_test.go
+++ b/internal/worktree/worktree_test.go
@@ -658,7 +658,7 @@ func TestFetch_Success(t *testing.T) {
 
 	remoteDir := t.TempDir()
 	remoteDir, _ = filepath.EvalSymlinks(remoteDir)
-	run(t, remoteDir, "git", "init", "--bare")
+	run(t, remoteDir, "git", "init", "--bare", "--initial-branch=main")
 
 	run(t, repo, "git", "remote", "add", "origin", remoteDir)
 	run(t, repo, "git", "push", "origin", "main")
@@ -691,7 +691,7 @@ func TestFetch_NonexistentBranch(t *testing.T) {
 
 	remoteDir := t.TempDir()
 	remoteDir, _ = filepath.EvalSymlinks(remoteDir)
-	run(t, remoteDir, "git", "init", "--bare")
+	run(t, remoteDir, "git", "init", "--bare", "--initial-branch=main")
 
 	run(t, repo, "git", "remote", "add", "origin", remoteDir)
 	run(t, repo, "git", "push", "origin", "main")
@@ -755,7 +755,7 @@ func TestPull_FastForward(t *testing.T) {
 
 	remoteDir := t.TempDir()
 	remoteDir, _ = filepath.EvalSymlinks(remoteDir)
-	run(t, remoteDir, "git", "init", "--bare")
+	run(t, remoteDir, "git", "init", "--bare", "--initial-branch=main")
 	run(t, repo, "git", "remote", "add", "origin", remoteDir)
 	run(t, repo, "git", "push", "origin", "main")
 
@@ -782,7 +782,7 @@ func TestPull_AlreadyUpToDate(t *testing.T) {
 
 	remoteDir := t.TempDir()
 	remoteDir, _ = filepath.EvalSymlinks(remoteDir)
-	run(t, remoteDir, "git", "init", "--bare")
+	run(t, remoteDir, "git", "init", "--bare", "--initial-branch=main")
 	run(t, repo, "git", "remote", "add", "origin", remoteDir)
 	run(t, repo, "git", "push", "origin", "main")
 
@@ -796,7 +796,7 @@ func TestPull_Diverged(t *testing.T) {
 
 	remoteDir := t.TempDir()
 	remoteDir, _ = filepath.EvalSymlinks(remoteDir)
-	run(t, remoteDir, "git", "init", "--bare")
+	run(t, remoteDir, "git", "init", "--bare", "--initial-branch=main")
 	run(t, repo, "git", "remote", "add", "origin", remoteDir)
 	run(t, repo, "git", "push", "origin", "main")
 


### PR DESCRIPTION
CI runners default `init.defaultBranch` to `master`, so the bare remotes in the `TestPull_*` fixtures got a HEAD pointing at nonexistent `master`; clones from them landed on an unborn `master` and `git push origin main` failed with `src refspec main does not match any`. Passed locally only because Apple git defaults to `main`.

Pins all bare fixture remotes (worktree + claim tests) with `--initial-branch=main`. Reproduced the CI failure locally by forcing `init.defaultBranch=master` via `GIT_CONFIG_GLOBAL`; green with the fix under the same config.

Note: the `TestSupervisor_ChildPidFileLifecycle` and allocator-lock CI failures predate #105 (failing on main since #103/#104) and are not addressed here.