### PR TITLE
Fix branch-aware router URL interpolation

### DIFF
--- a/internal/allocator/allocator.go
+++ b/internal/allocator/allocator.go
@@ -98,6 +98,7 @@ func (a *Allocation) ToInterpolationMap() interpolation.Allocation {
 		"ports":         a.Ports,
 		"database":      a.Database,
 		"worktree_name": a.WorktreeName,
+		"branch":        a.Branch,
 	}
 	if a.RedisDB > 0 {
 		m["redis_db"] = a.RedisDB

--- a/internal/allocator/allocator_test.go
+++ b/internal/allocator/allocator_test.go
@@ -792,6 +792,7 @@ func TestToInterpolationMap_Baseline(t *testing.T) {
 		Ports:        []int{3010, 3011},
 		Database:     "mydb_branch",
 		WorktreeName: "branch",
+		Branch:       "feature/router-url",
 	}
 	m := alloc.ToInterpolationMap()
 	if m["port"] != 3010 {
@@ -802,6 +803,9 @@ func TestToInterpolationMap_Baseline(t *testing.T) {
 	}
 	if m["worktree_name"] != "branch" {
 		t.Errorf("expected worktree_name=branch, got %v", m["worktree_name"])
+	}
+	if m["branch"] != "feature/router-url" {
+		t.Errorf("expected branch=feature/router-url, got %v", m["branch"])
 	}
 	if m["port_1"] != 3010 {
 		t.Errorf("expected port_1=3010, got %v", m["port_1"])


### PR DESCRIPTION
## Summary

- preserve the allocation branch when building interpolation values
- cover branch propagation in `ToInterpolationMap`

## Why

`gtl setup` builds `{router_url}` from the allocation interpolation map. The map omitted `Allocation.Branch`, so setup generated the shared project URL (for example, `https://myapp.localhost`) instead of the documented worktree-specific URL (for example, `https://myapp-feature.localhost`).

This restores the documented behavior for generated environment files without changing the interpolation contract.

## Validation

- `go test ./internal/allocator ./internal/setup`
- `go vet ./internal/allocator ./internal/setup`
- `git diff --check`
- verified `gtl setup --dry-run` generates a branch-specific `{router_url}`
