### PR TITLE
fix: remove child pid sidecar on supervised stop

### DIFF
--- a/internal/supervisor/supervisor.go
+++ b/internal/supervisor/supervisor.go
@@ -197,16 +197,26 @@ func (s *Supervisor) stopChildLocked() {
 
 	_ = syscall.Kill(-child.Process.Pid, syscall.SIGTERM)
 
+	exited := false
 	select {
 	case <-waitCh:
+		exited = true
 	case <-time.After(10 * time.Second):
 		s.Log("==> Process didn't exit in 10s, sending SIGKILL")
 		_ = syscall.Kill(-child.Process.Pid, syscall.SIGKILL)
 		select {
 		case <-waitCh:
+			exited = true
 		case <-time.After(5 * time.Second):
 			s.Log("==> Process did not exit after SIGKILL — proceeding")
 		}
+	}
+	// The wait goroutine only removes the sidecar on a self-exit (s.child ==
+	// cmd); on this path s.child is already nil, so the removal is ours. Skip
+	// it if the child never exited — the pgid is still needed for a later
+	// force-kill.
+	if exited {
+		_ = os.Remove(ChildPidPath(s.SocketPath))
 	}
 
 	s.mu.Lock()


### PR DESCRIPTION
`TestSupervisor_ChildPidFileLifecycle` has been failing on main CI since #104 — and it's a real regression, not a flake. The guard added in abd36dc (`if s.child == cmd` before removing the child pid sidecar) never matches on a normal stop, because `stopChildLocked` nils `s.child` before the child exits. Every supervised stop left the sidecar behind, so a later force-kill could aim `kill(-pgid)` at a recycled process group.

Fix: `stopChildLocked` removes the sidecar itself once the child has actually exited. The wait goroutine's guarded removal still covers self-exits (its intended purpose — protecting a restarted child's fresh sidecar from a late `cmd.Wait()`), and a child that survives SIGKILL keeps its sidecar since the pgid is still needed for force-kill.

Verified: `go test -race -count=3 ./internal/supervisor/` green (the lifecycle test failed deterministically before the fix); full suite green.