### PR TITLE
Enable HTTP/2 for TLS proxies

### DIFF
--- a/internal/proxy/proxy.go
+++ b/internal/proxy/proxy.go
@@ -69,7 +69,6 @@ func Run(opts Options) error {
 			Certificates: []tls.Certificate{*cert},
 			MinVersion:   tls.VersionTLS12,
 		}
-		ln = tls.NewListener(ln, server.TLSConfig)
 		scheme = "https"
 	}
 
@@ -78,6 +77,10 @@ func Run(opts Options) error {
 
 	errCh := make(chan error, 1)
 	go func() {
+		if opts.TLS {
+			errCh <- server.ServeTLS(ln, "", "")
+			return
+		}
 		errCh <- server.Serve(ln)
 	}()
 

--- a/internal/proxy/proxy_test.go
+++ b/internal/proxy/proxy_test.go
@@ -109,7 +109,8 @@ func TestProxyTLSTermination(t *testing.T) {
 
 	client := &http.Client{
 		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+			ForceAttemptHTTP2: true,
 		},
 	}
 	resp, err := client.Get(fmt.Sprintf("https://localhost:%d/secure", listenPort))
@@ -121,6 +122,9 @@ func TestProxyTLSTermination(t *testing.T) {
 	body, _ := io.ReadAll(resp.Body)
 	if string(body) != "ok" {
 		t.Errorf("expected 'ok', got %q", string(body))
+	}
+	if resp.ProtoMajor != 2 {
+		t.Errorf("expected HTTP/2, got %s", resp.Proto)
 	}
 }
 

--- a/internal/proxy/router.go
+++ b/internal/proxy/router.go
@@ -152,7 +152,6 @@ func (r *Router) Run() error {
 			GetCertificate: cm.GetCertificate,
 			MinVersion:     tls.VersionTLS12,
 		}
-		ln = tls.NewListener(ln, server.TLSConfig)
 		scheme = "https"
 	}
 
@@ -174,6 +173,10 @@ func (r *Router) Run() error {
 
 	errCh := make(chan error, 1)
 	go func() {
+		if r.useTLS {
+			errCh <- server.ServeTLS(ln, "", "")
+			return
+		}
 		errCh <- server.Serve(ln)
 	}()
 


### PR DESCRIPTION
## Summary

- serve TLS listeners through `http.Server.ServeTLS` so Go configures ALPN and HTTP/2
- preserve plain HTTP behavior
- require HTTP/2 negotiation in the TLS proxy test

The router currently wraps its listener with `tls.NewListener` before calling `Server.Serve`, which bypasses the standard library’s automatic HTTPS protocol setup. As a result, browsers only negotiate HTTP/1.1 even though the router terminates TLS.

## Test plan

- `make ci`
- verify `curl --http2` reports HTTP/2 through an installed router build