### PR TITLE
fix(serve): self-heal pf.conf when macOS updates revert it

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -317,7 +317,7 @@ func routerInstallIssues() []string {
 		proxy.IsCAInstalled(),
 		service.IsRunning(),
 		daemonRequired,
-		service.IsPfReloadDaemonInstalled(),
+		service.IsPfReloadDaemonInstalled() && service.IsPfReloadDaemonCurrent(),
 	)
 }
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -112,6 +112,14 @@ should not be an error).`,
 				})
 			}
 			fmt.Println(style.Dimf("pf rules reloaded."))
+		} else if runtime.GOOS == "darwin" {
+			// A restart is the first thing users reach for when clean URLs
+			// stop working — but it cannot fix a pf.conf that a macOS
+			// update reverted. Surface that state instead of reporting an
+			// all-clear that leaves port 443 dead.
+			if st := service.CheckPortForward(routerPort); st.ConfReverted {
+				fmt.Println(style.Warnf("Port forwarding is broken: %s", st.Detail))
+			}
 		}
 		return nil
 	},
@@ -430,6 +438,8 @@ func projectAliases(reg *registry.Registry) proxy.AliasSource {
 // failures as "disabled/missing" is the bug this helper exists to avoid.
 func formatPortForwardStatus(st service.PortForwardStatus, routerPort int) string {
 	switch {
+	case st.ConfReverted:
+		return "Port forwarding: ⚠ pf.conf lost the treeline lines (macOS updates revert this file) — run 'gtl serve reload-pf' to repair"
 	case !st.ConfiguredOnDisk:
 		return "Port forwarding: not configured"
 	case st.PfStateKnown && !st.PfEnabled:
@@ -460,9 +470,10 @@ var serveReloadPFCmd = &cobra.Command{
 	Use:   "reload-pf",
 	Short: "Reload port-forwarding rules into the running kernel",
 	Long: `Re-applies the port-forwarding rules from /etc/pf.conf into pf's running
