### PR TITLE
fix(db-template): use --ff-only pull and surface actionable error on diverged branches

### DIFF
--- a/cmd/db_template.go
+++ b/cmd/db_template.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -61,11 +62,19 @@ updated template.`,
 		}
 
 		fmt.Printf("==> Pulling %s in %s\n", mergeTarget, mainRepo)
-		pull := exec.Command("git", "pull", "origin", mergeTarget)
+		pull := exec.Command("git", "pull", "--ff-only", "origin", mergeTarget)
 		pull.Dir = mainRepo
 		pull.Stdout = os.Stdout
-		pull.Stderr = os.Stderr
+		var pullStderr strings.Builder
+		pull.Stderr = io.MultiWriter(os.Stderr, &pullStderr)
 		if err := pull.Run(); err != nil {
+			if strings.Contains(pullStderr.String(), "fast-forward") ||
+				strings.Contains(pullStderr.String(), "divergent") {
+				return cliErr(cmd, &CliError{
+					Message: fmt.Sprintf("Branch '%s' has diverged from origin/%s and cannot be fast-forwarded.", mergeTarget, mergeTarget),
+					Hint:    fmt.Sprintf("If origin is the source of truth, reset with:\n  cd %s && git reset --hard origin/%s", mainRepo, mergeTarget),
+				})
+			}
 			return fmt.Errorf("git pull: %w", err)
 		}
 


### PR DESCRIPTION
## Summary

- `git pull` in `db template update` now uses `--ff-only` to avoid the ambiguous divergent-branch hint wall
- When a fast-forward fails (e.g. branch was deleted and recreated on remote), the error now explains the cause and gives the exact reset command to fix it

## Test plan

- [ ] Run `gtl db template update` in a repo where local and remote are in sync — should work as before
- [ ] Simulate divergence (`git reset --hard HEAD~1` on the local branch) and run `gtl db template update` — should see the actionable error with the `git reset --hard origin/<branch>` hint