### PR TITLE
feat(setup): keep worktree on setup-command failure, exit 2

### DIFF
--- a/cmd/error.go
+++ b/cmd/error.go
@@ -16,11 +16,14 @@ type CliError struct {
 	Message string
 	Hint    string
 	DocsURL string
+	Cause   error
 }
 
 func (e *CliError) Error() string {
 	return e.Message
 }
+
+func (e *CliError) Unwrap() error { return e.Cause }
 
 // cliErr marks the command to suppress usage output and returns the error.
 // Use this for domain/state errors where the user invoked the command correctly
@@ -113,6 +116,7 @@ func errSetupFailed(inner error) error {
 	return &CliError{
 		Message: fmt.Sprintf("Setup failed: %s", inner),
 		Hint:    "Fix the issue above and re-run 'gtl setup'.",
+		Cause:   inner,
 	}
 }
 

--- a/cmd/output.go
+++ b/cmd/output.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -131,6 +132,15 @@ func runSetupWithRollback(cmd *cobra.Command, wtPath, mainRepo string, uc *confi
 	s.Options.DryRun = false
 	alloc, err := s.Run()
 	if err != nil {
+		var sce *setup.SetupCommandError
+		if errors.As(err, &sce) {
+			// Setup commands failed — worktree and allocation are intact.
+			// Don't remove the worktree; user can fix env and re-run gtl setup.
+			_, _ = fmt.Fprintln(progress, style.Warnf("Setup commands failed — worktree kept at %s", wtPath))
+			_, _ = fmt.Fprintln(progress, style.Dimf("Fix the issue above and re-run 'gtl setup'."))
+			return nil, cliErr(cmd, errSetupFailed(err))
+		}
+		// Fatal setup error (allocation, config, env file, DB) — roll back.
 		if rmErr := worktree.Remove(wtPath, true); rmErr != nil {
 			fmt.Fprintln(os.Stderr, style.Warnf("Could not remove worktree after failed setup: %s", rmErr))
 			fmt.Fprintln(os.Stderr, style.Dimf("  Remove it manually: git worktree remove --force %s", wtPath))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"strings"
 
 	"github.com/git-treeline/cli/internal/platform"
 	"github.com/git-treeline/cli/internal/service"
+	"github.com/git-treeline/cli/internal/setup"
 	"github.com/git-treeline/cli/internal/style"
 	"github.com/spf13/cobra"
 )
@@ -85,6 +87,10 @@ func rootCommandName(cmd *cobra.Command) string {
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		formatCliError(err)
+		var sce *setup.SetupCommandError
+		if errors.As(err, &sce) {
+			os.Exit(2)
+		}
 		os.Exit(1)
 	}
 }

--- a/internal/setup/setup.go
+++ b/internal/setup/setup.go
@@ -4,6 +4,7 @@
 package setup
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -26,6 +27,18 @@ import (
 	"github.com/git-treeline/cli/internal/style"
 	"github.com/git-treeline/cli/internal/worktree"
 )
+
+// SetupCommandError is returned by Run when the worktree and allocation
+// are intact but a setup command (commands.setup) failed. The caller
+// should keep the worktree and allocation — only the user's build
+// commands failed, not the provisioning infrastructure.
+type SetupCommandError struct {
+	Alloc *allocator.Allocation
+	Err   error
+}
+
+func (e *SetupCommandError) Error() string { return e.Err.Error() }
+func (e *SetupCommandError) Unwrap() error { return e.Err }
 
 // Options controls setup behavior. DryRun prints what would happen without
 // making changes. RefreshOnly re-applies environment files without running
@@ -133,6 +146,13 @@ func (s *Setup) Run() (*allocator.Allocation, error) {
 	// Both main and non-main allocations are now persisted atomically inside the
 	// allocator's registry transaction, so there is nothing to write here.
 	if err := s.runPostAllocation(alloc, redisURL); err != nil {
+		var sce *SetupCommandError
+		if errors.As(err, &sce) {
+			// Setup commands failed but allocation + worktree are intact.
+			// Populate the alloc reference for the caller and skip release.
+			sce.Alloc = alloc
+			return nil, sce
+		}
 		if !alloc.Reused {
 			_, _ = s.Registry.Release(s.WorktreePath)
 			s.log("Rolled back allocation due to error")
@@ -194,7 +214,7 @@ func (s *Setup) runPostAllocation(alloc *allocator.Allocation, redisURL string) 
 	}
 
 	if err := s.runSetupCommands(); err != nil {
-		return err
+		return &SetupCommandError{Err: err}
 	}
 
 	s.configureEditor(alloc)

--- a/internal/setup/setup_test.go
+++ b/internal/setup/setup_test.go
@@ -3,6 +3,7 @@ package setup
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -430,10 +431,51 @@ commands:
 		t.Fatal("expected error from failing setup command")
 	}
 
-	// Registry should be empty after rollback
+	// Should be a SetupCommandError — worktree and allocation are intact.
+	var sce *SetupCommandError
+	if !errors.As(err, &sce) {
+		t.Errorf("expected *SetupCommandError, got %T: %v", err, err)
+	}
+
+	// Registry should NOT be empty — allocation is kept so user can re-run gtl setup.
+	allocs := s.Registry.Allocations()
+	if len(allocs) != 1 {
+		t.Errorf("expected 1 registry entry (allocation kept), got %d entries", len(allocs))
+	}
+}
+
+func TestRun_RollbackOnAllocationError(t *testing.T) {
+	s, mainRepo, _ := testSetup(t, `
+project: test
+env_file:
+  target: .env.local
+  source: .env.local
+database:
+  adapter: badadapter
+  template: db/development.db
+  pattern: "db/{worktree}.db"
+env:
+  PORT: "{port}"
+`)
+	_ = os.WriteFile(filepath.Join(mainRepo, ".env.local"), []byte(""), 0o644)
+	_ = os.MkdirAll(filepath.Join(mainRepo, "db"), 0o755)
+	_ = os.WriteFile(filepath.Join(mainRepo, "db", "development.db"), []byte("data"), 0o644)
+
+	_, err := s.Run()
+	if err == nil {
+		t.Fatal("expected error from bad database adapter")
+	}
+
+	// Should NOT be a SetupCommandError — it's a provisioning failure, not a build failure.
+	var sce *SetupCommandError
+	if errors.As(err, &sce) {
+		t.Errorf("expected plain error (not SetupCommandError) for allocation failure, got SetupCommandError")
+	}
+
+	// Registry should be empty after rollback.
 	allocs := s.Registry.Allocations()
 	if len(allocs) != 0 {
-		t.Errorf("expected empty registry after rollback, got %d entries", len(allocs))
+		t.Errorf("expected empty registry after allocation error rollback, got %d entries", len(allocs))
 	}
 }
 


### PR DESCRIPTION
## Summary

- When `gtl new` runs and setup commands (e.g. `bundle install`) fail, the worktree and allocation are now **kept** rather than rolled back
- Exit code `2` signals "created but unprovisioned" — distinguishable from exit code `1` (fatal, worktree rolled back)
- `CliError` gains `Unwrap()` so `errors.As` can reach the underlying `SetupCommandError` through the error chain

## Motivation

Setup commands are environment-dependent (bundler version mismatch, missing npm package, etc.) and don't reflect on the validity of the worktree itself. By the time a setup command runs, the worktree, port allocation, database clone, and env file are all intact. Rolling back discards all that work and makes the worktree invisible — the user has no way to re-run `gtl setup` because there's nothing to run it on.

## Behavior change

**Before:** any setup failure → rollback everything → exit 1  
**After:**
- Setup command failure (`commands.setup`) → keep worktree + allocation → warn + exit 2
- Allocation / env file / DB clone failure → rollback (unchanged) → exit 1

## Test plan

- `TestRun_RollbackOnError` updated: asserts `*SetupCommandError` returned, registry has 1 entry (allocation kept)
- `TestRun_RollbackOnAllocationError` added: bad DB adapter triggers pre-setup failure, asserts plain error + empty registry
- `go test ./internal/setup/... ./cmd/...` passes