-ruleset. Useful after a reboot or network state change that left pf.conf on
-disk but cleared the kernel ruleset (a common cause of "port 443 not
-reachable" with the router otherwise healthy).
+ruleset, repairing pf.conf first if it no longer references the treeline
+anchor (macOS updates revert /etc/pf.conf to the stock file, which silently
+removes our lines). Useful whenever port 443 is not reachable while the
+router is otherwise healthy.
 
 Requires sudo on macOS.`,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/internal/service/pfdaemon.go
+++ b/internal/service/pfdaemon.go
@@ -9,14 +9,85 @@ import (
 
 // PfReloadDaemonLabel is the launchd label for our boot-time pf reloader.
 // Lives in /Library/LaunchDaemons (system-level, runs as root). The daemon
-// exists solely so pf rules survive a reboot — macOS loads pf.conf at boot
-// via Apple's own LaunchDaemon but does NOT enable pf. Our daemon re-runs
-// `pfctl -ef /etc/pf.conf` to enable pf and load our rdr rule.
+// exists so pf rules survive a reboot AND macOS updates: Apple loads
+// pf.conf at boot but does NOT enable pf, and OS updates periodically
+// revert /etc/pf.conf to the stock file, silently deleting our
+// rdr-anchor/load lines. The daemon runs pfEnsureScript, which re-inserts
+// those lines when missing, then loads the ruleset and enables pf. It
+// fires at boot (RunAtLoad) and whenever /etc/pf.conf changes (WatchPaths)
+// — so an update that rewrites the file triggers its own repair.
 //
-// The daemon invokes Apple's signed /sbin/pfctl directly — it does NOT
-// reference our gtl binary, so no notarization or code-signing concerns
-// apply. The plist itself is a static config file.
+// The daemon must NOT reference our gtl binary: a root daemon executing a
+// user-writable Homebrew binary would be a privilege escalation. Instead
+// it runs /bin/sh on a root-owned script installed by `gtl serve install`.
 const PfReloadDaemonLabel = "dev.treeline.pfreload"
+
+// pfEnsureScriptPath is where the repair script lives on disk. Installed
+// root:wheel 755 by the same sudo session that installs the daemon plist,
+// so root never executes anything user-writable.
+const pfEnsureScriptPath = "/Library/Application Support/dev.git-treeline/pf-ensure.sh"
+
+// pfEnsureScript is the static repair script the daemon runs. It handles
+// both the prod and .dev (GTL_HOME) anchor variants so a dev install
+// never breaks the shared daemon's ability to repair the prod lines.
+//
+// Load-bearing details:
+//   - The presence check greps for the `load anchor "<name>" from` line,
+//     NOT the marker comment — the prod marker is a substring of the .dev
+//     marker, so a marker grep would false-positive on dev-only installs.
+//   - The rewritten pf.conf is validated with `pfctl -n -f` before it
+//     replaces the live file; a failed validation leaves pf.conf alone.
+//   - `pfctl -e` is masked: it exits non-zero when pf is already enabled,
+//     which is the common case and not an error.
+const pfEnsureScript = `#!/bin/sh
+# git-treeline boot-time pf loader (dev.treeline.pfreload).
+#
+# Repairs /etc/pf.conf when a macOS update reverts it to the stock file
+# (removing the git-treeline rdr-anchor/load lines), then loads the
+# ruleset and enables pf. Runs at boot and whenever /etc/pf.conf changes.
+# Idempotent: when pf.conf already references the anchors it only reloads.
+# Managed by 'gtl serve install' — do not edit by hand.
+
+CONF=/etc/pf.conf
+
+repair() {
+    anchor="dev.treeline.router$1"
+    anchor_file="/etc/pf.anchors/$anchor"
+    marker="# git-treeline$1"
+    [ -f "$anchor_file" ] || return 0
+    /usr/bin/grep -qF "load anchor \"$anchor\" from" "$CONF" && return 0
+    tmp=$(/usr/bin/mktemp /tmp/treeline-pfconf.XXXXXX) || return 1
+    /usr/bin/awk -v rdr="rdr-anchor \"$anchor\" $marker" \
+        -v load="load anchor \"$anchor\" from \"$anchor_file\" $marker" '
+        { line[NR] = $0 }
+        $1 == "rdr-anchor" { last = NR }
+        END {
+            if (last == 0) print rdr
+            for (i = 1; i <= NR; i++) { print line[i]; if (i == last) print rdr }
+            print load
+        }' "$CONF" > "$tmp" || { /bin/rm -f "$tmp"; return 1; }
+    if ! /sbin/pfctl -n -f "$tmp" 2>/dev/null; then
+        /bin/rm -f "$tmp"
+        return 1
+    fi
+    /bin/cp "$tmp" "$CONF"
+    rc=$?
+    /bin/rm -f "$tmp"
+    return $rc
+}
+
+rc=0
+repair "" || rc=1
+repair ".dev" || rc=1
+
+/sbin/pfctl -f "$CONF" 2>/dev/null || rc=1
+/sbin/pfctl -e 2>/dev/null
+exit $rc
+`
+
+// pfEnsureScriptBody returns the static repair script installed at
+// pfEnsureScriptPath and executed by reloadPf via sudo.
+func pfEnsureScriptBody() string { return pfEnsureScript }
 
 // PfReloadDaemonPath returns the on-disk plist path. macOS-only; on
 // other platforms returns "" since we don't ship this daemon there.
@@ -27,9 +98,12 @@ func PfReloadDaemonPath() string {
 	return "/Library/LaunchDaemons/" + PfReloadDaemonLabel + ".plist"
 }
 
-// pfReloadDaemonPlist is the static plist body. No template params —
-// /sbin/pfctl is part of the OS, /etc/pf.conf is where our rdr rule
-// already lives.
+// pfReloadDaemonPlist is the static plist body. No template params — the
+// repair script lives at a fixed root-owned path. WatchPaths makes launchd
+// re-run the script the moment anything rewrites /etc/pf.conf (e.g. a
+// macOS update reverting it), closing the gap between updates and reboots.
+// The script's one self-write converges: the re-trigger finds the lines
+// present and only reloads.
 const pfReloadDaemonPlist = `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -38,12 +112,15 @@ const pfReloadDaemonPlist = `<?xml version="1.0" encoding="UTF-8"?>
     <string>dev.treeline.pfreload</string>
     <key>ProgramArguments</key>
     <array>
-        <string>/sbin/pfctl</string>
-        <string>-ef</string>
-        <string>/etc/pf.conf</string>
+        <string>/bin/sh</string>
+        <string>/Library/Application Support/dev.git-treeline/pf-ensure.sh</string>
     </array>
     <key>RunAtLoad</key>
     <true/>
+    <key>WatchPaths</key>
+    <array>
+        <string>/etc/pf.conf</string>
+    </array>
     <key>StandardErrorPath</key>
     <string>/var/log/dev.treeline.pfreload.err</string>
     <key>StandardOutPath</key>
@@ -63,26 +140,53 @@ func IsPfReloadDaemonInstalled() bool {
 	return err == nil
 }
 
+// IsPfReloadDaemonCurrent reports whether the installed daemon matches
+// what this version of gtl would install — both the plist and the repair
+// script, byte for byte. False for pre-script installs (whose plist ran
+// `pfctl -ef` and could not survive a macOS update reverting pf.conf),
+// signalling that `gtl serve install` should upgrade the daemon.
+// Read-only; both files are world-readable.
+func IsPfReloadDaemonCurrent() bool {
+	path := PfReloadDaemonPath()
+	if path == "" {
+		return false
+	}
+	plist, err := os.ReadFile(path)
+	if err != nil || string(plist) != pfReloadDaemonPlist {
+		return false
+	}
+	script, err := os.ReadFile(pfEnsureScriptPath)
+	return err == nil && string(script) == pfEnsureScript
+}
+
 // pfReloadDaemonPlistBody returns the static plist body installed at
-// PfReloadDaemonPath(). Used by installDarwinPortForward to write the
-// same plist as part of a combined sudo session, eliminating the second
-// password prompt that previously gated daemon installation.
+// PfReloadDaemonPath().
 func pfReloadDaemonPlistBody() string { return pfReloadDaemonPlist }
 
 // pfReloadDaemonInstallFragment returns a `sh -c` fragment that, when run
-// as root, copies a pre-rendered plist into /Library/LaunchDaemons, fixes
-// ownership/perms, and bootstraps the LaunchDaemon. The fragment ends with
-// `launchctl bootstrap`, whose exit code becomes the fragment's exit code
-// — so a failed bootstrap surfaces as a non-zero exit. The caller writes
-// pfReloadDaemonPlist to tmpPlistPath before invoking the script.
-func pfReloadDaemonInstallFragment(tmpPlistPath string) string {
+// as root, installs the repair script (root:wheel 755 — root must never
+// execute a user-writable file) and the plist, then bootstraps the
+// LaunchDaemon. The fragment ends with `launchctl bootstrap`, whose exit
+// code becomes the fragment's exit code — so a failed bootstrap surfaces
+// as a non-zero exit. The caller writes pfReloadDaemonPlist and
+// pfEnsureScript to the two temp paths before invoking the script.
+func pfReloadDaemonInstallFragment(tmpPlistPath, tmpScriptPath string) string {
 	target := PfReloadDaemonPath()
+	scriptDir := "/Library/Application Support/dev.git-treeline"
 	return fmt.Sprintf(
-		"/bin/cp '%s' '%s' && "+
+		"/bin/mkdir -p '%s' && "+
+			"/bin/cp '%s' '%s' && "+
+			"/usr/sbin/chown root:wheel '%s' && "+
+			"/bin/chmod 755 '%s' && "+
+			"/bin/cp '%s' '%s' && "+
 			"/usr/sbin/chown root:wheel '%s' && "+
 			"/bin/chmod 644 '%s' && "+
 			"(/bin/launchctl bootout system/%s 2>/dev/null; true) && "+
 			"/bin/launchctl bootstrap system '%s'",
+		scriptDir,
+		tmpScriptPath, pfEnsureScriptPath,
+		pfEnsureScriptPath,
+		pfEnsureScriptPath,
 		tmpPlistPath, target,
 		target,
 		target,
@@ -109,21 +213,15 @@ func InstallPfReloadDaemon() error {
 		return nil
 	}
 
-	tmp, err := os.CreateTemp("", "treeline-pfreload-*.plist")
+	tmpPlist, tmpScript, cleanup, err := writePfDaemonTempFiles()
 	if err != nil {
-		return fmt.Errorf("creating temp plist: %w", err)
-	}
-	defer func() { _ = os.Remove(tmp.Name()) }()
-	if _, err := tmp.WriteString(pfReloadDaemonPlist); err != nil {
 		return err
 	}
-	if err := tmp.Close(); err != nil {
-		return err
-	}
+	defer cleanup()
 
 	cmd := exec.Command("sudo", "-p",
 		"\nEnter your password to install the boot-time pf reloader: ",
-		"sh", "-c", pfReloadDaemonInstallFragment(tmp.Name()))
+		"sh", "-c", pfReloadDaemonInstallFragment(tmpPlist, tmpScript))
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -131,6 +229,39 @@ func InstallPfReloadDaemon() error {
 		return fmt.Errorf("pf-reload daemon install failed: %w", err)
 	}
 	return nil
+}
+
+// writePfDaemonTempFiles renders the daemon plist and repair script to
+// temp files for a root install fragment to copy into place. The caller
+// must invoke cleanup (safe even on partial failure).
+func writePfDaemonTempFiles() (tmpPlistPath, tmpScriptPath string, cleanup func(), err error) {
+	var paths []string
+	cleanup = func() {
+		for _, p := range paths {
+			_ = os.Remove(p)
+		}
+	}
+	write := func(pattern, content string) (string, error) {
+		f, err := os.CreateTemp("", pattern)
+		if err != nil {
+			return "", err
+		}
+		paths = append(paths, f.Name())
+		if _, err := f.WriteString(content); err != nil {
+			_ = f.Close()
+			return "", err
+		}
+		return f.Name(), f.Close()
+	}
+	if tmpPlistPath, err = write("treeline-pfreload-*.plist", pfReloadDaemonPlist); err != nil {
+		cleanup()
+		return "", "", func() {}, fmt.Errorf("creating temp plist: %w", err)
+	}
+	if tmpScriptPath, err = write("treeline-pf-ensure-*.sh", pfEnsureScript); err != nil {
+		cleanup()
+		return "", "", func() {}, fmt.Errorf("creating temp pf-ensure script: %w", err)
+	}
+	return tmpPlistPath, tmpScriptPath, cleanup, nil
 }
 
 // UninstallPfReloadDaemon removes the LaunchDaemon. Symmetric with install
@@ -145,9 +276,10 @@ func UninstallPfReloadDaemon() error {
 	target := PfReloadDaemonPath()
 	script := fmt.Sprintf(
 		"/bin/launchctl bootout system/%s 2>/dev/null; "+
-			"/bin/rm -f '%s'",
+			"/bin/rm -f '%s' '%s'",
 		PfReloadDaemonLabel,
 		target,
+		pfEnsureScriptPath,
 	)
 	cmd := exec.Command("sudo", "-p",
 		"\nEnter your password to remove the boot-time pf reloader: ",

--- a/internal/service/pfdaemon_test.go
+++ b/internal/service/pfdaemon_test.go
@@ -10,13 +10,20 @@ func TestPfReloadDaemonInstallFragment(t *testing.T) {
 	if runtime.GOOS != "darwin" {
 		t.Skip("pf reload daemon paths only resolve on darwin")
 	}
-	frag := pfReloadDaemonInstallFragment("/tmp/treeline-pfreload-abc.plist")
+	frag := pfReloadDaemonInstallFragment(
+		"/tmp/treeline-pfreload-abc.plist", "/tmp/treeline-pf-ensure-abc.sh")
 
 	target := "/Library/LaunchDaemons/dev.treeline.pfreload.plist"
 
-	// The fragment must copy the temp plist into the canonical LaunchDaemons
-	// path, fix ownership/perms, best-effort bootout, and then bootstrap.
+	// The fragment must install the repair script root-owned (root must
+	// never execute a user-writable file) and executable, copy the temp
+	// plist into the canonical LaunchDaemons path, fix ownership/perms,
+	// best-effort bootout, and then bootstrap.
 	for _, want := range []string{
+		"/bin/mkdir -p '/Library/Application Support/dev.git-treeline'",
+		"/bin/cp '/tmp/treeline-pf-ensure-abc.sh' '" + pfEnsureScriptPath + "'",
+		"/usr/sbin/chown root:wheel '" + pfEnsureScriptPath + "'",
+		"/bin/chmod 755 '" + pfEnsureScriptPath + "'",
 		"/bin/cp '/tmp/treeline-pfreload-abc.plist' '" + target + "'",
 		"/usr/sbin/chown root:wheel '" + target + "'",
 		"/bin/chmod 644 '" + target + "'",
@@ -46,14 +53,57 @@ func TestPfReloadDaemonPlistBody(t *testing.T) {
 	for _, want := range []string{
 		"<key>Label</key>",
 		"<string>dev.treeline.pfreload</string>",
-		"<string>/sbin/pfctl</string>",
-		"<string>-ef</string>",
-		"<string>/etc/pf.conf</string>",
+		"<string>/bin/sh</string>",
+		"<string>" + pfEnsureScriptPath + "</string>",
 		"<key>RunAtLoad</key>",
 		"<true/>",
+		// WatchPaths is the update-proofing: a macOS update that rewrites
+		// /etc/pf.conf triggers the repair without waiting for a reboot.
+		"<key>WatchPaths</key>",
+		"<string>/etc/pf.conf</string>",
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("plist body missing %q", want)
+		}
+	}
+
+	// The daemon must never execute the gtl binary — a root daemon running
+	// a user-writable Homebrew binary would be a privilege escalation.
+	if strings.Contains(body, "gtl") && !strings.Contains(body, "dev.git-treeline") {
+		t.Errorf("plist must not reference the gtl binary\nbody: %s", body)
+	}
+}
+
+func TestPfEnsureScript(t *testing.T) {
+	script := pfEnsureScriptBody()
+
+	// The presence check must grep the load-anchor line, not the marker:
+	// the prod marker ("# git-treeline") is a substring of the .dev marker
+	// ("# git-treeline.dev"), so a marker grep would see a dev-only
+	// install as "prod already configured" and skip the prod repair.
+	if !strings.Contains(script, `load anchor \"$anchor\" from`) {
+		t.Errorf("script must detect presence via the load-anchor line\nscript: %s", script)
+	}
+
+	// The rewritten pf.conf must be validated before it replaces the live
+	// file — a bad rewrite must never land in /etc/pf.conf.
+	if !strings.Contains(script, `/sbin/pfctl -n -f "$tmp"`) {
+		t.Errorf("script must validate the rewritten pf.conf with pfctl -n before installing it\nscript: %s", script)
+	}
+
+	// Both the prod and .dev anchor variants must be repaired so a dev
+	// install (GTL_HOME) never breaks the shared daemon's prod repair.
+	for _, want := range []string{`repair ""`, `repair ".dev"`} {
+		if !strings.Contains(script, want) {
+			t.Errorf("script missing %q\nscript: %s", want, script)
+		}
+	}
+
+	// After any repair the script must still load the ruleset and enable
+	// pf — that is the original daemon's job and must be preserved.
+	for _, want := range []string{`/sbin/pfctl -f "$CONF"`, "/sbin/pfctl -e"} {
+		if !strings.Contains(script, want) {
+			t.Errorf("script missing %q\nscript: %s", want, script)
 		}
 	}
 }

--- a/internal/service/portforward.go
+++ b/internal/service/portforward.go
@@ -97,6 +97,12 @@ type PortForwardStatus struct {
 	// require sudo — if our calls fail with permission errors, this is
 	// false, and LoadedInKernel should not be trusted as authoritative.
 	KernelStateKnown bool
+	// ConfReverted (macOS only) is true when the anchor file exists but
+	// pf.conf no longer references it — the signature of a macOS update
+	// reverting /etc/pf.conf to the stock file. Distinguishes "was
+	// installed, then wiped by Apple" (repair with 'gtl serve reload-pf')
+	// from "never installed" (run 'gtl serve install').
+	ConfReverted bool
 	// Detail is a one-line human-readable summary, or "" when everything is
 	// healthy.
 	Detail string
@@ -162,7 +168,15 @@ func checkPortForwardDarwin(routerPort int) PortForwardStatus {
 		}
 	}
 
+	if !st.ConfiguredOnDisk {
+		if _, err := os.Stat(pfAnchorPath()); err == nil {
+			st.ConfReverted = true
+		}
+	}
+
 	switch {
+	case st.ConfReverted:
+		st.Detail = "pf.conf lost the treeline lines (macOS updates revert this file) — run 'gtl serve reload-pf' to repair"
 	case !st.ConfiguredOnDisk:
 		st.Detail = "not configured (run 'gtl serve install')"
 	case st.PfStateKnown && !st.PfEnabled:
@@ -358,18 +372,18 @@ func installDarwinPortForward(routerPort int) error {
 		anchorExists = false
 	}
 	pfConfigured := strings.Contains(string(pfConf), pfMarker()) && anchorExists
-	daemonInstalled := IsPfReloadDaemonInstalled()
 
-	if pfConfigured && daemonInstalled {
+	if pfConfigured && IsPfReloadDaemonCurrent() {
 		fmt.Println("  Port forwarding already configured (443 → router).")
 		return reloadPf()
 	}
 
-	if pfConfigured && !daemonInstalled {
-		// Rules are on disk but the boot-time reloader isn't — typical for
-		// installs that predate the daemon, or where a previous install
-		// silently lost the second sudo prompt. Reload kernel state and
-		// drop the daemon in one sudo session.
+	if pfConfigured {
+		// Rules are on disk but the boot-time reloader is missing or
+		// outdated — typical for installs that predate the daemon (or its
+		// self-healing script), or where a previous install silently lost
+		// the second sudo prompt. Reload kernel state and (re)install the
+		// daemon in one sudo session.
 		fmt.Println("  Port forwarding already configured (443 → router); installing boot-time reloader.")
 		return reloadPfAndInstallDaemon()
 	}
@@ -401,22 +415,18 @@ func installDarwinPortForward(routerPort int) error {
 	}
 	_ = tmpPfConf.Close()
 
-	tmpPlist, err := os.CreateTemp("", "treeline-pfreload-*.plist")
+	tmpPlist, tmpScript, cleanupDaemonTmp, err := writePfDaemonTempFiles()
 	if err != nil {
 		return err
 	}
-	defer func() { _ = os.Remove(tmpPlist.Name()) }()
-	if _, err := tmpPlist.WriteString(pfReloadDaemonPlistBody()); err != nil {
-		return err
-	}
-	_ = tmpPlist.Close()
+	defer cleanupDaemonTmp()
 
 	// One sudo session for everything that requires root: validate the new
 	// pf.conf, swap it in, apply the rules, and install the boot-time
 	// reloader. Bundling these together means a single password prompt and
 	// guarantees the daemon either lands on disk or the install fails
 	// loudly — no silent half-installs.
-	script := darwinPortForwardScript(tmpAnchor.Name(), tmpPfConf.Name(), tmpPlist.Name())
+	script := darwinPortForwardScript(tmpAnchor.Name(), tmpPfConf.Name(), tmpPlist, tmpScript)
 
 	cmd := exec.Command("sudo", "-p",
 		"\nEnter your password (2 of 2): ",
@@ -439,19 +449,13 @@ func installDarwinPortForward(routerPort int) error {
 // from a previous install where the daemon's separate sudo prompt
 // silently failed.
 func reloadPfAndInstallDaemon() error {
-	tmpPlist, err := os.CreateTemp("", "treeline-pfreload-*.plist")
+	tmpPlist, tmpScript, cleanup, err := writePfDaemonTempFiles()
 	if err != nil {
-		return fmt.Errorf("creating temp plist: %w", err)
-	}
-	defer func() { _ = os.Remove(tmpPlist.Name()) }()
-	if _, err := tmpPlist.WriteString(pfReloadDaemonPlistBody()); err != nil {
 		return err
 	}
-	if err := tmpPlist.Close(); err != nil {
-		return err
-	}
+	defer cleanup()
 
-	script := reloadPfAndInstallDaemonScript(tmpPlist.Name())
+	script := reloadPfAndInstallDaemonScript(tmpPlist, tmpScript)
 	cmd := exec.Command("sudo", "-p",
 		"\nEnter your password to reload port forwarding and install the boot-time reloader: ",
 		"sh", "-c", script)
@@ -477,7 +481,7 @@ func reloadPfAndInstallDaemon() error {
 //     failed `launchctl bootstrap` propagates as the script's exit code.
 //     This is the whole point of the bundling: pf rules and daemon
 //     land together or the install fails loudly.
-func darwinPortForwardScript(tmpAnchorPath, tmpPfConfPath, tmpPlistPath string) string {
+func darwinPortForwardScript(tmpAnchorPath, tmpPfConfPath, tmpPlistPath, tmpScriptPath string) string {
 	return fmt.Sprintf(
 		"/bin/mkdir -p /etc/pf.anchors && /bin/cp '%s' '%s' && /sbin/pfctl -n -f '%s' 2>&1 || exit 1; "+
 			"/bin/cp '%s' '%s' && /bin/cp '%s' '%s' && { /sbin/pfctl -ef '%s' 2>/dev/null; true; } && %s",
@@ -486,7 +490,7 @@ func darwinPortForwardScript(tmpAnchorPath, tmpPfConfPath, tmpPlistPath string) 
 		pfConfPath, pfBackupPath,
 		tmpPfConfPath, pfConfPath,
 		pfConfPath,
-		pfReloadDaemonInstallFragment(tmpPlistPath),
+		pfReloadDaemonInstallFragment(tmpPlistPath, tmpScriptPath),
 	)
 }
 
@@ -494,30 +498,41 @@ func darwinPortForwardScript(tmpAnchorPath, tmpPfConfPath, tmpPlistPath string) 
 // reloadPfAndInstallDaemon. `pfctl -f` failure must propagate (a broken
 // pf.conf means the daemon would fail on every boot), so only `pfctl -e`
 // is masked. The daemon fragment is the final exit-code gate.
-func reloadPfAndInstallDaemonScript(tmpPlistPath string) string {
+func reloadPfAndInstallDaemonScript(tmpPlistPath, tmpScriptPath string) string {
 	return fmt.Sprintf(
 		"/sbin/pfctl -f '%s' 2>/dev/null && { /sbin/pfctl -e 2>/dev/null; true; } && %s",
 		pfConfPath,
-		pfReloadDaemonInstallFragment(tmpPlistPath),
+		pfReloadDaemonInstallFragment(tmpPlistPath, tmpScriptPath),
 	)
 }
 
-// reloadPf ensures the kernel's pf rules match /etc/pf.conf. The reload
-// uses -f (load rules) separately from -e (enable pf) because pfctl
-// returns exit 1 from -e when pf is already running.
+// reloadPf ensures the kernel's pf rules match /etc/pf.conf — including
+// repairing pf.conf itself when a macOS update reverted it to the stock
+// file and stripped our lines. It runs the same repair script the boot
+// daemon uses (rendered to a temp file), so `gtl serve reload-pf` fixes
+// every state the daemon can fix: missing lines, unloaded ruleset,
+// disabled pf.
 func reloadPf() error {
-	script := fmt.Sprintf(
-		"/sbin/pfctl -f '%s' 2>/dev/null && { /sbin/pfctl -e 2>/dev/null; true; }",
-		pfConfPath,
-	)
+	tmp, err := os.CreateTemp("", "treeline-pf-ensure-*.sh")
+	if err != nil {
+		return fmt.Errorf("creating temp pf-ensure script: %w", err)
+	}
+	defer func() { _ = os.Remove(tmp.Name()) }()
+	if _, err := tmp.WriteString(pfEnsureScriptBody()); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
 	cmd := exec.Command("sudo", "-p",
 		"\nEnter your password to reload port forwarding: ",
-		"sh", "-c", script)
+		"sh", tmp.Name())
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("pfctl reload failed: %w", err)
+		return fmt.Errorf("pf reload/repair failed: %w", err)
 	}
 	return nil
 }

--- a/internal/service/portforward_test.go
+++ b/internal/service/portforward_test.go
@@ -103,6 +103,7 @@ func TestDarwinPortForwardScript(t *testing.T) {
 		"/tmp/treeline-anchor-xyz",
 		"/tmp/treeline-pfconf-xyz",
 		"/tmp/treeline-pfreload-xyz.plist",
+		"/tmp/treeline-pf-ensure-xyz.sh",
 	)
 
 	// Invariant 1: dry-run validation gates the live pf.conf swap. The
@@ -123,7 +124,8 @@ func TestDarwinPortForwardScript(t *testing.T) {
 	// `&&`-joined at the tail so its exit code is the script's exit code.
 	// A `;` here would silently mask daemon-install failures and reopen
 	// the issue #51 bug.
-	daemonFrag := pfReloadDaemonInstallFragment("/tmp/treeline-pfreload-xyz.plist")
+	daemonFrag := pfReloadDaemonInstallFragment(
+		"/tmp/treeline-pfreload-xyz.plist", "/tmp/treeline-pf-ensure-xyz.sh")
 	if !strings.HasSuffix(strings.TrimSpace(script), daemonFrag) {
 		t.Errorf("daemon fragment must be the final segment so its exit code drives the script\nscript: %s", script)
 	}
@@ -133,7 +135,8 @@ func TestDarwinPortForwardScript(t *testing.T) {
 }
 
 func TestReloadPfAndInstallDaemonScript(t *testing.T) {
-	script := reloadPfAndInstallDaemonScript("/tmp/treeline-pfreload-xyz.plist")
+	script := reloadPfAndInstallDaemonScript(
+		"/tmp/treeline-pfreload-xyz.plist", "/tmp/treeline-pf-ensure-xyz.sh")
 
 	// `pfctl -f` (load) failure MUST propagate — a broken pf.conf means
 	// the daemon would re-apply broken rules every boot. Only `pfctl -e`
@@ -146,7 +149,8 @@ func TestReloadPfAndInstallDaemonScript(t *testing.T) {
 	}
 
 	// Daemon fragment is the exit gate.
-	daemonFrag := pfReloadDaemonInstallFragment("/tmp/treeline-pfreload-xyz.plist")
+	daemonFrag := pfReloadDaemonInstallFragment(
+		"/tmp/treeline-pfreload-xyz.plist", "/tmp/treeline-pf-ensure-xyz.sh")
 	if !strings.HasSuffix(strings.TrimSpace(script), daemonFrag) {
 		t.Errorf("daemon fragment must be the final segment\nscript: %s", script)
 	}


### PR DESCRIPTION
## Problem

macOS updates restore `/etc/pf.conf` to the stock Apple file, silently deleting the treeline `rdr-anchor`/`load anchor` lines. After that:

- the boot daemon (`pfctl -ef /etc/pf.conf`) faithfully reloads a ruleset with **no 443 redirect**
- `gtl serve reload-pf` re-applies the gutted file and reports success
- `serve status` says only "not configured" with no hint of why
- bare `https://*.prt.dev` URLs go dead while the router itself is healthy

Hit in the wild: an Aug 1 macOS update reverted pf.conf; every boot since loaded no redirect, and every advertised repair was a no-op.

## Fix

**Self-healing boot daemon.** `dev.treeline.pfreload` now runs a root-owned repair script (`/Library/Application Support/dev.git-treeline/pf-ensure.sh`) instead of bare `pfctl -ef`:

- re-inserts the treeline lines when missing (same placement as `insertPfRules`), validating with `pfctl -n -f` before swapping the live file
- then loads the ruleset and enables pf, as before
- fires at boot (`RunAtLoad`) **and whenever /etc/pf.conf changes** (`WatchPaths`) — an OS update triggers its own repair within seconds, no reboot needed
- handles both prod and `.dev` anchor variants; detects presence via the `load anchor "<name>" from` line (the prod marker is a substring of the .dev marker, so a marker grep would false-positive)

**Security invariant preserved:** the daemon never references the user-writable Homebrew `gtl` binary — the script is installed root:wheel 755 in the same sudo session as the plist.

**Repair paths actually repair.** `gtl serve reload-pf` runs the same script, so the fix that `status`/`doctor` advertise now fixes the reverted-file case too.

**Honest diagnostics.** `serve status` and `serve restart` distinguish "macOS update reverted pf.conf — run 'gtl serve reload-pf'" from "never installed", and `gtl serve install` detects an outdated daemon (pre-script plist) and upgrades it.

## Testing

- `go test ./...`, `make vet`, `make lint` all green
- new unit tests: repair-script invariants (validate-before-swap, load-anchor grep, both suffix variants), plist `WatchPaths`/no-gtl-binary, install-fragment script ownership/perms
- dry-ran the awk insertion against a real reverted stock `/etc/pf.conf`: inserts `rdr-anchor` directly after Apple's and `load anchor` at EOF, matching a fresh install byte-for-byte